### PR TITLE
LP-0009, LP-0010: Keycard NIP-46 Nostr Signer Proxy and Shell dApp Integration PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ All prizes live in the [`prizes/`](prizes/) directory. Each prize is a markdown 
 | [LP-0006](prizes/LP-0006.md) | Bitcoin–LEZ Atomic Swap Using Adaptor Signatures         |
 | [LP-0007](prizes/LP-0007.md) | Monero–LEZ Atomic Swap                                   |
 | [LP-0008](prizes/LP-0008.md) | Autonomous AI Module with Wallet, Storage, and Messaging |
+| [LP-0009](prizes/LP-0009.md) | Keycard NIP-46 Nostr Signer Proxy                        |
+| [LP-0010](prizes/LP-0010.md) | Shell dApp Integration Proof of Concept                  |
 
 ### Proposing a New Prize
 

--- a/prizes/LP-0009.md
+++ b/prizes/LP-0009.md
@@ -1,0 +1,62 @@
+# LP-0009: Keycard NIP-46 Nostr Signer Proxy
+
+**`Logos Circle: N/A`**
+
+## Overview
+
+Build a NIP-46 proxy daemon that bridges Nostr remote signing requests to a Keycard via a USB reader, translating NIP-46 protocol messages into Keycard SDK commands. The proxy handles `get_public_key`, `sign_event`, and `connect`, manages websocket connections to Nostr relays, and includes a basic event approval policy. The private key never leaves the card's secure element. Any NIP-46-compatible client (Coracle, noStrudel, Snort) can use it as a drop-in signer.
+
+## Motivation
+
+Nostr private key management is one of the protocol's core challenges. Keys are typically stored in browser cache or extensions. Since a Nostr key is the user's permanent identity with no recovery mechanism, a compromised key means permanent impersonation. Storing keys on secure hardware ensures the private key never leaves the card, giving users stronger protection over their identity.
+
+## Success Criteria
+
+- [ ] The daemon handles `connect`, `get_public_key`, and `sign_event` NIP-46 methods, with signing performed by the Keycard via USB.
+- [ ] The daemon manages websocket connections to Nostr relays and correctly routes NIP-46 messages.
+- [ ] A basic event approval policy lets the user approve or reject signing requests before the Keycard is invoked.
+- [ ] Tested end-to-end against at least one NIP-46-compatible client (Coracle, noStrudel, or Snort).
+- [ ] Documentation and a clean public repository under MIT or Apache-2.0.
+
+## Scope
+
+### In Scope
+
+- CLI daemon implementing the NIP-46 remote signer role with Keycard SDK integration over USB.
+- Websocket relay connection management and a basic event approval policy.
+- Documentation covering installation, Keycard setup, relay configuration, and client integration.
+
+### Out of Scope
+
+- Encrypted DMs (NIP-44 / NIP-04): Keycard does not currently expose an ECDH API.
+- NFC transport, polished GUI, ongoing maintenance.
+
+## Prize Structure
+
+- **Total Prize:** $TBD
+- **Next Planned Revision Date:** TBD
+
+## Eligibility
+
+Open to any individual or team. Submissions must be original work. Teams must hold the rights to all submitted code and agree to license it under MIT or Apache-2.0.
+
+## Submission Requirements
+
+- Public repository with all daemon code under MIT or Apache-2.0.
+- End-to-end demo of signing with at least one NIP-46-compatible client.
+- Documentation covering setup, integration, and known limitations.
+
+## Evaluation Process
+
+Submissions are evaluated first-come-first-served against the success criteria. The first submission that satisfies all criteria wins.
+
+## Resources
+
+- [NIP-46: Nostr Connect](https://github.com/nostr-protocol/nips/blob/master/46.md)
+- [NIP-01: Basic protocol flow](https://github.com/nostr-protocol/nips/blob/master/01.md)
+- [Keycard open-source applet](https://github.com/status-im/status-keycard)
+- [Keycard ecosystem projects](https://github.com/keycard-tech/keycard-ecosystem-projects) — curated list of SDKs and tools
+- [keycard-go](https://github.com/status-im/keycard-go) — Go SDK
+- [keycard-sdk](https://github.com/nicedoc/keycard-sdk) — TypeScript SDK
+- [nexum-keycard](https://github.com/aspect-build/nexum-keycard) — Rust SDK and CLI
+- [keycard-cli](https://github.com/status-im/keycard-cli) — Go CLI (useful as implementation reference)

--- a/prizes/LP-0010.md
+++ b/prizes/LP-0010.md
@@ -1,0 +1,62 @@
+# LP-0010: Shell dApp Integration Proof of Concept
+
+**`Logos Circle: N/A`**
+
+## Overview
+
+Build a dApp that integrates directly with Shell through QR codes, 100% airgapped, no browser extension. The dApp demonstrates three things: connecting to Shell by scanning a QR code it presents, displaying the user's public keys and addresses across derivation paths (BIP-44 for EVM and Bitcoin legacy, BIP-84 for native SegWit, BIP-49 for nested SegWit), and signing a simple message with one of those keys.
+
+## Motivation
+
+This dApp will serve as a reference implementation showing how any dApp can integrate directly with Shell without a browser extension. A working example that developers can read, run, and fork lowers the barrier to building on Shell significantly.
+
+## Success Criteria
+
+- [ ] The dApp connects to Shell by scanning a QR code, with no browser extension or native app required.
+- [ ] After connection, the dApp displays the user's public keys and addresses for BIP-44 (EVM and Bitcoin legacy), BIP-84 (native SegWit), and BIP-49 (nested SegWit) derivation paths.
+- [ ] The dApp asks the user for a message to sign and to choose one of the above keys. The dApp then provides a QR code for Shell to sign this message. personal_sign (EIP-191) is used for EVM, and BIP-322 for Bitcoin. Shell scans the QR and returns the signature to the dApp, completing the full QR-based signing round-trip.
+- [ ] The entire interaction is airgapped — no data leaves or enters Shell except via QR codes.
+- [ ] Documentation written as a developer integration guide, and a clean public repository under MIT or Apache-2.0.
+
+## Scope
+
+### In Scope
+
+- Web dApp integrating with Shell via QR codes: connection, address display across derivation paths, and message signing.
+- Developer integration guide covering QR exchange format, connection flow, derivation paths, and signing protocol.
+
+### Out of Scope
+
+- Browser extensions, transaction broadcasting, full wallet functionality, mobile-native apps.
+
+## Prize Structure
+
+- **Total Prize:** $TBD
+- **Next Planned Revision Date:** TBD
+
+## Eligibility
+
+Open to any individual or team. Submissions must be original work. Teams must hold the rights to all submitted code and agree to license it under MIT or Apache-2.0.
+
+## Submission Requirements
+
+- Public repository with all dApp code under MIT or Apache-2.0.
+- Working demo (video or live link) showing connection, address display, and message signing.
+- Developer integration guide covering the QR exchange format, connection flow, and signing protocol.
+
+## Evaluation Process
+
+Submissions are evaluated first-come-first-served against the success criteria. The first submission that satisfies all criteria wins.
+
+## Resources
+
+- [ERC-4527: QR Code Based Air-Gapped Signer Interface](https://eips.ethereum.org/EIPS/eip-4527) — the standard for QR-based communication between airgapped signers and watch-only wallets, built on UR (Uniform Resources). Keystone pioneered this standard and provides mature SDKs implementing it.
+- [Keystone Developer Portal](https://dev.keyst.one/) — integration guides and documentation
+- [keystone-sdk-web](https://github.com/KeystoneHQ/keystone-sdk-web) — TypeScript SDK implementing ERC-4527; handles UR encoding/decoding, animated QR codes, and supports both EVM and Bitcoin (including PSBTs and multi-account derivation paths)
+- [@keystonehq/animated-qr](https://www.npmjs.com/package/@keystonehq/animated-qr) — animated QR code presenting and scanning
+- [keystone-sdk-android-demo](https://github.com/KeystoneHQ/keystone-sdk-android-demo/) — Android demo app
+- [keystone-sdk-ios-demo](https://github.com/KeystoneHQ/keystone-sdk-ios-demo/) — iOS demo app
+- [Shell by Keystone](https://keyst.one/)
+- [BIP-44: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+- [BIP-49: Derivation scheme for P2WPKH-nested-in-P2SH](https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki)
+- [BIP-84: Derivation scheme for P2WPKH](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)


### PR DESCRIPTION
- **LP-0009 — Keycard NIP-46 Nostr Signer Proxy**: A NIP-46 proxy daemon that bridges Nostr remote signing requests to a Keycard via USB. The private key never leaves the card's secure element. Any NIP-46-compatible client (Coracle, noStrudel, Snort) can use it as a drop-in signer.
- **LP-0010 — Shell dApp Integration Proof of Concept**: A web dApp that integrates with Shell entirely through QR codes (ERC-4527 / UR), with no browser extension. Demonstrates connection, address display across BIP-44/49/84 derivation paths, and message signing.
- README updated with the two new entries.

