### PR TITLE
ci: allow fork checkout in submission validator

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -34,6 +34,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: pr
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Get changed files
         id: changed


### PR DESCRIPTION
This fixes the `Validate Submission` workflow for fork-based solution PRs.

Current failure on LP-0002 submission PR #115:

- workflow: `Validate Submission`
- run: https://github.com/logos-co/lambda-prize/actions/runs/30554437421
- failing step: `Checkout PR head (untrusted data, never executed)`
- error: `Refusing to check out fork pull request code from a pull_request_target workflow`

The workflow already treats the PR-head checkout as untrusted data and does not execute code from it. It checks out the fork only so the trusted base-branch validation script can inspect submitted markdown content and changed files.

Change:

- set `allow-unsafe-pr-checkout: true` on the PR-head `actions/checkout@v4` step.

After this merges, fork-based solution PRs such as #115 can be rerun by the normal validator workflow.