### PR TITLE
fix: update broken RFP-001 link in LP-0013

### DIFF
--- a/prizes/LP-0013.md
+++ b/prizes/LP-0013.md
@@ -25,7 +25,7 @@ Adding a clean authority model enables the ecosystem to support real economic us
   - authority rotation and/or revocation (e.g., set to `None` to make supply fixed).
 - [ ] Documentation and examples: Provide:
   - at least *two* example integrations (e.g., “fixed supply token with revoked authority” and “variable supply token with mint authority”).
-- [ ] Produced a self-sufficient, agnostic library that handles approval as defined in [RFP-001](https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-poc.md).
+- [ ] Produced a self-sufficient, agnostic library that handles approval as defined in [RFP-001](https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-lib.md).
 
 ### Usability
 


### PR DESCRIPTION
The RFP-001 link in LP-0013 currently 404s. PR logos-co/rfp#33 (merged 2026-04-08) renamed the file from `RFP-001-admin-authority-poc.md` to `RFP-001-admin-authority-lib.md`. This updates LP-0013 to point at the new path.

New URL: https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-lib.md
