### PR TITLE
template: require Mac + Linux build support

### DIFF
--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -53,6 +53,7 @@ dependencies: []
 >
 > **Supportability** — standard requirements (adapt as needed):
 > - The program is deployed and tested on LEZ devnet/testnet.
+> - The submission builds and runs end-to-end on both **macOS (Apple Silicon)** and **Linux (x86_64)**. The demo script must succeed without modification on both platforms from a clean clone. If a component is genuinely platform-bound (e.g. Mach-O install-name fixup), the flake/build system must conditionally skip it on the other platform rather than fail evaluation.
 > - End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.
 > - CI must be green on the default branch.
 > - A README documents end-to-end usage: deployment steps, program addresses, and step-by-step instructions for interacting with the program via CLI and Basecamp app.

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -53,7 +53,8 @@ dependencies: []
 >
 > **Supportability** — standard requirements (adapt as needed):
 > - The program is deployed and tested on LEZ devnet/testnet.
-> - The submission builds and runs end-to-end on both **macOS (Apple Silicon)** and **Linux (x86_64)**. The demo script must succeed without modification on both platforms from a clean clone. If a component is genuinely platform-bound (e.g. Mach-O install-name fixup), the flake/build system must conditionally skip it on the other platform rather than fail evaluation.
+> - The submission builds and runs end-to-end on both **macOS (Apple Silicon)** and **Linux (x86_64)**. The demo script must succeed without modification on both platforms from a clean clone.
+> - Logos Basecamp modules are built with [`logos-module-builder`](https://github.com/logos-co/logos-module-builder) (`mkLogosModule`).
 > - End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.
 > - CI must be green on the default branch.
 > - A README documents end-to-end usage: deployment steps, program addresses, and step-by-step instructions for interacting with the program via CLI and Basecamp app.

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -55,6 +55,7 @@ dependencies: []
 > - The program is deployed and tested on LEZ devnet/testnet.
 > - The submission builds and runs end-to-end on both **macOS (Apple Silicon)** and **Linux (x86_64)**. The demo script must succeed without modification on both platforms from a clean clone.
 > - Logos Basecamp modules are built with [`logos-module-builder`](https://github.com/logos-co/logos-module-builder) (`mkLogosModule`).
+> - Logos Basecamp modules are published to a module catalog: a fork of [`logos-modules-release-base`](https://github.com/logos-co/logos-modules-release-base), publishing releases via [`logos-modules-release-action`](https://github.com/logos-co/logos-modules-release-action). The catalog's `logos-repo.json` URL must be included in the submission so evaluators can install the module through the package-manager UI / `lgpd`.
 > - End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.
 > - CI must be green on the default branch.
 > - A README documents end-to-end usage: deployment steps, program addresses, and step-by-step instructions for interacting with the program via CLI and Basecamp app.


### PR DESCRIPTION
## Summary
Add two Supportability criteria to the prize template (`prizes/LP-0000.md`):

1. **Cross-platform build requirement** — submissions must build and run end-to-end on both macOS (Apple Silicon) and Linux (x86_64) from a clean clone, without modification.
2. **`logos-module-builder` for Basecamp modules** — Basecamp module flakes must use `mkLogosModule` from `logos-co/logos-module-builder` (per the [Logos tutorial](https://github.com/logos-co/logos-tutorial)) rather than hand-rolling derivations. Cross-platform packaging (Mach-O install names, ELF RPATH, etc.) lives in the shared builder so individual modules don't have to re-solve it — and don't get to solve it wrong.

## Motivation
Reviewing LP-0017 (#58) on a Linux x86_64 host surfaced both gaps:
- The submission's flake fails `nix build .#lgx` at evaluation time because it unconditionally references `pkgs.darwin.cctools` (a macOS-only package) in a hand-rolled `postFixup`.
- The submission opted to write its own ~250-line flake instead of using `logos-module-builder`. Had it used the standard builder, the platform fixup would have been handled centrally and the Linux build would have just worked.

The template was silent on both points, so neither the builder nor the reviewer had a shared expectation.

## Scope
- Forward-looking only: updates `prizes/LP-0000.md` so new prizes inherit the requirements.
- Does NOT touch existing open prizes (LP-0001..LP-0017) — those have their own success criteria already negotiated.

## Test plan
- [ ] `prizes/LP-0000.md` renders cleanly on GitHub.
- [ ] Only `prizes/LP-0000.md` is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)