### PR TITLE
Solution: LP-0002 — Private M-of-N Multisig

### DIFF
--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -61,7 +61,7 @@ The threshold proof is a Risc0 zkVM circuit. The on-chain verifier is a SPEL `#[
 - [x] End-to-end integration tests against a LEZ sequencer (standalone) — Layer B harness (`--features lez-integration`); Layer A runs in CI.
 - [x] CI green on default branch — `main` is CI-green (fmt, clippy `-D warnings`, golden-IDL diff, Layer-A e2e under `RISC0_DEV_MODE=1`; nightly re-runs under `RISC0_DEV_MODE=0`).
 - [x] README documenting end-to-end usage — deployment/build/test steps and CLI usage in README.
-- [x] Reproducible end-to-end demo script working with `RISC0_DEV_MODE=0` — `quickstart` bin; real-proof mode via `RISC0_USE_DOCKER=1 RISC0_DEV_MODE=0`.
+- [x] Reproducible end-to-end demo script working with `RISC0_DEV_MODE=0` — [`demo.sh`](https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/demo.sh) wraps the `quickstart` bin; real-proof mode via `RISC0_USE_DOCKER=1 RISC0_DEV_MODE=0`.
 - [~] Recorded video demo showing terminal output confirming `RISC0_DEV_MODE=0`.
 
 ## FURPS Self-Assessment
@@ -92,6 +92,8 @@ CI runs `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warni
 - Threat model: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/THREAT_MODEL.md
 - Benchmarks: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/BENCHMARKS.md
 - IDL: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/private_multisig.idl.json
+- Reproducible demo script: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/demo.sh
+- License: dual [MIT](https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/LICENSE-MIT) OR [Apache-2.0](https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/LICENSE-APACHE) (both files present at the repo root; every crate declares `license = "MIT OR Apache-2.0"`).
 
 ## Terms & Conditions
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -1,0 +1,98 @@
+# Solution: LP-0002 — Private M-of-N Multisig
+
+**Submitted by:** nizarsyahmi37
+
+## Summary
+
+A private M-of-N multisig primitive for the Logos Execution Zone (LEZ). Members hold shielded accounts; proposals and approvals leave no public trace of who voted; and on-chain state reveals only that a threshold of M approvals was reached — not which members approved.
+
+The threshold proof is a Risc0 zkVM circuit. The on-chain verifier is a SPEL `#[lez_program]` that runs `env::verify(APPROVE_CIRCUIT_IMAGE_ID, public_inputs)` on each `approve` instruction and initialises a `NullifierEntry` PDA to prevent double-voting. Approvals are unlinkable to any individual member's shielded account, and proof generation runs client-side on a standard laptop (real-proof baseline: ~161 s prove, ~46 ms verify on an Apple M1).
+
+## Repository
+
+- **Repo:** https://github.com/nizarsyahmi37/private-m-of-n-multisig
+
+## Approach
+
+**Threshold membership via nullifiers, not signatures.** Rather than a threshold signature scheme (e.g. FROST), each member holds an identity commitment in a depth-20 Merkle tree. To approve, a member proves in-circuit that (a) they know the secret behind a leaf in the tree, and (b) they derived a nullifier `H(secret, proposal_id)` correctly. The circuit's public inputs (`ApprovePublicInputs`, 96 bytes) expose the Merkle root, the proposal id, and the nullifier — but nothing that links back to which leaf was used. Threshold is reached when M distinct nullifiers have been accepted on-chain. This was chosen over FROST because it sidesteps interactive DKG/signing rounds and maps cleanly onto the Semaphore-style anonymity set, which is the well-trodden path for anonymous signalling with double-vote prevention.
+
+**Double-vote prevention.** Each accepted nullifier initialises a `NullifierEntry` PDA keyed by `(proposal_id, nullifier)`. A second approval reusing the same `(secret, proposal_id)` derives the same nullifier, so the PDA init fails deterministically. Because the nullifier is a one-way function of a per-proposal secret, it reveals nothing across proposals — the same member approving two different proposals produces two unlinkable nullifiers.
+
+**LEZ account-model compatibility.** The lez-multisig PoC is incompatible with shielded accounts because it requires fresh zero-nonce keypairs that the multisig program claims, whereas private accounts are owned by the privacy protocol and increment nonce on every use. This design avoids the constraint entirely: membership lives in the Merkle tree of identity commitments, not in on-chain member accounts, so there is no `program_owner`/nonce coupling to the members' shielded accounts. The `THREAT_MODEL.md` documents each threat with its mitigation site and verification hook.
+
+**Reproducible proving.** The two guests (`approve_circuit`, `private_multisig`) are compiled through Risc0 with reproducible Docker builds gated on `RISC0_USE_DOCKER=1`, and image-id drift sentinels fail the build if the canonical pin changes. This matters for a verifier: the on-chain `APPROVE_CIRCUIT_IMAGE_ID` must match the client's proving image bit-for-bit, so the demo/CI pins `risczero/risc0-guest-builder:r0.1.91.1`.
+
+**Why the Logos stack.** A multisig that exposes its member list and approval history on-chain is a surveillance surface — it reveals voting patterns and links member identities to governance decisions. LEZ's separation of public and private state, with shielded accounts as first-class primitives, is what makes anonymous-but-verifiable threshold approval possible: the verifier confirms a threshold was met using trustless on-chain execution, while member identity stays in the shielded domain. On a centralised alternative the anonymity set and the threshold check would both reduce to trusting the operator, which defeats the purpose.
+
+## Success Criteria Checklist
+
+> Honest status against the LP-0002 criteria. Core cryptographic and program work is complete and CI-green; the on-chain deployment, external-instance, and demo-video criteria are not yet met and are tracked as the prize-submission follow-on in [`PLAN.md`](https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/PLAN.md).
+
+### Functionality
+
+- [x] Any M-of-N member with a shielded account can approve without revealing identity — nullifier-based membership proof; public inputs expose no leaf linkage.
+- [x] The on-chain verifier confirms M approvals without recording which members approved — `env::verify(APPROVE_CIRCUIT_IMAGE_ID, …)` + threshold count over distinct nullifiers.
+- [x] A member cannot approve the same proposal twice — `NullifierEntry` PDA keyed by `(proposal_id, nullifier)`; re-init fails.
+- [x] A completed execution is unlinkable to any individual member — nullifiers are one-way and per-proposal.
+- [x] Proof generation runs client-side on a standard laptop — ~161 s real-proof on Apple M1 (see [`BENCHMARKS.md`](https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/BENCHMARKS.md)).
+- [ ] Reference integration demoing a threshold-gated action on **LEZ testnet** — Layer-A in-process demo complete; testnet integration deferred (follow-on).
+- [ ] At least 1 multisig instance created on **LEZ testnet** with a proposal submitted, approved by threshold, and executed — **not yet done** (hard blocker, follow-on).
+- [x] Full documentation and a clean public repository — README, PLAN, THREAT_MODEL delivered.
+
+### Usability
+
+- [x] Module/SDK for building Logos modules — `sdk/` (identity lifecycle, `MultisigBuilder`, `ApprovalProver`, resumable `ApprovalSession`).
+- [~] Logos Basecamp app GUI — (out of scope for the foundation plan).
+- [x] IDL for the LEZ program via SPEL — `private_multisig.idl.json`, emitted by `idl-gen/` from SPEL annotations.
+
+### Reliability
+
+- [x] Proof-generation failures surface a clear error — error catalog `E1xxx`–`E4xxx`.
+- [x] Partial approvals (< M) preserved and resumable across restarts — sled-backed `ApprovalSession`; demotes `Submitted → Proved` on reorg deeper than `DEFAULT_FINALITY_BLOCKS = 32`.
+- [x] Deterministic, documented verifier error codes for invalid-proof / double-vote — documented in `private_multisig_core`.
+
+### Performance
+
+- [~] CU cost per on-chain operation — real-proof prove/verify timings captured in `BENCHMARKS.md`; per-op CU on LEZ devnet/testnet pending deployment (follow-on).
+
+### Supportability
+
+- [~] Deployed and tested on LEZ devnet/testnet.
+- [x] End-to-end integration tests against a LEZ sequencer (standalone) — Layer B harness (`--features lez-integration`); Layer A runs in CI.
+- [x] CI green on default branch — `main` is CI-green (fmt, clippy `-D warnings`, golden-IDL diff, Layer-A e2e under `RISC0_DEV_MODE=1`; nightly re-runs under `RISC0_DEV_MODE=0`).
+- [x] README documenting end-to-end usage — deployment/build/test steps and CLI usage in README.
+- [x] Reproducible end-to-end demo script working with `RISC0_DEV_MODE=0` — `quickstart` bin; real-proof mode via `RISC0_USE_DOCKER=1 RISC0_DEV_MODE=0`.
+- [~] Recorded video demo showing terminal output confirming `RISC0_DEV_MODE=0`.
+
+## FURPS Self-Assessment
+
+### Functionality
+
+Anonymous threshold approval over shielded LEZ accounts using Risc0 nullifier proofs, with on-chain threshold verification and double-vote prevention via `NullifierEntry` PDAs. Six instruction handlers; five work end-to-end through the generic IDL-driven CLI, and `approve` runs in-process through the SDK pending the testnet integration item. Out of scope for v1: member-set rotation, proposal rejection, and image-id migration (v1 pins the circuit image-id immutably).
+
+### Usability
+
+`sdk/` provides the full identity/member lifecycle with `Secret<T>` + `Zeroize`, a `MultisigBuilder`, an `ApprovalProver`, and a resumable `ApprovalSession`. The `pmsig` CLI is IDL-driven. A single `quickstart` command runs a 2-of-3 multisig end-to-end in ~30 s on a warm cache with no on-chain dependencies.
+
+### Reliability
+
+Resumable sessions survive crashes (sled-backed) and reorgs (finality demotion at 32 blocks). Structured error catalog `E1xxx`–`E4xxx`. Image-id drift sentinels guarantee the on-chain verifier and client prover agree bit-for-bit.
+
+### Performance
+
+Real-proof baseline (Apple M1, `RISC0_DEV_MODE=0`): 161.1 s to prove one approval, 45.8 ms median to verify. 262,144 guest cycles, 256,102-byte receipt, 96-byte journal. See `BENCHMARKS.md`; nightly CI re-measures on hosted runners and uploads `proof_timing.json`.
+
+### Supportability
+
+CI runs `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, a golden-IDL diff, and the Layer-A e2e. Code is split into focused crates (`crypto`, `private_multisig_core`, `methods`, `private_multisig_program`, `sdk`, `cli`, `idl-gen`, `e2e_tests`). `THREAT_MODEL.md` maps each threat to a mitigation site and verification hook.
+
+## Supporting Materials
+
+- Implementation plan: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/PLAN.md
+- Threat model: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/THREAT_MODEL.md
+- Benchmarks: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/BENCHMARKS.md
+- IDL: https://github.com/nizarsyahmi37/private-m-of-n-multisig/blob/main/private_multisig.idl.json
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](../TERMS.md).


### PR DESCRIPTION
Adds `solutions/LP-0002.md` for prize **LP-0002 — Private M-of-N Multisig**.

**Implementation repo:** https://github.com/nizarsyahmi37/private-m-of-n-multisig

## What's delivered
A private M-of-N multisig primitive for LEZ: members hold shielded accounts; approvals leave no public trace of who voted; on-chain state reveals only that a threshold of M was met.

- Risc0 zkVM threshold-membership circuit (nullifier-based, Semaphore-style anonymity set — no FROST/DKG)
- SPEL `#[lez_program]` verifier running `env::verify(APPROVE_CIRCUIT_IMAGE_ID, …)`
- Double-vote prevention via `NullifierEntry` PDAs keyed by `(proposal_id, nullifier)`
- Client-side SDK + IDL-driven `pmsig` CLI; resumable, reorg-aware `ApprovalSession`
- Reproducible guest builds (`RISC0_USE_DOCKER=1`) with image-id drift sentinels
- Reproducible `demo.sh` wrapping the `quickstart` flow
- Real-proof benchmarks: ~161 s prove / ~46 ms verify (Apple M1); CI-green Layer-A e2e
- Dual-licensed MIT OR Apache-2.0 (LICENSE-MIT + LICENSE-APACHE at repo root)

## Honest status
The core cryptography, verifier program, SDK/CLI, IDL, benchmarks, licensing, and reproducible demo script are complete and CI-green. Open items (marked in the checklist) remain as the prize-submission follow-on: LEZ-testnet deployment + an executed on-chain instance, a narrated demo video, and the optional Basecamp GUI.

The solution file's Success Criteria Checklist reflects exactly which criteria are met vs. outstanding.