### PR TITLE
LP-0018: Token-gated forum extension (draft placeholder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All prizes live in the `[prizes/](prizes/)` directory. Each prize is a markdown 
 | [LP-0015](prizes/LP-0015.md) | General cross-program calls via tail calls               | Large  | Open   |
 | [LP-0016](prizes/LP-0016.md) | Anonymous Forum with Threshold Moderation                | Large  | Open   |
 | [LP-0017](prizes/LP-0017.md) | Whistleblower: document upload and indexing Basecamp app     | Medium | Open   |
+| [LP-0018](prizes/LP-0018.md) | Token-gated access for anonymous forum (extends LP-0016)     | TBD    | Draft  |
 
 ### Proposing a New Prize
 

--- a/prizes/LP-0018.md
+++ b/prizes/LP-0018.md
@@ -1,0 +1,64 @@
+# LP-0018: Token-gated access for the anonymous forum (LP-0016 extension) [DRAFT]
+
+**`Status: Draft — placeholder; success criteria and prize structure to be finalised`**
+**`Logos Circle: N/A`**
+
+## Overview
+
+This prize is a **follow-on to [LP-0016](./LP-0016.md)** (anonymous forum with threshold moderation). It extends that design with **token gating**: forum instances can require demonstrable token-based eligibility — for example minimum balance, stake, or hold of a designated asset — before a user may register, post, or access content, depending on how the instance is configured.
+
+The intent is to combine LP-0016’s anonymity and moderation guarantees with **economic or community-boundary controls** (who may participate at all), without replacing threshold moderation as the mechanism for ongoing content enforcement.
+
+## Motivation
+
+LP-0016 focuses on anonymous participation and fair moderation but does not specify how a forum instance limits *who* may join. Many real forums want a gate: DAO members, NFT holders, recipients of an airdrop, or stakeholders in a specific token. A dedicated extension prize keeps LP-0016’s scope stable while making token-based membership a first-class, composable layer.
+
+## Success Criteria
+
+> **Placeholder.** Detailed, testable criteria will be added in a later revision. At minimum, a winning submission is expected to demonstrate the following themes:
+
+- [ ] **Extends LP-0016**: builds on the moderation library and app patterns from LP-0016 (or a compatible implementation that satisfies LP-0016’s deliverables) without breaking anonymity and moderation guarantees unless explicitly scoped otherwise.
+- [ ] **Token gating**: at least one concrete gate (e.g. minimum balance, stake, or hold of a forum-configured token or asset) enforced in a trust-minimised way appropriate to the Logos stack (on-chain checks, attestations, or proofs as specified in the final criteria).
+- [ ] **Configurable per instance**: forum creators can set gating parameters for their instance; behaviour is documented.
+- [ ] **Standard deliverables** (once finalised): Basecamp app and/or module updates, LEZ program or integration as needed, tests, CI, and demo consistent with [evaluation policies](../README.md#evaluation-policies).
+
+## Scope
+
+### In Scope
+
+- Token-based eligibility for forum participation on top of the LP-0016 anonymous forum model.
+- Documentation of how gating interacts with registration, posting, and (if applicable) read access.
+
+### Out of Scope
+
+> To be refined. Likely excludes wholesale redesign of LP-0016 core moderation cryptography unless required for gating.
+
+- Replacing threshold moderation with token voting alone.
+- Centralised gatekeeping services not justified by the final criteria.
+
+## Prize Structure
+
+- **Total Prize:** *TBD*
+- **Effort:** *TBD*
+
+## Eligibility
+
+Open to any individual or team once the prize leaves Draft. Submissions must be original work and license terms will match other λPrizes (typically MIT or Apache-2.0).
+
+## Submission Requirements
+
+> **Placeholder.** Will mirror standard λPrize expectations: public repository, narrated demo, integration tests, and any LP-specific artifacts once success criteria are fixed.
+
+## Evaluation Process
+
+First-come-first-served against the final success criteria unless this file specifies otherwise. See [evaluation policies](../README.md#evaluation-policies).
+
+## Resources
+
+- [LP-0016](./LP-0016.md) — Anonymous forum with threshold moderation (base prize)
+- [LP-0005](./LP-0005.md) — Private token balance attestation (possibly relevant for privacy-preserving eligibility proofs)
+- [LP-0013](./LP-0013.md) / [LP-0014](./LP-0014.md) — Token program tooling (may inform gate implementation)
+
+## Potential for Subsequent λPrizes
+
+Further extensions (e.g. multiple concurrent gates, cross-forum eligibility, or deeper privacy for token proofs) may be split into additional prizes after this one is scoped.


### PR DESCRIPTION
## Summary

Adds **LP-0018** as a **Draft** placeholder prize that builds on [LP-0016](prizes/LP-0016.md) (anonymous forum with threshold moderation).

## Functionality (placeholder scope)

- **Token gating**: forum instances can require token-based eligibility (e.g. minimum balance, stake, or hold of a configured asset) for registration, posting, and/or access, as final criteria will specify.
- **Extends LP-0016**: intended to layer economic or community boundaries on top of the existing anonymity + N-of-M moderation model, not replace it.

Detailed success criteria, prize pool, and effort are marked **TBD** in the prize file until the Logos team finalises the spec.

## Changes

- New `prizes/LP-0018.md`
- README prizes table updated

Made with [Cursor](https://cursor.com)