### PR TITLE
Solution: LP-0016 — Anonymous Forum with Threshold Moderation and Membership Revocation

### DIFF
--- a/solutions/LP-0016.md
+++ b/solutions/LP-0016.md
@@ -1,0 +1,125 @@
+# Solution: LP-0016 — Anonymous Forum with Threshold Moderation and Membership Revocation
+
+**Submitted by:** Johan Sellström / Advatar
+
+## Summary
+
+This submission implements an anonymous forum protocol with threshold moderation, K-strike revocation, retroactive linkability for slashed members, and a Basecamp app built on a forum-agnostic moderation SDK.
+
+Members register a private commitment, publish posts with unlinkable membership proofs, and remain anonymous across posts while below the slash threshold. Moderators issue off-chain N-of-M moderation certificates against abstract content identifiers. Once K certificates accumulate for the same member, the slash verifier reconstructs the member secret, proves the strike bundle, revokes the commitment in the registry, and makes only that slashed member's prior posts retroactively linkable.
+
+The repository includes the Rust protocol core, moderation SDK, slash verifier, LEZ registry guest, RISC0 membership proof path, Lean 4 invariant surface, optional Noir circuit, Basecamp QML app, narrated demo video, and reproducible local evidence scripts.
+
+## Repository
+
+- **Repo:** https://github.com/advatar/Logos
+- **Commit:** `749b3cefec3ce3c9d07b130835ac9fcd2ec9597c` (branch: `main`)
+- **License:** MIT
+- **Narrated demo video:** https://github.com/advatar/Logos/blob/main/submission/lp0016-demo.mp4
+- **Demo poster:** https://github.com/advatar/Logos/blob/main/submission/lp0016-demo-poster.jpg
+- **Local evidence gate:** `cd src && scripts/local_submission_gate.py`
+- **Key files:**
+  - `src/crates/protocol-core/` — pure protocol state machine, commitments, Merkle proofs, certificates, Shamir reconstruction, threshold ElGamal, and revocation state
+  - `src/crates/moderation-sdk/` — forum-agnostic SDK facade over abstract content identifiers, off-chain storage, and retry queues
+  - `src/crates/slash-verifier/` — slash bundle verification and CLI surface
+  - `src/registry/lp0016-registry/` — LEZ/SPEL membership registry crate
+  - `src/registry/idl/lp0016_registry.idl.json` — SPEL-compatible registry IDL alias
+  - `src/registry/idl/lp0016_registry.json` — original registry IDL
+  - `src/methods/guest/src/bin/lp0016_registry.rs` — deployable LEZ guest
+  - `src/zk/membership-host/` and `src/zk/membership-guest/` — RISC0 host and guest proof path
+  - `src/lean/AnonymousForum/` — Lean 4 proof modules for protocol invariants
+  - `src/noir/post_binding/` — optional Noir post-binding circuit
+  - `src/app/basecamp-forum/` — Basecamp QML flow and Rust core-module bridge
+  - `src/scripts/demo_e2e.py` — two-forum end-to-end lifecycle demo
+  - `src/scripts/demo_e2e.sh` — RISC0 host integration demo with `RISC0_DEV_MODE=0`
+  - `src/scripts/collect_localnet_evidence.py` — local LEZ sequencer deploy and evidence collection
+  - `src/docs/protocol.md`, `src/docs/api.md`, `src/docs/threat-model.md`, `src/docs/performance.md`, `src/docs/submission.md` — protocol, API, threat, performance, and submission documentation
+
+## Approach
+
+The protocol separates reusable moderation machinery from the forum application. The `moderation-sdk` exposes registration, proof generation, moderation certificate construction, slash evidence assembly, and retryable off-chain storage through library traits. It operates on content identifiers and forum parameters rather than forum-specific posts, comments, or UI state.
+
+Each forum instance has independent K and N-of-M parameters, moderator keys, registry roots, and revocation state. The deterministic end-to-end demo creates two instances:
+
+- Forum A: K=2, N=2-of-3
+- Forum B: K=3, N=1-of-2
+
+Posting proves membership and revocation non-membership without revealing the member commitment. Moderation certificates are signed by threshold moderator sets and stored off-chain. When the slash threshold is reached, the verifier checks K valid certificates for the same member, reconstructs the revocation secret using the threshold shares, submits the registry slash path, and rejects later posts tied to the revoked commitment.
+
+The implementation uses a layered evidence model:
+
+- Python simulator and unit tests for the full lifecycle and edge cases.
+- Rust workspace tests for protocol state, Shamir reconstruction, Merkle proofs, certificate validation, SDK behavior, and slash verification.
+- RISC0 guest/host path for the primary membership proof statement, measured with `RISC0_DEV_MODE=0`.
+- LEZ local sequencer deployment evidence using the current public standalone sequencer path.
+- Lean 4 modules for state-machine invariants, certificate threshold soundness, slash bundle shape, and Shamir/Lagrange reconstruction contracts.
+- Basecamp QML package demonstrating instance creation, registration, posting, moderation, history, and revocation through the SDK bridge.
+
+The submission is explicit about the remaining runtime evidence blocked by public Logos infrastructure availability: separate public devnet/testnet RPC program IDs, CU reports for custom registry instructions, and public Basecamp inspector click-through evidence. The repository includes structured diagnostics for each blocker.
+
+## Success Criteria Checklist
+
+- [x] A member can register in a forum instance and publish posts with valid anonymous membership proofs.
+- [x] Posts from the same member are unlinkable while the member remains below the slash threshold.
+- [x] Upon slash, the reconstructed secret enables retroactive linkability of the slashed member's prior posts without affecting other members.
+- [x] The retroactive deanonymization property is documented in `src/docs/protocol.md`.
+- [x] N-of-M moderators can jointly produce valid moderation certificates off-chain.
+- [x] Fewer than N moderators cannot produce a valid certificate.
+- [x] K accumulated moderation certificates for the same member trigger the slash path.
+- [x] Slashed commitments are added to the revocation list and later posts tied to those commitments are rejected.
+- [x] Forum parameters are independent per instance, including K and N-of-M.
+- [x] A standalone, forum-agnostic moderation SDK exposes documented APIs for membership, proofs, moderation certificates, and slash evidence.
+- [x] The SDK operates on abstract content identifiers and does not assume forum content structure.
+- [x] A Basecamp app is provided on top of the SDK.
+- [x] The Basecamp app covers instance creation, registration, posting, moderation, moderation history, and revocation.
+- [x] The demo exercises two independent forum instances with different K and N-of-M parameters.
+- [x] The repository provides an IDL for the membership registry program.
+- [x] Proof generation failures surface as errors and the retry path does not consume the member nullifier.
+- [x] Partial moderation certificates are rejected before slash submission.
+- [x] Off-chain pending posts and moderation actions are represented through retry queue abstractions.
+- [x] RISC0 membership proof generation was measured below 10 seconds with `RISC0_DEV_MODE=0`; the latest documented run reports about 6 seconds.
+- [x] The membership registry program is deployed and exercised against the official local standalone LEZ sequencer path.
+- [x] End-to-end integration tests and a reproducible local evidence gate are included.
+- [x] The README and docs cover deployment, program IDs, forum creation, registration, posting, moderation, slash, and Basecamp usage.
+- [x] A narrated MP4 demo video is included.
+- [ ] Public LEZ devnet/testnet program IDs are not included because public RPC URLs were not available in the current Logos docs/tooling path.
+- [ ] Live CU numbers for `register_member` and `slash_member` remain blocked on a custom invoke/CU-report path in the public scaffold/wallet tooling; `src/scripts/measure_cu.sh` reports the narrowed blocker.
+- [ ] Public Basecamp QML inspector click-through evidence remains blocked by the public runtime not exposing the inspector endpoint; the QML flow and diagnostic script are included.
+
+## FURPS Self-Assessment
+
+### Functionality
+
+The implementation covers the full moderation lifecycle: forum instance creation, member registration, anonymous proof-backed posting, threshold moderation, strike accumulation, slash verification, revocation, post-after-revocation rejection, and retroactive linkability only for the slashed member. The reusable SDK remains forum-agnostic and is used by both the local demos and Basecamp app bridge.
+
+### Usability
+
+The evaluator path is a single local command: `cd src && scripts/local_submission_gate.py`. The Basecamp app exposes a 9-screen QML flow for non-CLI interaction, while the scripts provide deterministic evidence for reviewers who want to inspect protocol behavior directly. API usage and integration notes are documented in `src/docs/api.md`.
+
+### Reliability
+
+The local gate covers Python lifecycle tests, Rust workspace build/tests, RISC0 host feature checks, real proof-performance measurement, LEZ guest checks/builds, Lean 4 build, and Basecamp package creation. Runtime-dependent checks are separated into structured diagnostics so missing external infrastructure is reported explicitly rather than silently skipped.
+
+### Performance
+
+The RISC0 proof path has been measured with `RISC0_DEV_MODE=0` under the 10-second target. `src/docs/performance.md` documents the benchmark command, proof cost model, and remaining CU-reporting blocker for live LEZ custom instructions.
+
+### Supportability
+
+The repository is organized into small crates and documented surfaces: protocol core, SDK, registry simulator, slash verifier, RISC0 statement, registry program, Basecamp app, Lean proofs, optional Noir circuit, and scripts. The submission docs map prize criteria to concrete files and commands, and generated evidence is written under `src/dist/submission/`.
+
+## Supporting Materials
+
+- Protocol specification: https://github.com/advatar/Logos/blob/main/src/docs/protocol.md
+- SDK API reference: https://github.com/advatar/Logos/blob/main/src/docs/api.md
+- Threat model: https://github.com/advatar/Logos/blob/main/src/docs/threat-model.md
+- Performance notes: https://github.com/advatar/Logos/blob/main/src/docs/performance.md
+- Submission evidence notes: https://github.com/advatar/Logos/blob/main/src/docs/submission.md
+- Success-criteria mapping: https://github.com/advatar/Logos/blob/main/src/docs/success_criteria.json
+- Localnet program ID: https://github.com/advatar/Logos/blob/main/src/registry/program_ids/localnet.txt
+- Basecamp app: https://github.com/advatar/Logos/tree/main/src/app/basecamp-forum
+- Narrated video: https://github.com/advatar/Logos/blob/main/submission/lp0016-demo.mp4
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](../TERMS.md).


### PR DESCRIPTION
## Summary

Adds the Advatar LP-0016 solution entry under `solutions/LP-0016.md`, matching the repository submission format. The implementation repo is public at https://github.com/advatar/Logos and the solution entry links the exact commit, demo video, local evidence gate, protocol docs, SDK, LEZ registry, RISC0 proof path, Lean proof modules, and Basecamp app.

## Validation

- Ran the lambda-prize `validate-submission.sh` script locally with this PR title and changed-file scope.
- Validation passed after adding non-Markdown evaluator aliases to `advatar/Logos` (`demo.sh`, `lp0016_registry.idl.json`, and `module.json`).

## Scope

This PR only touches `solutions/LP-0016.md`.