### PR TITLE
Solution: LP-0009 — Keycard NIP-46 Proxy (v2 with proper protocol)

### DIFF
--- a/solutions/LP-0009.md
+++ b/solutions/LP-0009.md
@@ -1,0 +1,72 @@
+# Solution: LP-0009 — Keycard NIP-46 Nostr Signer Proxy (v2)
+
+## Prize
+
+[LP-0009: Keycard NIP-46 Nostr Signer Proxy](../prizes/LP-0009.md)
+
+## Repository
+
+https://github.com/ygd58/keycard-nip46-proxy
+
+## Summary
+
+A CLI daemon written in Rust that bridges NIP-46 remote signing requests
+to a Keycard smart card via the official keycard-cli tool.
+
+## Hardware Protocol
+
+Based on official Keycard documentation: https://keycard.tech/en/developers
+
+The daemon uses keycard-cli for proper Secure Channel handling:
+
+    keycard-select
+    keycard-set-secrets <pin> <puk> KeycardDefaultPairing
+    keycard-pair
+    keycard-open-secure-channel
+    keycard-verify-pin <pin>
+    keycard-derive-key m/44'/1237'/0'/0/0   (NIP-06 Nostr path)
+    keycard-sign <hash>
+
+Secure Channel (ECDH key exchange + AES-256-CBC + MAC) is handled
+automatically by keycard-cli as documented at:
+https://keycard.tech/en/developers/apdu/opensecurechannel
+
+## NIP-46 Methods
+
+- connect: returns ack
+- get_public_key: returns Nostr pubkey from Keycard
+- sign_event: SHA-256 hash -> Keycard SIGN -> Schnorr signature
+
+## Quick Demo (Mock Mode)
+
+    cargo run -- --pin 123456 --mock --relay wss://nos.lol
+
+Output:
+    Keycard pubkey: 1dc1eeaa...
+    nostrconnect://1dc1eeaa...?relay=wss://nos.lol
+
+## Hardware Mode
+
+    # Install keycard-cli
+    go install github.com/status-im/keycard-cli@latest
+
+    # Build
+    cargo build --features hardware
+
+    # Run with real Keycard
+    ./target/debug/keycard-nip46-proxy --pin YOUR_PIN --relay wss://nos.lol
+
+## Checklist
+
+- [x] connect, get_public_key, sign_event NIP-46 methods
+- [x] WebSocket relay connection
+- [x] NIP-04 encrypted communication
+- [x] Proper Keycard protocol via keycard-cli
+- [x] Secure Channel (ECDH + AES-256-CBC) via keycard-cli
+- [x] Nostr key derivation path m/44'/1237'/0'/0/0
+- [x] Mock mode for testing without hardware
+- [x] MIT/Apache-2.0 licensed
+
+## License
+
+MIT OR Apache-2.0


### PR DESCRIPTION
## Solution for LP-0009 (v2)

**Repository:** https://github.com/ygd58/keycard-nip46-proxy

Previous submission was closed due to incorrect protocol implementation.
This v2 uses the official keycard-cli for proper Secure Channel handling.

## Hardware Protocol

Based on official docs: https://keycard.tech/en/developers

    keycard-select
    keycard-set-secrets <pin> <puk> KeycardDefaultPairing
    keycard-pair
    keycard-open-secure-channel
    keycard-verify-pin <pin>
    keycard-derive-key m/44'/1237'/0'/0/0
    keycard-sign <hash>

Secure Channel (ECDH + AES-256-CBC + MAC) is handled by keycard-cli automatically.

## Checklist

- [x] connect, get_public_key, sign_event NIP-46 methods
- [x] Proper Keycard protocol via keycard-cli
- [x] Secure Channel via official implementation
- [x] Nostr key path m/44'/1237'/0'/0/0
- [x] Mock mode for testing
- [x] MIT/Apache-2.0 licensed