### PR TITLE
Solution: LP-0009 — Keycard NIP-46 Nostr Signer Proxy

### DIFF
--- a/solutions/LP-0009.md
+++ b/solutions/LP-0009.md
@@ -1,0 +1,77 @@
+# Solution: LP-0009 — Keycard NIP-46 Nostr Signer Proxy
+
+## Prize
+
+[LP-0009: Keycard NIP-46 Nostr Signer Proxy](../prizes/LP-0009.md)
+
+## Summary
+
+A CLI daemon written in Rust that bridges NIP-46 remote signing requests to a
+Keycard smart card via USB/PC-SC. The private key never leaves the card's secure
+element. Any NIP-46-compatible client (Coracle, noStrudel, Snort) can connect
+to it as a drop-in remote signer.
+
+## Repository
+
+https://github.com/ygd58/keycard-nip46-proxy
+
+## Approach
+
+Architecture:
+
+    Nostr Client (Coracle/Snort/noStrudel)
+            |  NIP-46 encrypted DM (NIP-04, WebSocket)
+            v
+       Nostr Relay (wss://nos.lol)
+            |  WebSocket subscription
+            v
+     keycard-nip46-proxy (daemon)
+            |  APDU commands via PC/SC (USB)
+            v
+       Keycard secure element
+
+NIP-46 Methods:
+- connect: returns ack, registers client pubkey
+- get_public_key: returns hex pubkey from Keycard
+- sign_event: SHA-256 hash -> Keycard SIGN -> Schnorr sig
+
+Key Design Decisions:
+- Rust with tokio for async WebSocket handling
+- NIP-04 (AES-256-CBC + ECDH) for relay message encryption
+- Mock signer mode for testing without physical hardware
+- Interactive CLI approval policy before invoking Keycard
+- Hardware feature flag: build with --features hardware for real Keycard
+
+## Demo
+
+    cargo run -- --pin 123456 --mock --relay wss://nos.lol
+
+Output:
+
+    Keycard pubkey: 410a0b2ad4bb0b2ec...
+    nostrconnect://410a0b2ad4bb0b2ec...?relay=wss://nos.lol
+    Paste this into your NIP-46 client.
+
+## Test Instructions
+
+    cargo run -- --pin 123456 --mock --auto-approve --relay wss://nos.lol
+
+## Checklist
+
+- [x] connect, get_public_key, sign_event NIP-46 methods
+- [x] WebSocket relay connection management
+- [x] NIP-04 encrypted communication
+- [x] Event approval policy (interactive CLI)
+- [x] Mock signer for testing without hardware
+- [x] MIT/Apache-2.0 licensed
+- [x] README documentation
+
+## Known Limitations
+
+- NFC transport: out of scope
+- NIP-44 encryption: not yet supported
+- Hardware APDU commands need validation against real Keycard device
+
+## License
+
+MIT OR Apache-2.0


### PR DESCRIPTION
## Solution for LP-0009

**Repository:** https://github.com/ygd58/keycard-nip46-proxy

A CLI daemon written in Rust that bridges NIP-46 remote signing requests to a Keycard smart card via USB/PC-SC. The private key never leaves the card's secure element.

## Quick Demo

    cargo run -- --pin 123456 --mock --relay wss://nos.lol

Output:
    nostrconnect://<pubkey>?relay=wss://nos.lol
    Paste into Coracle, Snort, or noStrudel.

## Checklist

- [x] connect, get_public_key, sign_event NIP-46 methods
- [x] WebSocket relay connection management  
- [x] NIP-04 encrypted communication
- [x] Event approval policy (interactive CLI)
- [x] Mock signer for testing without hardware
- [x] MIT/Apache-2.0 licensed
- [x] README documentation