### PR TITLE
ci: opt in to fork-PR checkout after the actions/checkout guard change

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -34,6 +34,12 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: pr
           persist-credentials: false
+          # actions/checkout v4.4.0 (2026-07-20) backported a guard that refuses
+          # to check out fork PR code from a pull_request_target workflow. This
+          # step only reads the checked-out files as data and never executes
+          # them, and it already drops credentials, so opting in restores the
+          # previous behaviour without widening what the workflow trusts.
+          allow-unsafe-pr-checkout: true
 
       - name: Get changed files
         id: changed


### PR DESCRIPTION
Every submission PR from a fork currently fails `validate`, including ones whose content is fine. The job dies at **Checkout PR head** and the **Run validation** step is skipped, so the workflow never reads the submission at all.

### Cause

`actions/checkout` **v4.4.0** was published on 2026-07-20 at 15:36 UTC and backported a guard that refuses to check out fork pull-request code from a `pull_request_target` workflow. The previous v4 release was **v4.3.1, from 2025-11-17**, so this workflow picked the new behaviour up through the floating `@v4` tag without changing on its own side.

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
... To opt in ... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

### Verification

I reproduced it in a scratch repository rather than guessing, holding everything constant but one variable at a time: https://github.com/test-readme/checkout-guard-repro

| # | Fork PR? | checkout ref | opt-in | Result |
|---|---|---|---|---|
| 1 | yes | `@v4` (now v4.4.0) | no | [failure](https://github.com/test-readme/checkout-guard-repro/actions/runs/29776897571) |
| 2 | yes | `@v4.3.1` pinned | no | [success](https://github.com/test-readme/checkout-guard-repro/actions/runs/29776935662) |
| 3 | yes | `@v4` | yes | [success](https://github.com/test-readme/checkout-guard-repro/actions/runs/29776977611) |
| 4 | no | `@v4` | no | [success](https://github.com/test-readme/checkout-guard-repro/actions/runs/29777030983) |

Runs 1 and 2 isolate the cause: same pull request, same content, only the action version differs. Runs 1 and 4 isolate the trigger: only the fork differs. Run 3 is this patch.

### The change

One line on the step that checks out the fork's head. That step reads the checked-out files as data, never executes them, and already sets `persist-credentials: false`, so opting in restores the previous behaviour without widening what the workflow trusts. Pinning to `@v4.3.1` would also work but leaves the guard off indefinitely.

Found this while looking into why the `validate` job went red on #64. Happy to close if you would rather handle it differently.
