### PR TITLE
Close LP-0015 (LEZ team delivery, no submission)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All prizes live in the `[prizes/](prizes/)` directory. Each prize is a markdown 
 | [LP-0012](prizes/LP-0012.md) | Event/Log mechanism                                      | Large  | Open                         |
 | [LP-0013](prizes/LP-0013.md) | Token program improvements (authorities)                 | Medium | Open   |
 | [LP-0014](prizes/LP-0014.md) | Token program improvements (ATAs + wallet tooling)       | Medium | Closed |
-| [LP-0015](prizes/LP-0015.md) | General cross-program calls via tail calls               | Large  | Open   |
+| [LP-0015](prizes/LP-0015.md) | General cross-program calls via tail calls               | Large  | Closed |
 | [LP-0016](prizes/LP-0016.md) | Anonymous Forum with Threshold Moderation                | Large  | Open   |
 | [LP-0017](prizes/LP-0017.md) | Whistleblower: document upload and indexing Basecamp app     | Medium | Open   |
 

--- a/prizes/LP-0015.md
+++ b/prizes/LP-0015.md
@@ -1,6 +1,9 @@
-# LP-0015: General cross-program calls via tail calls: external vs internal entrypoints + tooling [OPEN]
+# LP-0015: General cross-program calls via tail calls: external vs internal entrypoints + tooling [CLOSED]
 
+**`Status: Closed`**
 **`Logos Circle: N/A`**
+
+This prize is closed **without an external λPrize submission**. The work was **delivered by the Logos Execution Zone (LEZ) team** as part of the core runtime and tooling rather than awarded through this competition.
 
 ## Overview
 This prize is for designing and implementing *general cross-program calls* (call mid-execution, then continue) while keeping *tail calls as the only execution primitive*. The system should let a program tail-call another program, have control return later via another tail call, and then continue execution in an *internal-only function* that cannot be invoked directly by users.
@@ -102,14 +105,9 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 ## Evaluation Process
 
-By default, submissions are evaluated first-come-first-served against the success criteria. The first submission that meets **all** criteria wins.
+**Closed.** This prize is not accepting submissions. The capability was implemented by the **LEZ team**; there is **no external λPrize winner** or `solutions/LP-0015.md` entry.
 
-Evaluators will independently clone the repository and run the demo script from a clean environment; the script must succeed without modification. Evaluators may also ask technical follow-up questions to verify authorship and understanding of the implementation.
-
-The following policies apply to all prizes (see [evaluation policies](../README.md#evaluation-policies)):
-
-- **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
-- **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
+The success criteria and submission requirements above are **retained as the original specification** of the intended work for historical reference.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

Marks **LP-0015** as **Closed** with **no external λPrize winner**. The cross-program / tail-call work was **delivered by the LEZ team** as part of the core stack.

## Changes

- `prizes/LP-0015.md`: title `[CLOSED]`, explicit closure note, evaluation section updated so it does not read as open for submissions
- `README.md`: LP-0015 status column **Open → Closed**
