### PR TITLE
LP-0015 — General cross-program calls via tail calls

### DIFF
--- a/solutions/LP-0015.md
+++ b/solutions/LP-0015.md
@@ -1,0 +1,118 @@
+# Solution: LP-0015 — General Cross-Program Calls via Tail Calls
+
+**Submitted by:** soloking
+
+## Summary
+
+A complete implementation of general cross-program calls for the Logos Execution Zone using an unforgeable capability ticket mechanism built on top of the existing tail-call primitive. Programs can declare External entrypoints (callable by any user) and Internal continuation handlers (only reachable during a legitimately chained tail-call execution). The sequencer enforces capability validity for every hop in a chain — forgery or direct invocation of internal handlers is always rejected. Ships with two Rust macros (`call_program!`, `assert_internal!`), a full specification, three example programs, a demo script, and a complete integration test suite (148 tests, 0 failures).
+
+## Repository
+
+- **Repo:** https://github.com/soloking1412/logos-execution-zone
+
+## Approach
+
+### Capability Ticket Mechanism
+
+Every `ProgramInput<T>` and every `ChainedCall` carries a `capabilities: Vec<ProgramId>` field. A capability ticket is simply a `ProgramId` value passed alongside a call:
+
+- **Minting**: A program may always include its own `ProgramId` in any `ChainedCall.capabilities` it emits.
+- **Forwarding**: A program may forward any capability it received in its own `ProgramInput.capabilities`.
+- **Forgery rejection**: The sequencer rejects any `ChainedCall` that carries a `ProgramId` the emitting program neither owns nor received.
+
+User-submitted transactions always produce an initial call with `capabilities: vec![]`. There is no way for a user to inject capability tickets into the initial call, so internal handlers that call `assert_capability` at their entry point will always fail when invoked directly.
+
+### Sequencer Enforcement
+
+Both the public transaction path (`validate_and_produce_public_state_diff`) and the privacy-preserving circuit path (`execute_and_prove_program`) apply the same rule immediately after each program execution and before dispatching its chained calls:
+
+```rust
+// A program may only forward caps it minted (own ID) or received.
+for cap in &new_call.capabilities {
+    let program_can_mint_own = *cap == executing_program_id;
+    let program_is_forwarding_received = chained_call.capabilities.contains(cap);
+    ensure!(
+        program_can_mint_own || program_is_forwarding_received,
+        NssaError::InvalidProgramBehavior
+    );
+}
+```
+
+### CPS Execution Model
+
+"Call B then return to A" is expressed as:
+
+```
+A_entry       →  tail-calls B, minting A's capability, passing A_internal's ProgramId
+B             →  tail-calls A_internal, forwarding the received capability
+A_internal    →  assert_internal!(capabilities, required_caller); continues
+```
+
+Every step is a tail call. The internal continuation is a separate ELF protected by `assert_capability`, which panics inside the zkVM when the required ticket is absent, producing an invalid proof that the sequencer rejects.
+
+### SDK
+
+Two macros exported from `nssa_core`:
+
+```rust
+// Build a ChainedCall; optionally attach capabilities
+call_program!(target_id, accounts, &instruction)
+call_program!(target_id, accounts, &instruction; caps => vec![my_id])
+
+// Guard an internal entrypoint — panics if ticket absent
+assert_internal!(capabilities, required_caller)
+```
+
+`assert_capability(&capabilities, required_caller)` is also available as a plain function for use without the macro.
+
+## Success Criteria Checklist
+
+- [x] **External vs internal entrypoints** — Programs declare visibility by convention: External handlers omit any capability guard; Internal handlers call `assert_internal!` (or `assert_capability`) at their entry, which panics and fails the proof when no valid ticket is present.
+
+- [x] **Non-forgeable internal access** — Capability tickets are `ProgramId` values. A user cannot fabricate a ticket: the sequencer initialises all user transactions with `capabilities: vec![]` and enforces the mint/forward rules on every emitted `ChainedCall`, rejecting forgery with `InvalidProgramBehavior` before further execution.
+
+- [x] **General calls compile to tail calls** — The A→B→A_internal example demonstrates CPS encoding: the "call and return" pattern is expressed as two sequential tail calls with the continuation address carried as instruction data and the capability as a ticket.
+
+- [x] **Ergonomic developer tooling** — `call_program!` macro for constructing chained calls (with optional `caps => [...]` arm); `assert_internal!` macro for guarding internal handlers. Both are re-exported from `nssa_core` and documented in the README and spec.
+
+- [x] **End-to-end demo** — Three example programs in `test_program_methods/guest/src/bin/`: `program_a_entry.rs` (External), `program_b.rs` (External, relays continuation), `program_a_internal.rs` (Internal, guarded). Positive test (`general_call_capability_positive_path`) and negative test (`direct_call_to_internal_entrypoint_is_rejected`) both pass. Demo script: `examples/program_deployment/run_demo_capabilities.sh`.
+
+- [x] **Clear interface rules** — `docs/general-calls-via-tail-c-calls.md` covers: entrypoint encoding (separate ELF per entrypoint), capability invariants, sequencer enforcement pseudocode, ordering/determinism (depth-first FIFO), and error semantics table.
+
+- [x] **Test coverage** — `general_call_capability_positive_path` (A→B→A chain succeeds), `direct_call_to_internal_entrypoint_is_rejected` (direct user call fails), `sequencer_rejects_forged_capability_in_chained_call` (forgery rule fires), plus all pre-existing chained-call tests for backward compatibility. 148 tests total, 0 failures.
+
+## FURPS Self-Assessment
+
+**Functionality**: All seven success criteria are met. External and Internal entrypoints are enforced structurally — internal handlers panic inside the zkVM when the required capability is absent, producing an invalid proof. The sequencer enforces the mint/forward rules independently on both the public and privacy-preserving code paths. The CPS encoding is demonstrated end-to-end with three programs.
+
+**Usability**: Developers interact with two macros (`call_program!`, `assert_internal!`) and one function (`assert_capability`). The README shows the full API and the A→B→A execution chain in a concise diagram. A standalone demo script (`run_demo_capabilities.sh`) runs all three scenarios (positive, negative, forgery) with clear PASS/FAIL output.
+
+**Reliability**: `assert_capability` is a hard panic inside the zkVM guest — there is no way to "catch" a missing capability and continue; the zkVM proof is simply invalid. Sequencer enforcement is applied before dispatching every chained call, so a rogue program emitting a forged capability is caught before any further execution occurs. Backward compatibility is maintained: all pre-existing programs with empty `capabilities` lists continue to work unchanged.
+
+**Performance**: No new hash computations or cryptographic operations are added. Capability checking is a linear scan over `Vec<ProgramId>` (typically 0–3 elements). Sequencer overhead is negligible. All 148 tests complete in under 4 seconds under `RISC0_DEV_MODE=1`.
+
+**Supportability**: Changes are isolated to `nssa_core::program` (data structures + macros + `assert_capability`) and the sequencer's capability enforcement loop in two files. Pre-compiled artifacts for all programs are rebuilt via `just build-artifacts` (Docker). CI runs `RISC0_DEV_MODE=1 cargo test --release` and `cargo clippy -- -D warnings` with zero errors.
+
+## Supporting Materials
+
+- **Spec**: `docs/general-calls-via-tail-c-calls.md`
+- **Demo script**: `examples/program_deployment/run_demo_capabilities.sh`
+- **Example programs**: `test_program_methods/guest/src/bin/program_a_entry.rs`, `program_b.rs`, `program_a_internal.rs`
+- **Core implementation**: `nssa/core/src/program.rs` (capabilities field, macros, `assert_capability`), `nssa/src/public_transaction/transaction.rs` (sequencer enforcement), `nssa/src/privacy_preserving_transaction/circuit.rs` (sequencer enforcement)
+
+```bash
+# Run the demo
+bash examples/program_deployment/run_demo_capabilities.sh
+
+# Full test suite
+RISC0_DEV_MODE=1 cargo test -p nssa --release
+
+# Specific capability tests
+RISC0_DEV_MODE=1 cargo test -p nssa --release -- general_call_capability_positive_path
+RISC0_DEV_MODE=1 cargo test -p nssa --release -- direct_call_to_internal_entrypoint_is_rejected
+RISC0_DEV_MODE=1 cargo test -p nssa --release -- sequencer_rejects_forged_capability
+```
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](../TERMS.md).


### PR DESCRIPTION
## What's in this PR

Adds `solutions/LP-0015.md` — a complete implementation of general cross-program calls for the Logos Execution Zone via an unforgeable capability ticket mechanism.

## Implementation repo

https://github.com/soloking1412/logos-execution-zone

## Summary

Programs declare **External** entrypoints (user-callable) and **Internal** continuation handlers (chain-only). The sequencer issues capability tickets (`ProgramId` values carried in `capabilities: Vec<ProgramId>` on `ProgramInput` and `ChainedCall`) and enforces mint/forward rules on every emitted chained call. Internal handlers call `assert_internal!` at entry — when invoked directly by a user the capabilities list is always empty, the zkVM panics, and the sequencer rejects the transaction.

Ships with:
- `call_program!` and `assert_internal!` macros in `nssa_core`
- Sequencer enforcement on both the public and privacy-preserving paths
- Three example programs (`program_a_entry`, `program_b`, `program_a_internal`)
- Demo script: `examples/program_deployment/run_demo_capabilities.sh`
- Spec: `docs/general-calls-via-tail-c-calls.md`
- 148 tests, 0 failures (`RISC0_DEV_MODE=1 cargo test -p nssa --release`)

## Success criteria

- [x] External vs internal entrypoints
- [x] Non-forgeable internal access
- [x] General calls compile to tail calls (CPS model)
- [x] Ergonomic developer tooling (`call_program!`, `assert_internal!`)
- [x] End-to-end demo + negative rejection test
- [x] Clear interface rules in spec doc
- [x] Test coverage (positive path, direct-call prevention, forgery rejection, multi-hop)

## Run it

```bash
git clone https://github.com/soloking1412/logos-execution-zone
cd logos-execution-zone

# Demo (3 scenarios)
bash examples/program_deployment/run_demo_capabilities.sh

# Full suite
RISC0_DEV_MODE=1 cargo test -p nssa --release
