### PR TITLE
Solution: LP-0013 – Token Program Improvements: Authorities

### DIFF
--- a/solutions/LP-0013.md
+++ b/solutions/LP-0013.md
@@ -16,6 +16,10 @@ Added a mint authority model to the LEZ token program. Changes made directly in 
 
 The design follows Solana’s SPL Token: a single `Option<AccountId>` encodes both who the authority is and whether minting is possible. `None` is self-describing — no authority, no minting, ever.
 
+## Approach
+
+Changes made directly in the canonical `lez-programs` fork. Added `mint_authority: Option<AccountId>` to `TokenDefinition::Fungible`, two new instructions (`NewFungibleDefinitionWithAuthority`, `SetAuthority`), and updated `Mint` to enforce the authority check. The `token_core` crate serves as the agnostic SDK. IDL regenerated via `idl-gen` and committed to `artifacts/token-idl.json`. Wallet CLI extended with `wallet token new-with-authority` and `wallet token set-authority` commands in the supporting `logos-execution-zone` fork.
+
 ## Repository
 
 - **Primary (lez-programs fork):** https://github.com/youthisguy/lez-programs

--- a/solutions/LP-0013.md
+++ b/solutions/LP-0013.md
@@ -1,6 +1,6 @@
 # LP-0013: Token Program Improvements — Mint Authority
 
-## Submitted by: youthisguy
+**Submitted by:** youthisguy
 
 ## Summary
 
@@ -53,11 +53,18 @@ https://youtu.be/mbNpOoOs7T4
 
 ### Performance
 
-- [x] CU costs documented in `docs/authority-model.md`:
-  - `NewFungibleDefinitionWithAuthority`: ~80–130ms execution time (RISC0_DEV_MODE=1)
-  - `Mint` (with authority check): ~50–80ms
-  - `SetAuthority` (rotate or revoke): ~40–60ms
-  - Note: real proof generation (`RISC0_DEV_MODE=0`) takes 5–30 minutes per transaction on a standard laptop; LEZ per-transaction CU budget not yet finalized for testnet
+- [x] CU costs measured on LEZ devnet, run with `RISC0_DEV_MODE=0` (ZK proofs generated):
+
+| Operation | Tx Hash | Block | Execution Time |
+|---|---|---|---|
+| `NewFungibleDefinitionWithAuthority` | `14197f9113ff000e81b7545c671942b286ef19bae7122ba280a0a620b8e01ca1` | 410 | 15.92ms |
+| `Mint` (authority active) | `99f00dbe40600d0c8bb745b74980c2241f1e7a6daa1291f5cef6b9ea27c82bd9` | 411 | 19.29ms |
+| `SetAuthority` (rotate) | `d865e26dfb5f82a5528aa9a0882307a73b00ffc4fa7825f0e7b5d0888d5c87fc` | 414 | 13.40ms |
+| `SetAuthority` (revoke to None) | `9408ef7ffd3efdbafbe2dd5bf243da32edd1a4d52f9709b5cfc92cb696b8956e` | 415 | 15.74ms |
+| `Mint` (rejected — authority revoked) | `5228cc62094a91e479b86a3aee067809f18674465ac72d8623d1ed770ab496de` | 416 | 9.84ms |
+
+  Rejected operations cost ~38% less than successful ones — execution halts at the authority guard before any account writes, confirming rejection is via the correct code path. Reproducible: clone repo, run `scripts/demo.sh` with `RISC0_DEV_MODE=0`, observe `execution time:` lines in sequencer logs.
+
 
 ### Supportability
 

--- a/solutions/LP-0013.md
+++ b/solutions/LP-0013.md
@@ -1,8 +1,20 @@
 # LP-0013: Token Program Improvements — Mint Authority
 
-## Builder
+## Submitted by
 
-GitHub: [@youthisguy](https://github.com/youthisguy)
+[@youthisguy](https://github.com/youthisguy)
+
+## Summary
+
+Added a mint authority model to the LEZ token program. Changes made directly in the canonical `lez-programs` fork.
+
+- `mint_authority: Option<AccountId>` field on `TokenDefinition::Fungible`
+- `NewFungibleDefinitionWithAuthority` instruction — create token with mint authority at initialization
+- `SetAuthority` instruction — rotate or permanently revoke mint authority
+- Updated `Mint` instruction — enforces authority check before minting
+- Fully backwards compatible — existing `NewFungibleDefinition` unchanged
+
+The design follows Solana’s SPL Token: a single `Option<AccountId>` encodes both who the authority is and whether minting is possible. `None` is self-describing — no authority, no minting, ever.
 
 ## Repository
 
@@ -13,49 +25,69 @@ GitHub: [@youthisguy](https://github.com/youthisguy)
 
 https://youtu.be/mbNpOoOs7T4
 
-## Approach
+## Success Criteria Checklist
 
-Changes made directly in the canonical `lez-programs` fork. Added a mint authority model to the LEZ token program:
+### Functionality
 
-- `mint_authority: Option<AccountId>` field on `TokenDefinition::Fungible`
-- `NewFungibleDefinitionWithAuthority` instruction — create token with mint authority at initialization
-- `SetAuthority` instruction — rotate or permanently revoke mint authority
-- Updated `Mint` instruction — enforces authority check before minting
-- Fully backwards compatible — existing `NewFungibleDefinition` unchanged
+- [x] Mint authority set at token initialization (`NewFungibleDefinitionWithAuthority` instruction)
+- [x] Minting by the authority (updated `Mint` instruction enforces `mint_authority.is_some()`)
+- [x] Authority rotation (`SetAuthority` with `Some(new_id)`)
+- [x] Authority revocation (`SetAuthority` with `None` — permanently fixes supply)
+- [x] Two example integrations: `examples/program_deployment/src/bin/run_new_token_with_authority.rs` (variable supply) and fixed supply via `mint_authority: None` at creation
+- [x] Self-sufficient agnostic library: `token_core` crate exposes all new instruction variants; any downstream program imports `token_core::Instruction` and gets the full authority API
 
-The design follows Solana's SPL Token: a single `Option<AccountId>` encodes both who the authority is and whether minting is possible. `None` is self-describing — no authority, no minting, ever.
+### Usability
 
-## Deliverables
+- [x] Module/SDK: `token_core` crate — downstream consumers import `token_core::Instruction` to get `NewFungibleDefinitionWithAuthority` and `SetAuthority` variants
+- [x] IDL for the updated token program via SPEL framework: regenerated `artifacts/token-idl.json` using `cargo run -p idl-gen`
+- [x] Wallet CLI: two new commands added to `logos-execution-zone` — `wallet token new-with-authority` and `wallet token set-authority`
 
-| File | Description |
-|---|---|
-| `programs/token/core/src/lib.rs` | Data model + new instruction variants |
-| `programs/token/src/set_authority.rs` | Authority rotation/revocation logic |
-| `programs/token/src/mint.rs` | Authority enforcement on mint |
-| `programs/token/src/tests.rs` | 8 new unit tests |
-| `programs/integration_tests/tests/token.rs` | 3 new integration tests |
-| `artifacts/token-idl.json` | Regenerated IDL via idl-gen |
-| `docs/authority-model.md` | Design spec, lifecycle, error codes, threat model |
-| `programs/token/README.md` | Usage guide and deploy steps |
-| `scripts/demo.sh` | Reproducible end-to-end demo script |
-| `examples/program_deployment/src/bin/` | Fixed supply + variable supply examples |
+### Reliability
 
-## CI
+- [x] Authority rotation and revocation are atomic — RISC Zero zkVM either commits the full output state or panics; no partial write is possible
+- [x] Minting with a revoked authority is rejected deterministically with panic message `"Mint authority has been revoked; supply is fixed"`
+- [x] `SetAuthority` on already-revoked authority panics with `"Mint authority is already revoked; cannot rotate a revoked authority"`
+- [x] `SetAuthority` on NonFungible token panics with `"Cannot set mint authority on a Non-Fungible Token definition"`
 
-Green on main branch: https://github.com/youthisguy/lez-programs/actions
+### Performance
 
-## On-chain Evidence
+- [x] CU costs documented in `docs/authority-model.md`:
+  - `NewFungibleDefinitionWithAuthority`: ~80–130ms execution time (RISC0_DEV_MODE=1)
+  - `Mint` (with authority check): ~50–80ms
+  - `SetAuthority` (rotate or revoke): ~40–60ms
+  - Note: real proof generation (`RISC0_DEV_MODE=0`) takes 5–30 minutes per transaction on a standard laptop; LEZ per-transaction CU budget not yet finalized for testnet
 
-Full lifecycle demonstrated on local LEZ sequencer with `RISC0_DEV_MODE=0`:
+### Supportability
 
-1. Token created with `mint_authority` set
-2. 500,000 tokens minted (total_supply: 1M → 1.5M)
-3. Authority rotated to new account
-4. Authority permanently revoked (`mint_authority: null`)
-5. Mint rejected after revocation — confirmed by guest panic `"Mint authority has been revoked; supply is fixed"`
+- [x] Updated token program deployed and tested on local LEZ sequencer (standalone mode)
+- [x] End-to-end integration tests run against `V03State` (LEZ sequencer standalone mode) and included in CI
+- [x] CI green on main branch: https://github.com/youthisguy/lez-programs/actions
+- [x] README documents end-to-end usage: `programs/token/README.md` — deploy steps, program addresses, CLI instructions for minting, rotating, and revoking
+- [x] Reproducible demo script: `scripts/demo.sh` — works from clean clone with `RISC0_DEV_MODE=0` against local sequencer; requires only `WALLET_BIN` and `LEZ_WALLET_HOME_DIR` env vars
+- [x] Recorded video demo with narration: https://youtu.be/mbNpOoOs7T4 — shows terminal output with `RISC0_DEV_MODE=0` active during proof generation
 
-Transaction hashes and sequencer logs shown in video.
+## FURPS Self-Assessment
 
-## License
+### Functionality
 
-MIT OR Apache-2.0
+The implementation covers the full mint authority lifecycle: creation with authority, minting by authority, rotation to a new authority, and permanent revocation. All three authority state transitions are exercised on-chain in the demo with `RISC0_DEV_MODE=0`. The `token_core` crate acts as the self-sufficient agnostic library — it exposes `NewFungibleDefinitionWithAuthority` and `SetAuthority` instruction variants that any LEZ program can import without modification.
+
+### Usability
+
+The SDK is `token_core` — the same pattern used by `amm_core`, `stablecoin_core`, and `ata_core` throughout the repo. The IDL is regenerated via `idl-gen` and committed to `artifacts/token-idl.json`. The wallet CLI in `logos-execution-zone` exposes `wallet token new-with-authority` and `wallet token set-authority` commands for interactive use.
+
+### Reliability
+
+All state transitions are atomic by construction — the RISC Zero zkVM either commits the full output or panics, with no possibility of partial writes. Every error condition produces a deterministic, documented panic message. The `SetAuthority` function checks revocation before authorization to produce the clearest possible error message when authority is already gone.
+
+### Performance
+
+Execution times measured on local LEZ sequencer with `RISC0_DEV_MODE=1` (no proof generation). Real `RISC0_DEV_MODE=0` proof times are shown in the video. Full CU cost documentation is in `docs/authority-model.md`.
+
+### Supportability
+
+Changes are made directly in the canonical `lez-programs` fork — evaluators can diff against upstream to see exactly what changed. CI runs unit tests and integration tests on every push. The `scripts/demo.sh` demo script is fully reproducible from a clean clone. The `docs/authority-model.md` file covers the design spec, authority lifecycle diagram, atomicity proof, error codes, authorization model, backwards compatibility notes, and threat model.
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](https://github.com/logos-co/lambda-prize/blob/master/TERMS.md).

--- a/solutions/LP-0013.md
+++ b/solutions/LP-0013.md
@@ -1,0 +1,61 @@
+# LP-0013: Token Program Improvements — Mint Authority
+
+## Builder
+
+GitHub: [@youthisguy](https://github.com/youthisguy)
+
+## Repository
+
+- **Primary (lez-programs fork):** https://github.com/youthisguy/lez-programs
+- **Supporting (logos-execution-zone fork):** https://github.com/youthisguy/logos-execution-zone
+
+## Video
+
+https://youtu.be/mbNpOoOs7T4
+
+## Approach
+
+Changes made directly in the canonical `lez-programs` fork. Added a mint authority model to the LEZ token program:
+
+- `mint_authority: Option<AccountId>` field on `TokenDefinition::Fungible`
+- `NewFungibleDefinitionWithAuthority` instruction — create token with mint authority at initialization
+- `SetAuthority` instruction — rotate or permanently revoke mint authority
+- Updated `Mint` instruction — enforces authority check before minting
+- Fully backwards compatible — existing `NewFungibleDefinition` unchanged
+
+The design follows Solana's SPL Token: a single `Option<AccountId>` encodes both who the authority is and whether minting is possible. `None` is self-describing — no authority, no minting, ever.
+
+## Deliverables
+
+| File | Description |
+|---|---|
+| `programs/token/core/src/lib.rs` | Data model + new instruction variants |
+| `programs/token/src/set_authority.rs` | Authority rotation/revocation logic |
+| `programs/token/src/mint.rs` | Authority enforcement on mint |
+| `programs/token/src/tests.rs` | 8 new unit tests |
+| `programs/integration_tests/tests/token.rs` | 3 new integration tests |
+| `artifacts/token-idl.json` | Regenerated IDL via idl-gen |
+| `docs/authority-model.md` | Design spec, lifecycle, error codes, threat model |
+| `programs/token/README.md` | Usage guide and deploy steps |
+| `scripts/demo.sh` | Reproducible end-to-end demo script |
+| `examples/program_deployment/src/bin/` | Fixed supply + variable supply examples |
+
+## CI
+
+Green on main branch: https://github.com/youthisguy/lez-programs/actions
+
+## On-chain Evidence
+
+Full lifecycle demonstrated on local LEZ sequencer with `RISC0_DEV_MODE=0`:
+
+1. Token created with `mint_authority` set
+2. 500,000 tokens minted (total_supply: 1M → 1.5M)
+3. Authority rotated to new account
+4. Authority permanently revoked (`mint_authority: null`)
+5. Mint rejected after revocation — confirmed by guest panic `"Mint authority has been revoked; supply is fixed"`
+
+Transaction hashes and sequencer logs shown in video.
+
+## License
+
+MIT OR Apache-2.0

--- a/solutions/LP-0013.md
+++ b/solutions/LP-0013.md
@@ -1,8 +1,6 @@
 # LP-0013: Token Program Improvements — Mint Authority
 
-## Submitted by
-
-[@youthisguy](https://github.com/youthisguy)
+## Submitted by: youthisguy
 
 ## Summary
 


### PR DESCRIPTION
## Solution: LP-0013 — Token Program Improvements: Mint Authority

**PR:** https://github.com/logos-blockchain/lez-programs/pull/152

---

### Summary

Added a mint authority model to the LEZ token program. Changes made directly in the canonical `lez-programs` repository.

- `mint_authority: Option<AccountId>` field on `TokenDefinition::Fungible`
- `NewFungibleDefinitionWithAuthority` instruction
- `SetAuthority` instruction (rotate, or revoke by passing `None`)
- Updated `Mint` instruction with an early authority guard
- Fully backwards compatible

The design follows Solana's SPL Token authority model.

---

### Mint Authority Library Extracted (RFP-001)

Authorization logic is  extracted into a standalone, reusable crate — **`crates/lez-authority`** — satisfying [RFP-001](https://github.com/logos-co/rfp/blob/master/RFPs/RFP-001-admin-authority-lib.md).

- New `Authority` type with `.rotate()`, `.revoke()`, `.require()`
- Typed `AuthorityError` enum (`Unauthorized` / `Renounced`)
- Token program is the reference consumer; any LEZ program can depend on it directly
- 16 dedicated unit tests; zero runtime/serialization overhead

Satisfies the "self-sufficient, agnostic library" success criterion.

---

### Evidence

- [x] Reproducible demo script (`scripts/demo.sh`) with `RISC0_DEV_MODE=0`
- [x] Narrated video demo: https://youtu.be/mbNpOoOs7T4

---

### Repositories

| Repo | Purpose |
|---|---|
| [logos-blockchain/lez-programs#152](https://github.com/logos-blockchain/lez-programs/pull/152) | Token program changes, `lez-authority` library (this PR) |
| [youthisguy/logos-execution-zone](https://github.com/youthisguy/logos-execution-zone) | Wallet CLI support |