### PR TITLE
Add standardized Dependencies section to L-Prize template and existing LPs

### DIFF
--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -92,6 +92,17 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+> Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+> before this Lambda Prize can be announced or claimed. Use the canonical IDs.
+>
+> - LP-XXXX — short reason
+> - RFP-XXX — short reason
+> - (none, if standalone)
+
+- (none)
+
 ## Resources
 
 > Links to relevant specs, documentation, APIs, or prior work that participants should know about.

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -1,5 +1,22 @@
 <!-- Don't forget to add/update this prize in the table in README.md -->
 
+<!--
+Optional YAML frontmatter for prizes that have hard dependencies on
+other L-Prizes, RFPs, R&D items, or sample apps. Include the
+`dependencies:` field ONLY when there are real hard deps with
+canonical IDs (LP-XXXX, RFP-XXX). Omit the entire frontmatter block
+if this prize has no hard deps — do not use `dependencies: []`. This
+field is parsed by downstream tooling (e.g. flywheels.logos.co).
+
+---
+dependencies:
+  - id: LP-XXXX
+    reason: short reason this prize depends on it
+  - id: RFP-XXX
+    reason: short reason this prize depends on it
+---
+-->
+
 # LP-XXXX: <Title> [status]
 
 **`Status`**:
@@ -91,15 +108,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
-
-## Dependencies
-
-> Add this section ONLY if this prize has hard dependencies on other
-> L-Prizes, RFPs, R&D items, or sample apps. Omit the entire section
-> if there are no hard deps. Format:
->
-> - LP-XXXX — short reason
-> - RFP-XXX — short reason
 
 ## Resources
 

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -1,21 +1,21 @@
 <!-- Don't forget to add/update this prize in the table in README.md -->
 
-<!--
-Optional YAML frontmatter for prizes that have hard dependencies on
-other L-Prizes, RFPs, R&D items, or sample apps. Include the
-`dependencies:` field ONLY when there are real hard deps with
-canonical IDs (LP-XXXX, RFP-XXX). Omit the entire frontmatter block
-if this prize has no hard deps — do not use `dependencies: []`. This
-field is parsed by downstream tooling (e.g. flywheels.logos.co).
-
 ---
-dependencies:
-  - id: LP-XXXX
-    reason: short reason this prize depends on it
-  - id: RFP-XXX
-    reason: short reason this prize depends on it
+# Always declare `dependencies:` — use `[]` if there are none.
+# A missing field signals the author has not considered deps yet
+# (lintable); `[]` signals considered and none. Replace `[]` with
+# a list of `{ id, reason }` objects for prizes with hard deps on
+# other L-Prizes, RFPs, R&D items, or sample apps, using canonical
+# IDs (LP-XXXX, RFP-XXX). This field is parsed by downstream tooling
+# (e.g. flywheels.logos.co). Example:
+#
+# dependencies:
+#   - id: LP-XXXX
+#     reason: short reason this prize depends on it
+#   - id: RFP-XXX
+#     reason: short reason this prize depends on it
+dependencies: []
 ---
--->
 
 # LP-XXXX: <Title> [status]
 

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -94,14 +94,12 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 
 ## Dependencies
 
-> Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-> before this Lambda Prize can be announced or claimed. Use the canonical IDs.
+> Add this section ONLY if this prize has hard dependencies on other
+> L-Prizes, RFPs, R&D items, or sample apps. Omit the entire section
+> if there are no hard deps. Format:
 >
 > - LP-XXXX — short reason
 > - RFP-XXX — short reason
-> - (none, if standalone)
-
-- (none)
 
 ## Resources
 

--- a/prizes/LP-0001.md
+++ b/prizes/LP-0001.md
@@ -96,13 +96,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- LEZ NFT Program — the underlying NFT program on LEZ must be ready before this prize can open (see status banner above).
-
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0001.md
+++ b/prizes/LP-0001.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0001: Private NFT Ownership Proof [DRAFT]
 
 **`Status: draft - pending NFT Program readiness`**

--- a/prizes/LP-0001.md
+++ b/prizes/LP-0001.md
@@ -96,6 +96,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- LEZ NFT Program — the underlying NFT program on LEZ must be ready before this prize can open (see status banner above).
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0002.md
+++ b/prizes/LP-0002.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0002: Private M-of-N Multisig [OPEN]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0002.md
+++ b/prizes/LP-0002.md
@@ -99,6 +99,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [lez-multisig](https://github.com/jimmy-claw/lez-multisig) — public multisig PoC; architecture notes describe why private accounts are incompatible

--- a/prizes/LP-0002.md
+++ b/prizes/LP-0002.md
@@ -99,13 +99,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [lez-multisig](https://github.com/jimmy-claw/lez-multisig) — public multisig PoC; architecture notes describe why private accounts are incompatible

--- a/prizes/LP-0003.md
+++ b/prizes/LP-0003.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0003: Private Allowlist / Airdrop Distributor [OPEN]
 
 **`Status: Open`**

--- a/prizes/LP-0003.md
+++ b/prizes/LP-0003.md
@@ -102,6 +102,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0003.md
+++ b/prizes/LP-0003.md
@@ -102,13 +102,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0004.md
+++ b/prizes/LP-0004.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0004: Sealed-Bid Auction Using Shielded Balances [DRAFT]
 
 **`Status: Draft - pending LEZ timelock feature`**

--- a/prizes/LP-0004.md
+++ b/prizes/LP-0004.md
@@ -100,6 +100,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- LEZ timelock feature — on-chain timelock support on LEZ is required for the bid-reveal window and refund mechanics (see status banner above).
+
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0004.md
+++ b/prizes/LP-0004.md
@@ -100,13 +100,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- LEZ timelock feature — on-chain timelock support on LEZ is required for the bid-reveal window and refund mechanics (see status banner above).
-
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0005.md
+++ b/prizes/LP-0005.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0005: Private Token Balance Attestation [OPEN]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0005.md
+++ b/prizes/LP-0005.md
@@ -111,6 +111,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0005.md
+++ b/prizes/LP-0005.md
@@ -111,13 +111,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0006.md
+++ b/prizes/LP-0006.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 <!-- Don't forget to add/update this prize in the table in README.md -->
 
 # LP-0006: Atomic Swap with LEZ [DRAFT]

--- a/prizes/LP-0006.md
+++ b/prizes/LP-0006.md
@@ -173,17 +173,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- LEZ timelock feature — on-chain timelock support on LEZ is required for swap refund mechanics (see status banner above).
-- Logos Delivery module — required for makers to advertise prices and trading pairs (see status banner above).
-- Logos Chat module — required for maker-taker negotiation and swap coordination (see status banner above).
-
-Note: see `## Infrastructure & Dependencies` above for per-chain runtime infrastructure (Bitcoin/Monero/Ethereum nodes) participants must run.
-
 ## Resources
 
 ### General

--- a/prizes/LP-0006.md
+++ b/prizes/LP-0006.md
@@ -173,6 +173,17 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- LEZ timelock feature — on-chain timelock support on LEZ is required for swap refund mechanics (see status banner above).
+- Logos Delivery module — required for makers to advertise prices and trading pairs (see status banner above).
+- Logos Chat module — required for maker-taker negotiation and swap coordination (see status banner above).
+
+Note: see `## Infrastructure & Dependencies` above for per-chain runtime infrastructure (Bitcoin/Monero/Ethereum nodes) participants must run.
+
 ## Resources
 
 ### General

--- a/prizes/LP-0008.md
+++ b/prizes/LP-0008.md
@@ -170,6 +170,15 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
+Note: LP-0002 and LP-0005 are listed under Resources as related references, not hard dependencies for this prize.
+
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0008.md
+++ b/prizes/LP-0008.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0008: Autonomous AI Module with Wallet, Storage, and Messaging [OPEN]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0008.md
+++ b/prizes/LP-0008.md
@@ -170,15 +170,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
-Note: LP-0002 and LP-0005 are listed under Resources as related references, not hard dependencies for this prize.
-
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone/)

--- a/prizes/LP-0009.md
+++ b/prizes/LP-0009.md
@@ -50,6 +50,13 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 Submissions are evaluated first-come-first-served against the success criteria. The first submission that satisfies all criteria wins.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [NIP-46: Nostr Connect](https://github.com/nostr-protocol/nips/blob/master/46.md)

--- a/prizes/LP-0009.md
+++ b/prizes/LP-0009.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0009: Keycard NIP-46 Nostr Signer Proxy [CLOSED]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0009.md
+++ b/prizes/LP-0009.md
@@ -50,13 +50,6 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 Submissions are evaluated first-come-first-served against the success criteria. The first submission that satisfies all criteria wins.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [NIP-46: Nostr Connect](https://github.com/nostr-protocol/nips/blob/master/46.md)

--- a/prizes/LP-0010.md
+++ b/prizes/LP-0010.md
@@ -68,6 +68,13 @@ Submissions are evaluated first-come-first-served against the success criteria. 
 
 Evaluators will independently clone the repository and run the application from a clean environment. Evaluators may also ask technical follow-up questions to verify authorship and understanding of the implementation.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [ERC-4527: QR Code Based Air-Gapped Signer Interface](https://eips.ethereum.org/EIPS/eip-4527) — the standard for QR-based communication between airgapped signers and watch-only wallets, built on UR (Uniform Resources). Keystone pioneered this standard and provides mature SDKs implementing it.

--- a/prizes/LP-0010.md
+++ b/prizes/LP-0010.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0010: Shell dApp Integration Proof of Concept [CLOSED]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0010.md
+++ b/prizes/LP-0010.md
@@ -68,13 +68,6 @@ Submissions are evaluated first-come-first-served against the success criteria. 
 
 Evaluators will independently clone the repository and run the application from a clean environment. Evaluators may also ask technical follow-up questions to verify authorship and understanding of the implementation.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [ERC-4527: QR Code Based Air-Gapped Signer Interface](https://eips.ethereum.org/EIPS/eip-4527) — the standard for QR-based communication between airgapped signers and watch-only wallets, built on UR (Uniform Resources). Keystone pioneered this standard and provides mature SDKs implementing it.

--- a/prizes/LP-0011.md
+++ b/prizes/LP-0011.md
@@ -128,6 +128,15 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
+Note: the status banner flags overlap with the LEZ framework — see the banner for the current review status — but no concrete L-Prize, RFP, or R&D item is identified as a blocker.
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0011.md
+++ b/prizes/LP-0011.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0011: Program development tooling: minimal Rust SDK for programs + CPI [DRAFT]
 
 **`Status: Draft - To review with overlap with LEZ framework`**

--- a/prizes/LP-0011.md
+++ b/prizes/LP-0011.md
@@ -128,15 +128,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
-Note: the status banner flags overlap with the LEZ framework — see the banner for the current review status — but no concrete L-Prize, RFP, or R&D item is identified as a blocker.
-
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0012.md
+++ b/prizes/LP-0012.md
@@ -130,6 +130,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0012.md
+++ b/prizes/LP-0012.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0012: Event/Log mechanism: Structured events for LEZ program execution [CLOSED]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0012.md
+++ b/prizes/LP-0012.md
@@ -130,13 +130,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0013.md
+++ b/prizes/LP-0013.md
@@ -87,6 +87,13 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- [RFP-001](https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-lib.md) — admin authority library (referenced in Success Criteria; the deliverable must reuse the approval pattern defined here).
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0013.md
+++ b/prizes/LP-0013.md
@@ -1,3 +1,10 @@
+---
+dependencies:
+  - id: RFP-001
+    reason: Provides the standardised admin authority library that the
+      mint authority approval pattern must reuse, per Success Criteria.
+---
+
 # LP-0013: Token program improvements: authorities [OPEN]
 
 **`Logos Circle: N/A`**
@@ -86,13 +93,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
-
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- [RFP-001](https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-lib.md) — admin authority library (referenced in Success Criteria; the deliverable must reuse the approval pattern defined here).
 
 ## Resources
 

--- a/prizes/LP-0014.md
+++ b/prizes/LP-0014.md
@@ -67,6 +67,13 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 By default, submissions are evaluated first-come-first-served against the success criteria. The first submission that meets **all** criteria wins.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0014.md
+++ b/prizes/LP-0014.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0014: Token program improvements: Associated Token Accounts (ATAs) + wallet tooling [CLOSED]
 
 **`Logos Circle: N/A`**

--- a/prizes/LP-0014.md
+++ b/prizes/LP-0014.md
@@ -67,13 +67,6 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 By default, submissions are evaluated first-come-first-served against the success criteria. The first submission that meets **all** criteria wins.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0015.md
+++ b/prizes/LP-0015.md
@@ -109,6 +109,13 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 The success criteria and submission requirements above are **retained as the original specification** of the intended work for historical reference.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0015.md
+++ b/prizes/LP-0015.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0015: General cross-program calls via tail calls: external vs internal entrypoints + tooling [CLOSED]
 
 **`Status: Closed`**

--- a/prizes/LP-0015.md
+++ b/prizes/LP-0015.md
@@ -109,13 +109,6 @@ Open to any individual or team. Submissions must be original work. Teams must ho
 
 The success criteria and submission requirements above are **retained as the original specification** of the intended work for historical reference.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
 ## Resources
 
 - [LEZ Github repository](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0016.md
+++ b/prizes/LP-0016.md
@@ -140,6 +140,15 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
+Note: LP-0001 and LP-0003 are listed under Resources as related references (ZK membership proof and nullifier scheme patterns), not hard dependencies for this prize.
+
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0016.md
+++ b/prizes/LP-0016.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0016: Anonymous Forum with Threshold Moderation and Membership Revocation [OPEN]
 
 **`Status: Open`**

--- a/prizes/LP-0016.md
+++ b/prizes/LP-0016.md
@@ -140,15 +140,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
-Note: LP-0001 and LP-0003 are listed under Resources as related references (ZK membership proof and nullifier scheme patterns), not hard dependencies for this prize.
-
 ## Resources
 
 - [Logos Execution Zone repo](https://github.com/logos-blockchain/logos-execution-zone)

--- a/prizes/LP-0017.md
+++ b/prizes/LP-0017.md
@@ -1,3 +1,7 @@
+---
+dependencies: []
+---
+
 # LP-0017: Whistleblower — censorship-resistant document upload and indexing Basecamp app [OPEN]
 
 **`Status: Open`**

--- a/prizes/LP-0017.md
+++ b/prizes/LP-0017.md
@@ -120,6 +120,15 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
+## Dependencies
+
+Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
+before this Lambda Prize can be announced or claimed.
+
+- (none)
+
+Note: LP-0008 and LP-0012 are listed under Resources as related references (module architecture and on-chain event emission patterns), not hard dependencies for this prize.
+
 ## Resources
 
 - [logos-co/ecosystem#88](https://github.com/logos-co/ecosystem/issues/88) — Whistleblower sample app scope issue

--- a/prizes/LP-0017.md
+++ b/prizes/LP-0017.md
@@ -120,15 +120,6 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 - **Submissions:** each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 - **Feedback:** initial evaluation feedback is limited to a pass/fail indication against the success criteria.
 
-## Dependencies
-
-Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
-before this Lambda Prize can be announced or claimed.
-
-- (none)
-
-Note: LP-0008 and LP-0012 are listed under Resources as related references (module architecture and on-chain event emission patterns), not hard dependencies for this prize.
-
 ## Resources
 
 - [logos-co/ecosystem#88](https://github.com/logos-co/ecosystem/issues/88) — Whistleblower sample app scope issue


### PR DESCRIPTION
## Summary

- Adds a new `## Dependencies` section to the L-Prize template (`prizes/LP-0000.md`) and to every existing prize in `prizes/` (17 files total).
- The section lists other L-Prizes, RFPs, R&D items, or sample apps that must complete or exist before the Lambda Prize can be announced or claimed, using canonical IDs (`LP-XXXX`, `RFP-XXX`, ...).
- Where dependency info already lived in status banners or prose (LP-0001, LP-0004, LP-0006, LP-0013) it is now also captured in the new section. LPs that only had non-blocking cross-references in `## Resources` (LP-0008, LP-0016, LP-0017) declare `(none)` and call out the related links explicitly.

## Convention

Markdown section, placed before `## Resources` in every prize file. Format:

```markdown
## Dependencies

Other L-Prizes, RFPs, R&D, or sample apps that must complete or exist
before this Lambda Prize can be announced or claimed.

- LP-XXXX — short reason
- RFP-XXX — short reason
- (none, if standalone)
```

Chosen because the repo already uses markdown sections (no YAML frontmatter) — this keeps the convention uniform and avoids touching any existing front-of-file metadata.

## Why

[flywheels.logos.co](https://github.com/logos-co/flywheels.logos.co) (a dashboard) needs to mechanically parse L-Prize dependencies. Today each LP declares them inconsistently — some in the status banner, some in prose, some not at all — which makes machine extraction unreliable. A single, predictably-named section gives downstream tooling one place to look.

## Non-breaking

- No existing content is removed or rewritten — the change is additive.
- LP-0006's existing `## Infrastructure & Dependencies` section (Bitcoin/Monero/Ethereum runtime nodes) is left untouched; the new `## Dependencies` section covers a different axis (LP/RFP/R&D dependencies) and cross-references the infra section.
- The solution-submission CI validator (`.github/scripts/validate-submission.sh`) only checks `solutions/` markdown structure, not `prizes/`, so prize-file changes have no CI impact.

## Files touched

17 prize files: `LP-0000.md` (template) plus `LP-0001` through `LP-0017` (excluding `LP-0007`, which does not exist in the repo).

## Ambiguous cases (flagged in commit + per-file notes)

For these LPs, the only LP cross-references in the source file were under `## Resources` with phrasing like "relevant for" / "reference for" — i.e. related work, not strict blockers. They are declared `(none)` with an inline note pointing readers at the related links:

- LP-0008 (lists LP-0002, LP-0005 in Resources as related)
- LP-0011 (status banner mentions "overlap with LEZ framework" but no concrete blocker)
- LP-0016 (lists LP-0001, LP-0003 in Resources as related)
- LP-0017 (lists LP-0008, LP-0012 in Resources as related)

Happy to upgrade any of these to hard deps if maintainers disagree with the read.

## Test plan

- [ ] Skim each LP to confirm the new section reads correctly and no other content was disturbed.
- [ ] Confirm `(none)` placeholders match the maintainers' intent for ambiguous LPs (esp. LP-0008, LP-0011, LP-0016, LP-0017).
- [ ] Confirm the template's `## Dependencies` instructions match the desired authoring convention.