### PR TITLE
Solution: LP-0010 — Shell dApp Integration PoC (v2 with real QR)

### DIFF
--- a/solutions/LP-0010.md
+++ b/solutions/LP-0010.md
@@ -1,0 +1,58 @@
+# Solution: LP-0010 — Shell dApp Integration Proof of Concept
+
+## Prize
+
+[LP-0010: Shell dApp Integration Proof of Concept](../prizes/LP-0010.md)
+
+## Summary
+
+A React + TypeScript web dApp that integrates with Shell via QR codes only.
+100% airgapped, no browser extension required.
+
+## Repository
+
+https://github.com/ygd58/shell-dapp-poc
+
+## What's Implemented
+
+### QR Scan (Shell -> dApp)
+- ConnectStep uses AnimatedQRScanner to read Shell's crypto-account QR
+- Supports UR types: crypto-account, crypto-hdkey (ERC-4527)
+
+### QR Output (dApp -> Shell)
+- SignStep uses AnimatedQRCode to display animated sign request QR
+- Shell scans this QR to get the signing request
+
+### QR Scan (Shell -> dApp, signature)
+- SignStep uses AnimatedQRScanner to read Shell's signature response
+- Supports UR types: eth-signature, btc-signature
+
+### Address Display
+- BIP-44 m/44'/60'/0'/0/0 — Ethereum
+- BIP-44 m/44'/0'/0'/0/0  — Bitcoin Legacy
+- BIP-49 m/49'/0'/0'/0/0  — Bitcoin Nested SegWit
+- BIP-84 m/84'/0'/0'/0/0  — Bitcoin Native SegWit
+
+### Signing Methods
+- EVM: EIP-191 personal_sign
+- Bitcoin: BIP-322 generic message signing
+
+## Quick Start
+
+    npm install
+    npm run dev
+    open http://localhost:5173
+
+## Full QR Flow (with Shell device)
+
+1. Shell: Watch-only Wallet -> Connect -> show QR
+2. dApp: click Scan Shell QR Code -> camera opens
+3. dApp: addresses displayed for all derivation paths
+4. dApp: enter message -> Generate QR for Shell
+5. Shell: scans animated QR -> signs
+6. Shell: displays signature as QR
+7. dApp: click Scan Shell Signature Response -> signature shown
+
+## License
+
+MIT OR Apache-2.0

--- a/solutions/LP-0010.md
+++ b/solutions/LP-0010.md
@@ -4,54 +4,42 @@
 
 [LP-0010: Shell dApp Integration Proof of Concept](../prizes/LP-0010.md)
 
-## Summary
-
-A React + TypeScript web dApp that integrates with Shell via QR codes only.
-100% airgapped, no browser extension required.
-
 ## Repository
 
 https://github.com/ygd58/shell-dapp-poc
 
-## What's Implemented
+## Implementation
 
-### QR Scan (Shell -> dApp)
-- ConnectStep uses AnimatedQRScanner to read Shell's crypto-account QR
-- Supports UR types: crypto-account, crypto-hdkey (ERC-4527)
+### QR Scan - Shell to dApp (ConnectStep)
+- AnimatedQRScanner reads Shell crypto-account QR
+- CryptoAccount.fromCBOR() parses the UR data
+- generateAddressFromXpub() derives ETH address
+- Supports crypto-account and crypto-hdkey UR types (ERC-4527)
 
-### QR Output (dApp -> Shell)
-- SignStep uses AnimatedQRCode to display animated sign request QR
-- Shell scans this QR to get the signing request
+### QR Output - dApp to Shell (SignStep)
+- AnimatedQRCode displays animated sign request
+- eth-sign-request UR type for EVM
+- btc-sign-request UR type for Bitcoin
 
-### QR Scan (Shell -> dApp, signature)
-- SignStep uses AnimatedQRScanner to read Shell's signature response
-- Supports UR types: eth-signature, btc-signature
+### QR Scan - Shell to dApp (Signature)
+- AnimatedQRScanner reads Shell signature response
+- eth-signature and btc-signature UR types
 
 ### Address Display
-- BIP-44 m/44'/60'/0'/0/0 — Ethereum
+- BIP-44 m/44'/60'/0'/0/0 — Ethereum (real address from xpub)
 - BIP-44 m/44'/0'/0'/0/0  — Bitcoin Legacy
 - BIP-49 m/49'/0'/0'/0/0  — Bitcoin Nested SegWit
 - BIP-84 m/84'/0'/0'/0/0  — Bitcoin Native SegWit
 
-### Signing Methods
-- EVM: EIP-191 personal_sign
-- Bitcoin: BIP-322 generic message signing
+### Signing
+- EIP-191 personal_sign for EVM
+- BIP-322 for Bitcoin
 
 ## Quick Start
 
     npm install
     npm run dev
     open http://localhost:5173
-
-## Full QR Flow (with Shell device)
-
-1. Shell: Watch-only Wallet -> Connect -> show QR
-2. dApp: click Scan Shell QR Code -> camera opens
-3. dApp: addresses displayed for all derivation paths
-4. dApp: enter message -> Generate QR for Shell
-5. Shell: scans animated QR -> signs
-6. Shell: displays signature as QR
-7. dApp: click Scan Shell Signature Response -> signature shown
 
 ## License
 


### PR DESCRIPTION
## Solution for LP-0010 (v2)

**Repository:** https://github.com/ygd58/shell-dapp-poc

Previous submission was closed due to missing QR functionality. This v2 adds full QR scan and output.

## QR Implementation

**QR Scan (Shell -> dApp):**
- ConnectStep: AnimatedQRScanner reads Shell crypto-account QR (ERC-4527)
- SignStep: AnimatedQRScanner reads Shell signature response

**QR Output (dApp -> Shell):**
- SignStep: AnimatedQRCode displays animated sign request to Shell
- Supports eth-sign-request and btc-sign-request UR types

## Features

- BIP-44/49/84 address display (ETH + BTC Legacy/NestedSegWit/NativeSegWit)
- EIP-191 personal_sign for EVM
- BIP-322 for Bitcoin
- Full airgapped QR round-trip
- Mock mode for testing without hardware

## Quick Start

    npm install && npm run dev

Closes #LP-0010