### PR TITLE
Align templates with proven-useful prize policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/lambda-prize-claim.yml
+++ b/.github/ISSUE_TEMPLATE/lambda-prize-claim.yml
@@ -18,6 +18,23 @@ body:
         > [!IMPORTANT]
         > The prize amount will be paid in **USDT on Ethereum** to the **Ethereum wallet address** you enter below.
 
+  - type: dropdown
+    id: release
+    attributes:
+      label: Which release is this?
+      description: >
+        Prizes are split 50% delivery / 50% adoption. Most claims are the full
+        prize, released once adoption is verified. Choose "Delivery only" if you
+        were told the delivery half is being released early because the consumer was
+        unresponsive, and "Adoption" if you are now claiming the remaining adoption
+        half.
+      options:
+        - Full prize (delivery + adoption)
+        - Delivery only (consumer-unresponsive release)
+        - Adoption (remaining half after an earlier delivery-only release)
+    validations:
+      required: true
+
   - type: input
     id: typeform_response_id
     attributes:

--- a/.github/ISSUE_TEMPLATE/lambda-prize-claim.yml
+++ b/.github/ISSUE_TEMPLATE/lambda-prize-claim.yml
@@ -18,23 +18,6 @@ body:
         > [!IMPORTANT]
         > The prize amount will be paid in **USDT on Ethereum** to the **Ethereum wallet address** you enter below.
 
-  - type: dropdown
-    id: release
-    attributes:
-      label: Which release is this?
-      description: >
-        Prizes are split 50% delivery / 50% adoption. Most claims are the full
-        prize, released once adoption is verified. Choose "Delivery only" if you
-        were told the delivery half is being released early because the consumer was
-        unresponsive, and "Adoption" if you are now claiming the remaining adoption
-        half.
-      options:
-        - Full prize (delivery + adoption)
-        - Delivery only (consumer-unresponsive release)
-        - Adoption (remaining half after an earlier delivery-only release)
-    validations:
-      required: true
-
   - type: input
     id: typeform_response_id
     attributes:

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -37,8 +37,9 @@ dependencies: []
 - **Adoption green-light owner:** <the specific accountable person>
 - **Contact channel:** <a dedicated thread the builder uses to reach the consumer,
   e.g. a forum.logos.co thread or a Discord thread>
-- **Redundancy / fallback:** <a second candidate consumer, or a pre-agreed
-  sample-app fallback, so a single unresponsive consumer cannot block the prize>
+- **Other candidate consumers (optional):** <you may flag more than one; adoption by
+  any one of them meets the win condition, so a single unresponsive consumer cannot
+  block the prize>
 
 > Out of scope as a consumer: a RFP that needs this LP; a LP that depends on a PR
 > being merged into Logos (a PR against `scaffold` / `spel` is fine); another LP
@@ -85,7 +86,7 @@ dependencies: []
 
 - [ ] Functional criterion 1
 - [ ] Functional criterion 2
-- [ ] **Adoption:** <named consumer> has integrated this and runs it on testnet
+- [ ] **Adoption:** a named consumer has integrated this and runs it on testnet (if several are flagged, any one suffices)
 
 ## Scope
 

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -46,6 +46,14 @@ dependencies: []
 > build and the builder shares in the upside of the commercial protocol. (A DeFi
 > deliverable that is not launch-critical may still be an LP.)
 
+> **Stop if a partner is integrating their own product.** When the partner is also
+> the builder (integrating Logos into their own product), an LP is the wrong
+> instrument: its competitive dibs/fork mechanics would let someone swoop in on the
+> partner's integration, and the partner needs clear committed criteria (deliver X,
+> get Y), not a discretionary, adoption-gated prize they could miss. Route it to a
+> **light integration RFP** scoped to that partner. (A partner that *adopts* a
+> third-party builder's work is fine as a consumer below.)
+
 ## Consumer
 
 > **Testnet-stage prizes only.** A testnet prize is not published (Draft → Open)
@@ -53,7 +61,9 @@ dependencies: []
 > and the accountable person who gives the adoption green light. Mainnet-stage prizes
 > skip this section.
 
-- **Type:** Circle / Sample-app integration (Eco Dev Eng) / Partner
+- **Type:** Circle / Sample-app integration (Eco Dev Eng) / Partner-as-consumer
+  (a third party builds, the partner adopts; a partner integrating their *own*
+  product is a light integration RFP, not an LP)
 - **Consumer:** <which Circle / which sample app / which partner>
 - **Adoption green-light owner:** <the specific accountable person>
 - **Contact channel:** <a dedicated thread the builder uses to reach the consumer,

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -38,6 +38,14 @@ dependencies: []
 
 - **Adoption stage:** testnet | mainnet
 
+> **Stop if this is DeFi and launch-critical.** A DeFi deliverable (value depends on
+> real TVL / liquidity / derivative positions) that is also needed for mainnet launch
+> cannot be a Lambda Prize: testnet adoption is hollow (testnet value is unreal) and
+> the mainnet usage criterion cannot apply to something that must exist *before*
+> launch. Route it to a **win-win RFP** instead: a co-venture where Logos funds the
+> build and the builder shares in the upside of the commercial protocol. (A DeFi
+> deliverable that is not launch-critical may still be an LP.)
+
 ## Consumer
 
 > **Testnet-stage prizes only.** A testnet prize is not published (Draft → Open)

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -25,12 +25,25 @@ dependencies: []
 - Up for fork: Original builder disengaged; another builder may take the existing work forward toward adoption (set at Logos discretion)
 - Completed: Submission accepted and adopted, prize completed
 
+## Adoption Stage
+
+> Each prize declares an adoption stage. The stage picks the adoption criterion, and
+> the two are mutually exclusive (XOR):
+>
+> - **Testnet** — adoption is proven by a **named consumer** (see the Consumer
+>   section). No usage metrics exist yet, so a specific consumer is the proof.
+> - **Mainnet** — adoption is proven by **usage thresholds** (TVL / active users /
+>   volume). **No consumer is named**; the market is the consumer. Skip the Consumer
+>   section entirely and state the thresholds under Success Criteria → Adoption.
+
+- **Adoption stage:** testnet | mainnet
+
 ## Consumer
 
-> A prize is not published (Draft → Open) until a named consumer is identified: the
-> party that will adopt the deliverable, and the accountable person who gives the
-> adoption green light. Adoption by this consumer is the win condition (see Success
-> Criteria → Adoption).
+> **Testnet-stage prizes only.** A testnet prize is not published (Draft → Open)
+> until a named consumer is identified: the party that will adopt the deliverable,
+> and the accountable person who gives the adoption green light. Mainnet-stage prizes
+> skip this section.
 
 - **Type:** Circle / Sample-app integration (Eco Dev Eng) / Partner
 - **Consumer:** <which Circle / which sample app / which partner>
@@ -79,14 +92,16 @@ dependencies: []
 > - A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.
 > - A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.
 >
-> **Adoption** — the win condition. State the concrete, verifiable adoption the named
-> consumer (see Consumer section) must demonstrate. Pre-mainnet this is binary: the
-> consumer has integrated the deliverable and runs it on testnet. (Quantitative
-> thresholds such as users / TVL / usage apply to a later mainnet adoption stage.)
+> **Adoption** — the win condition. Its form depends on the Adoption Stage (XOR):
+> - **Testnet:** a named consumer has integrated the deliverable and runs it on
+>   testnet (binary; if several consumers are flagged, any one suffices).
+> - **Mainnet:** the deliverable meets declared usage thresholds (TVL / active users
+>   / volume). No named consumer; state the concrete numbers here.
 
 - [ ] Functional criterion 1
 - [ ] Functional criterion 2
-- [ ] **Adoption:** a named consumer has integrated this and runs it on testnet (if several are flagged, any one suffices)
+- [ ] **Adoption (testnet):** a named consumer has integrated this and runs it on testnet (any one of the flagged consumers suffices)
+- [ ] **Adoption (mainnet):** <usage threshold, e.g. ≥ $X TVL / ≥ N active users / ≥ N tx over a stated window>
 
 ## Scope
 
@@ -102,12 +117,13 @@ dependencies: []
 
 - **Total Prize:** $X
 - **Effort:** XS / S / M / L / XL / Variable
-- **Split:** 50% delivery (Logos-owned acceptance: criteria met, license, security, reproducible demo) / 50% adoption (the named consumer uses it, verified by Logos)
+- **Split:** 50% delivery (Logos-owned acceptance: criteria met, license, security, reproducible demo) / 50% adoption (verified by Logos: a named consumer on testnet, or usage thresholds on mainnet)
 > Leave prize pool blank — this will be determined by the Logos team. Single winner by default. Detail here if otherwise.
 >
-> The default is a single payout released once Logos verifies adoption. The split
-> becomes two separate releases only if the consumer is unresponsive for two weeks:
-> the delivery half is then released so an engaged builder is not blocked by an
+> The default is a single payout released once Logos verifies adoption. On a
+> **testnet** prize the split becomes two separate releases only if the consumer is
+> unresponsive for two weeks: the delivery half is then released so an engaged
+> builder is not blocked by an
 > absent consumer, and the adoption half stays open until adoption happens.
 
 ## Eligibility

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -22,9 +22,28 @@ dependencies: []
 **`Status`**:
 - Draft: Not yet ready
 - Open: Ready for application
-- Completed: Submission accepted, prize completed
+- Up for fork: Original builder disengaged; another builder may take the existing work forward toward adoption (set at Logos discretion)
+- Completed: Submission accepted and adopted, prize completed
 
-**`Logos Circle: <City/Chapter or N/A>`**
+## Consumer
+
+> A prize is not published (Draft → Open) until a named consumer is identified: the
+> party that will adopt the deliverable, and the accountable person who gives the
+> adoption green light. Adoption by this consumer is the win condition (see Success
+> Criteria → Adoption).
+
+- **Type:** Circle / Sample-app integration (Eco Dev Eng) / Partner
+- **Consumer:** <which Circle / which sample app / which partner>
+- **Adoption green-light owner:** <the specific accountable person>
+- **Contact channel:** <a dedicated thread the builder uses to reach the consumer,
+  e.g. a forum.logos.co thread or a Discord thread>
+- **Redundancy / fallback:** <a second candidate consumer, or a pre-agreed
+  sample-app fallback, so a single unresponsive consumer cannot block the prize>
+
+> Out of scope as a consumer: a RFP that needs this LP; a LP that depends on a PR
+> being merged into Logos (a PR against `scaffold` / `spel` is fine); another LP
+> consuming this one. The consumer must already exist and be independently useful,
+> not be built in order to consume this prize.
 
 ## Overview
 
@@ -58,10 +77,15 @@ dependencies: []
 > - A README documents end-to-end usage: deployment steps, program addresses, and step-by-step instructions for interacting with the program via CLI and Basecamp app.
 > - A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.
 > - A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.
+>
+> **Adoption** — the win condition. State the concrete, verifiable adoption the named
+> consumer (see Consumer section) must demonstrate. Pre-mainnet this is binary: the
+> consumer has integrated the deliverable and runs it on testnet. (Quantitative
+> thresholds such as users / TVL / usage apply to a later mainnet adoption stage.)
 
-- [ ] Criterion 1
-- [ ] Criterion 2
-- [ ] Criterion 3
+- [ ] Functional criterion 1
+- [ ] Functional criterion 2
+- [ ] **Adoption:** <named consumer> has integrated this and runs it on testnet
 
 ## Scope
 
@@ -77,7 +101,13 @@ dependencies: []
 
 - **Total Prize:** $X
 - **Effort:** XS / S / M / L / XL / Variable
+- **Split:** 50% delivery (Logos-owned acceptance: criteria met, license, security, reproducible demo) / 50% adoption (the named consumer uses it, verified by Logos)
 > Leave prize pool blank — this will be determined by the Logos team. Single winner by default. Detail here if otherwise.
+>
+> The default is a single payout released once Logos verifies adoption. The split
+> becomes two separate releases only if the consumer is unresponsive for two weeks:
+> the delivery half is then released so an engaged builder is not blocked by an
+> absent consumer, and the adoption half stays open until adoption happens.
 
 ## Eligibility
 
@@ -97,6 +127,12 @@ dependencies: []
 > The demo must make it easy for evaluators to verify that the implementation meets the stated criteria.
 >
 > Submissions must include a FURPS self-assessment as part of the solution (see [solution template](../solutions/LP-0000.md)).
+>
+> **Operational security.** The named consumer will run this code, potentially with
+> real keys and value. Beyond functional correctness, the submission must include
+> what an adopter needs to run it safely: key handling, any required sandboxing,
+> dependency/supply-chain notes, and deployment guidance. The Logos security review
+> covers this as part of acceptance.
 
 ## Evaluation Process
 

--- a/solutions/LP-0000.md
+++ b/solutions/LP-0000.md
@@ -36,16 +36,25 @@
 
 ## Adoption Evidence
 
-> **Leave this empty when you first submit.** Adoption by the prize's named consumer
-> is the win condition, and it usually happens after delivery. Once the consumer has
-> adopted your work, **edit this submission** to fill the fields below. Logos verifies
-> the evidence before releasing the prize.
+> **Leave this empty when you first submit.** Adoption is the win condition and
+> usually happens after delivery. Once it does, **edit this submission** to fill the
+> fields for your prize's adoption stage. Logos verifies before releasing the prize.
+>
+> Fill the **testnet** block (named consumer) or the **mainnet** block (usage
+> thresholds), per the prize's adoption stage, not both.
+
+**Testnet (named-consumer) prize:**
 
 - **Named consumer:** <the Circle / sample app / partner named in the prize>
 - **Contact channel:** <the forum.logos.co or Discord thread used with the consumer>
 - **Adopted on testnet?** <fill once true: integrated and running on testnet>
 - **Evidence:** <link to the consumer's integration: repo/PR, deployment, or the
   green-light from the accountable owner>
+
+**Mainnet (usage-threshold) prize:**
+
+- **Threshold met:** <the metric the prize required, e.g. TVL / active users / volume>
+- **Evidence:** <link to on-chain data / dashboard showing the threshold is met>
 
 ## FURPS Self-Assessment
 

--- a/solutions/LP-0000.md
+++ b/solutions/LP-0000.md
@@ -26,6 +26,18 @@
 - [ ] Criterion 2: _explanation_
 - [ ] Criterion 3: _explanation_
 
+## Adoption Evidence
+
+> Adoption by the prize's named consumer is the win condition. State who the consumer
+> is and the current status of their integration, and link the evidence. Logos
+> verifies this before releasing the adoption half of the prize.
+
+- **Named consumer:** <the Circle / sample app / partner named in the prize>
+- **Contact channel:** <the forum.logos.co or Discord thread used with the consumer>
+- **Integration status:** <integrated and running on testnet / in progress / not yet>
+- **Evidence:** <link to the consumer's integration: repo/PR, deployment, or the
+  green-light from the accountable owner>
+
 ## FURPS Self-Assessment
 
 > Evaluate your delivery against each of the following dimensions.

--- a/solutions/LP-0000.md
+++ b/solutions/LP-0000.md
@@ -5,10 +5,12 @@
 > **This submission has two phases on the one issue.**
 > 1. **Delivery (now).** Opening this submission timestamps your code as delivered
 >    and gives you first claim ("dibs") on taking it to adoption. Fill everything
->    except the Adoption Evidence section.
-> 2. **Adoption (later).** Once the prize's named consumer has adopted your work,
->    **edit this submission** to fill in the Adoption Evidence section below.
->    Adoption is the win condition; Logos verifies it before releasing the prize.
+>    except the Customer Notified and Adoption Evidence sections.
+> 2. **Adoption (later).** Logos runs the security check first. **Only once Logos has
+>    confirmed the security check do you contact the customer** (record it under
+>    Customer Notified). Once the customer has adopted your work, **edit this
+>    submission** to fill in the Adoption Evidence section. Adoption is the win
+>    condition; Logos verifies it before releasing the prize.
 
 ## Summary
 
@@ -33,6 +35,17 @@
 - [ ] Criterion 1: _explanation_
 - [ ] Criterion 2: _explanation_
 - [ ] Criterion 3: _explanation_
+
+## Customer Notified
+
+> **Leave this empty when you first submit.** Do **not** contact the customer until
+> the Logos team has confirmed the security check (see the prize's evaluation order):
+> we do not put unvetted code in front of a customer. Once Logos confirms, reach out
+> and record the link here.
+
+- **Security check confirmed by Logos?** <fill once Logos has confirmed>
+- **Customer notified:** <link to the message sent to the customer (forum.logos.co
+  thread / Discord), only after the security check above>
 
 ## Adoption Evidence
 

--- a/solutions/LP-0000.md
+++ b/solutions/LP-0000.md
@@ -43,9 +43,10 @@
 > we do not put unvetted code in front of a customer. Once Logos confirms, reach out
 > and record the link here.
 
-- **Security check confirmed by Logos?** <fill once Logos has confirmed>
+- **Security check green-light:** <link to the comment on this issue where the Logos
+  team gives the security green light>
 - **Customer notified:** <link to the message sent to the customer (forum.logos.co
-  thread / Discord), only after the security check above>
+  thread / Discord), only after the security green light above>
 
 ## Adoption Evidence
 

--- a/solutions/LP-0000.md
+++ b/solutions/LP-0000.md
@@ -2,6 +2,14 @@
 
 **Submitted by:** <Your name or team name>
 
+> **This submission has two phases on the one issue.**
+> 1. **Delivery (now).** Opening this submission timestamps your code as delivered
+>    and gives you first claim ("dibs") on taking it to adoption. Fill everything
+>    except the Adoption Evidence section.
+> 2. **Adoption (later).** Once the prize's named consumer has adopted your work,
+>    **edit this submission** to fill in the Adoption Evidence section below.
+>    Adoption is the win condition; Logos verifies it before releasing the prize.
+
 ## Summary
 
 > Brief description of the solution and how it addresses the prize's success criteria.
@@ -28,13 +36,14 @@
 
 ## Adoption Evidence
 
-> Adoption by the prize's named consumer is the win condition. State who the consumer
-> is and the current status of their integration, and link the evidence. Logos
-> verifies this before releasing the adoption half of the prize.
+> **Leave this empty when you first submit.** Adoption by the prize's named consumer
+> is the win condition, and it usually happens after delivery. Once the consumer has
+> adopted your work, **edit this submission** to fill the fields below. Logos verifies
+> the evidence before releasing the prize.
 
 - **Named consumer:** <the Circle / sample app / partner named in the prize>
 - **Contact channel:** <the forum.logos.co or Discord thread used with the consumer>
-- **Integration status:** <integrated and running on testnet / in progress / not yet>
+- **Adopted on testnet?** <fill once true: integrated and running on testnet>
 - **Evidence:** <link to the consumer's integration: repo/PR, deployment, or the
   green-light from the accountable owner>
 


### PR DESCRIPTION
Updates the prize, submission, and payment-claim templates to encode the **proven-useful** policy: a prize is not published until a named consumer exists, and adoption by that consumer is the win condition.

## Changes

**`prizes/LP-0000.md` (prize template)**
- New **Consumer** section, required before Draft → Open: consumer type (Circle / Sample-app / Partner, no default), the accountable adoption green-light owner, a **contact channel** (forum.logos.co or Discord thread) to reach the consumer, and a redundancy/fallback so one unresponsive consumer can't block the prize. Includes the out-of-scope consumer shapes (RFP-needs-LP, LP-on-unmerged-Logos-PR, LP-consumes-LP).
- **Adoption** added to Success Criteria as the win condition (binary pre-mainnet: consumer integrated + running on testnet).
- **Prize Structure**: 50/50 delivery/adoption split, with the consumer-unresponsive fallback (release the delivery half if the consumer goes dark for two weeks).
- **Operational security** requirement in Submission Requirements (a third party will run this code with real keys/value).
- New **Up for fork** status.
- Dropped the `Logos Circle: N/A` line — no default consumer type.

**`solutions/LP-0000.md` (submission template)**
- New **Adoption Evidence** section: named consumer, contact channel, integration status, evidence link.

**`.github/ISSUE_TEMPLATE/lambda-prize-claim.yml` (payment claim)**
- New **which release** dropdown: full / delivery-only (consumer-unresponsive) / adoption.

## Notes
- Source of the policy: the proven-useful redline of the internal "λPrize: Detailed Process and Internal Guidelines" doc (still under review by Martin / Franck / Eric / Mario). **This PR should land alongside that policy being accepted**, not before.
- **Out of scope here:** the README "Proposing a New Prize" flow still says "fill in all sections except Prize Structure" and documents the status list; it should be updated to mention the required Consumer section and the new statuses once the policy is approved. Left out to keep this PR template-only.
- Open policy questions still unresolved (and not encoded here): the delivery/adoption split ratio is set to 50/50 per current policy; fork-tranche split; operational-security sign-off owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)