### PR TITLE
feat: LP-0012 Event/Log mechanism for LEZ programs

### DIFF
--- a/solutions/LP-0012.md
+++ b/solutions/LP-0012.md
@@ -1,0 +1,130 @@
+# Solution: LP-0012 — Event/Log mechanism for LEZ programs
+
+**Submitted by:** Gmin2
+
+## Summary
+
+Structured events for LEZ programs. Programs call `emit_event(&self_program_id, &MyEvent { ... })` and events are retrievable via `getTransactionReceipt` after the transaction lands. Events emitted before a program panic are preserved -- the hard requirement that the journal-based approach cannot satisfy.
+
+The submission has three parts: the SDK crate (`lp_events_core`) that any LEZ program can import, patches to `logos-execution-zone` that wire events through the sequencer into receipts, and CLI tooling for fetching and indexing events from a live sequencer.
+
+## Repository
+
+- **SDK + CLI + docs:** https://github.com/Gmin2/lp-events
+- **Patched LEZ fork (branch `lp-0012-events`):** https://github.com/Gmin2/logos-execution-zone/tree/lp-0012-events
+
+## Approach
+
+### Why the journal cannot be used for failure-path events
+
+RISC0's journal (`env::commit`) is the standard output channel for guest programs. The host reads the journal after `executor.execute()` returns. If the guest panics, `execute()` returns `Err` and the journal is never constructed -- the bytes are gone. This rules out journal-based event emission for the failure-path requirement.
+
+### fd 100 side-channel
+
+RISC0's `ExecutorEnvBuilder::write_fd(fd, writer)` registers a host-owned writer on a file descriptor. When the guest calls `sys_write(fd, buf, len)`, the runtime synchronously flushes bytes to the host writer before proceeding to the next instruction. This happens regardless of whether the guest subsequently panics. The bytes are on the host side before the panic unwinds the guest.
+
+`LP_EVENT_FD = 100` was chosen because RISC0 reserves 0 (stdin), 1 (stdout), 2 (stderr), and 3 (journal). 100 is well clear of any reserved range.
+
+### Wire format
+
+Each event is a fixed 48-byte header followed by a postcard-encoded payload:
+
+```
+[MAGIC: 4][total_len: 4][program_id: 32][seq: 4][payload...]
+```
+
+MAGIC is `0x4556454C` ("EVEL"). `seq` is a per-transaction monotonic counter so event ordering is deterministic even if the host buffers are reordered. `program_id` is passed in by the program itself (taken from `ProgramInput::self_program_id`), which gives explicit program attribution without requiring runtime enforcement.
+
+The format is documented in full in `docs/event-format.md`.
+
+Alternatives considered: key-value attributes (Cosmos style) -- rejected because they require schema agreement at the framework level and are harder to type-check in Rust. Borsh -- rejected in favor of postcard which is lighter and the existing LEZ codebase already uses it.
+
+### Size limits
+
+A `LimitedWriter` wrapper caps the total event stream at `MAX_STREAM_BYTES = 64 KiB` per transaction. Writes that would exceed the cap return `Err(EventError::StreamFull)` to the guest. This is a documented, deterministic error -- the guest can handle it or let it propagate. Silent truncation was explicitly rejected.
+
+### LEZ patches
+
+Four areas of `logos-execution-zone` are patched:
+
+1. `nssa::program::execute` -- registers a `LimitedWriter` on fd 100, returns `Result<ProgramExecution, ExecutionFailed>` where both variants carry `events: Vec<u8>`.
+2. `nssa::ValidatedStateDiff` -- gains an `events` field; `from_public_transaction_with_failure_events` returns `Result<Self, (NssaError, Vec<u8>)>` so events are threaded out on both paths.
+3. `common::receipt::TransactionReceipt` -- new type storing `tx_hash`, `TxStatus`, `events: Vec<u8>`, and `events_digest: [u8; 32]` (SHA-256 of the event bytes for integrity checking).
+4. `sequencer_core::SequencerStore` -- gains `record_receipt` / `get_receipt`; `sequencer_service_rpc` exposes `getTransactionReceipt`.
+
+### What program authors do
+
+Program authors import `lp_events_core` and call one function. They do not touch the sequencer. The sequencer running the chain must use the patched LEZ fork for events to be captured and stored.
+
+## Success Criteria Checklist
+
+- [x] **Event API for programs:** `lp_events_core::emit::emit_event(&program_id, &event)` accepts any `serde::Serialize` type. Available in `lp_events_core` crate.
+- [x] **Machine-readable format:** 48-byte header with MAGIC, `total_len`, `program_id` (32 bytes), `seq` (monotonic per-tx), followed by postcard payload. Versioning via MAGIC. Ordering via `seq`. Attribution via `program_id`. Schema via postcard + serde. Documented in `docs/event-format.md`.
+- [x] **Human-friendly rendering:** `event-demo show <tx_hash>` CLI fetches a receipt over JSON-RPC and decodes events into readable output. `event-indexer` tails block production and prints summaries.
+- [x] **Available post-execution:** `getTransactionReceipt(tx_hash)` JSON-RPC method on the sequencer returns the receipt including raw event bytes.
+- [x] **Emittable on failure:** fd 100 side-channel writes synchronously to the host before the guest panics. Validated by `receipt_carries_events_on_panic` integration test.
+- [x] **Testing:** `lp_events_core` has unit tests for encoding, decoding, ordering, and size-limit enforcement. Integration tests cover the success path and the panic path end to end against a full running sequencer.
+- [x] **SDK without runtime modifications:** `lp_events_core` is a standalone crate. Any LEZ program adds it to `Cargo.toml` and calls `emit_event`. No changes to the program's build setup are required beyond importing the crate.
+- [x] **Failure-path preservation:** Events are on the host buffer before `execute()` returns `Err`. The sequencer reads them from the `ExecutionFailed` variant and stores them in the receipt.
+- [x] **Deterministic size-limit error:** `LimitedWriter` returns `Err(EventError::StreamFull)` when `MAX_STREAM_BYTES = 64 KiB` is exceeded. Documented behavior, no silent truncation.
+- [x] **CU cost documented:** `docs/performance.md` -- approximately 3,200 user cycles per event for small fixed-size payloads, measured against the same RISC0 executor the sequencer uses.
+- [x] **Deployed and tested on devnet:** Integration tests run against a full LEZ stack (testcontainers, bedrock Docker image). Both success and panic tests pass.
+- [x] **CI:** `lp-events` CI runs `cargo check --workspace` and `cargo build --release -p event_demo -p event_indexer` on push and pull request.
+- [x] **README:** Documents how to emit events from a program, retrieve them after execution, decode them with the CLI, and run all tests.
+- [x] **Demo script:** `demo.sh` clones the patched LEZ fork, builds guest ELFs, runs the integration test. Works with `RISC0_DEV_MODE=0` for real proof generation.
+- [x] **Video demo:** Narrated walkthrough showing `RISC0_DEV_MODE=0` terminal output -- see Supporting Materials.
+
+## FURPS Self-Assessment
+
+### Functionality
+
+- `emit_event` accepts any `serde::Serialize` type. Programs import one crate and call one function.
+- Events are retrievable on both success and failure paths via `getTransactionReceipt`.
+- The `event-demo show` CLI decodes events from a receipt fetched over JSON-RPC.
+- The `event-indexer` CLI tails block production from the sequencer.
+- The reference program (`event_emitter`) covers a success-path event (Greeted) and a failure-path event (InsufficientFunds followed by panic).
+- Size cap: 64 KiB per transaction. Exceeding it returns a typed error to the guest.
+
+Not implemented: private execution events (out of scope per prize spec). The design is explicit -- `emit_event` takes a `program_id` argument and programs control what they emit.
+
+### Usability
+
+Adding events to a LEZ program is three lines: add `lp_events_core` to `Cargo.toml`, import `emit_event`, call it. No macros, no schema registration, no build script changes.
+
+Retrieving events after a transaction: `event-demo show <tx_hash>` -- one command, readable output.
+
+### Reliability
+
+- Events emitted before a panic are always preserved. The fd 100 side-channel is synchronous: bytes reach the host writer before the next guest instruction executes, so there is no window where a panic can lose events.
+- `LimitedWriter` caps stream size and returns a typed error. No silent truncation, no panic on overflow.
+- `TransactionReceipt` includes `events_digest` (SHA-256) so clients can verify the event bytes have not been tampered with after storage.
+
+### Performance
+
+Approximately 3,200 user cycles per event for small fixed-size payloads (measured: noop baseline 20,230 cycles; single Greet event 23,444 cycles; delta 3,214 cycles). Per-byte estimate: ~20 cycles per byte of payload above the baseline, consistent with the postcard varint path through `sys_write`.
+
+At 32M cycles per transaction and ~3,200 cycles per event, the cycle budget supports approximately 10,000 events per transaction before emission alone exhausts it. In practice, the 64 KiB byte cap is the binding constraint: with a 48-byte header, the maximum is 1,365 zero-payload events per transaction.
+
+Full methodology and measurements in `docs/performance.md`.
+
+### Supportability
+
+- `lp_events_core`: 14 unit tests covering encode/decode round-trips, ordering, size-limit enforcement, and the `emit_to` pure function.
+- `common::receipt`: 4 unit tests for Borsh round-trip.
+- `sequencer_core`: 1 unit test for `record_and_fetch_receipt`.
+- `nssa::program`: 2 integration-level tests for event return on success and panic paths; 1 `#[ignore]` benchmark for cycle measurement.
+- End-to-end: 2 integration tests (`receipt_carries_events_on_success`, `receipt_carries_events_on_panic`) against a full LEZ stack. Both pass in 58 seconds with `RISC0_DEV_MODE=1`.
+- CI: `cargo check` and `cargo build` on `lp-events` repo run on every push and pull request.
+- `docs/event-format.md`: wire format spec with field layout, encoding rules, size limits, and versioning strategy.
+- `docs/performance.md`: cycle cost methodology and measurements.
+
+## Supporting Materials
+
+- Demo script: `demo.sh` in https://github.com/Gmin2/lp-events
+- Wire format spec: `docs/event-format.md`
+- Performance measurements: `docs/performance.md`
+- Video walkthrough: https://youtu.be/mtzXJB945ms
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](../TERMS.md).


### PR DESCRIPTION
Structured event system for LEZ programs. Programs call emit_event with any serializable type; events are retrievable via `getTransactionReceipt` after the transaction lands. Events emitted before a program panic are preserved via an fd 100 side-channel that writes synchronously to the host before the guest unwinds.

- SDK: https://github.com/Gmin2/lp-events
- Patched LEZ fork: https://github.com/Gmin2/logos-execution-zone/tree/lp-0012-events
- Demo: https://youtu.be/mtzXJB945ms
