### PR TITLE
Solution: LP-0003 - Private Allowlist / Airdrop Distributor

### DIFF
--- a/solutions/LP-0003.md
+++ b/solutions/LP-0003.md
@@ -43,7 +43,7 @@ The airdrop program is written as a RISC0 guest (`programs/airdrop/`) that runs 
 - [x] **Full documentation and a clean public repository.** Repo `dhozil/logos-airdrop` with `README.md`, `docs/`, `sdk/`, `programs/`, CI green on `master`.
 - [x] **Module/SDK to build Logos modules.** `sdk/airdrop-cli` provides manifest generation, proof preparation, and claim serialization (`sdk/` crate with library + CLI).
 - [ ] **Logos Basecamp app GUI.** Not delivered in this submission (out of scope for this iteration).
-- [ ] **IDL via the SPEL framework.** Not delivered; the program uses the LEZ raw instruction-word ABI (`airdrop-cli serialize`).
+- [x] **IDL for the LEZ program, using the SPEL framework.** `airdrop.idl.json` at the repo root describes the three instructions (`initialize`, `claim`, `close`) with accounts, args, and discriminators per the SPEL / lssa-lang schema.
 - [x] **Graceful proof-generation failure handling.** Claims that fail on the sequencer are retryable; the state is only mutated on success, so a rejected claim never marks the recipient as claimed.
 - [x] **Deterministic, documented error codes.** Guest returns structured error codes for invalid inclusion proof, double-claim, and allocation-cap violations (see `programs/airdrop/src/main.rs`).
 - [x] **CU cost of each on-chain operation documented.** `docs/cu-costs.md`: initialize 82,576 cycles, claim 751,132 cycles.

--- a/solutions/LP-0003.md
+++ b/solutions/LP-0003.md
@@ -78,7 +78,7 @@ Tests: guest integration tests (`programs/airdrop/tests/`) covering init, claim,
 
 ## Supporting Materials
 
-- **Video demo (MP4):** <https://github.com/dhozil/logos-airdrop/releases/download/demo-v1/demo.video.mp4> — narrated walkthrough of architecture, claim flow, and the live on-chain verification.
+- **Video demo (Google Drive preview):** <https://drive.google.com/file/d/1BNkKe2BEY6b1dEZeVZOIanqiSzvJrnXl/view> — narrated walkthrough of architecture, claim flow, and the live on-chain verification. (MP4 download backup: <https://github.com/dhozil/logos-airdrop/releases/download/demo-v1/demo.video.mp4>)
 - **Architecture diagram:** `demo/airdrop-architecture.svg`
 - **Claim-flow diagram:** `demo/airdrop-claimflow.svg`
 - **Live deployment evidence:** `docs/deployments.md` (program ID, deployment TX, init TXs, block ids, claim counts)

--- a/solutions/LP-0003.md
+++ b/solutions/LP-0003.md
@@ -1,0 +1,91 @@
+# Solution: LP-0003 — Private Allowlist / Airdrop Distributor
+
+**Submitted by:** DhoziL
+
+## Summary
+
+A complete private airdrop and allowlist primitive for LEZ. The distributor commits to a hidden eligibility set on-chain (a Merkle root) without publishing any individual addresses, and recipients claim their allocation through a public LEZ transaction that re-executes the airdrop program inside the RISC0 zkVM. Claims reveal only a fresh nullifier, so no on-chain observer can link a claim to a specific eligible address, and double-claims are prevented by a nullifier set stored in the distribution state.
+
+The implementation is deployed live on LEZ testnet with **2 distinct distributions and 43 confirmed claims** (22 + 21), documented in the repository below.
+
+## Repository
+
+- **Repo:** <https://github.com/dhozil/logos-airdrop>
+- **Branch:** `master`
+
+## Approach
+
+The airdrop program is written as a RISC0 guest (`programs/airdrop/`) that runs on LEZ. The program IS the circuit: public execution in LEZ re-executes the transaction inside the zkVM, so eligibility checks, Merkle verification, and nullifier bookkeeping all happen inside the guest and are covered by the execution proof.
+
+**Distribution setup.** The distributor compiles the recipient list `(recipient_address, amount)`, generates a random 32-byte `salt` and `nullifier_secret` per recipient, and builds a Merkle tree where each leaf is `SHA256("airdrop_leaf" || recipient_address || amount || salt)`. Only the root is committed on-chain via the `initialize` instruction, which claims a program-owned state account storing the root, distributor, `total_allocation`, `claimed_so_far`, and the nullifier set.
+
+**Claim.** The `claim` instruction reads the distribution state, recomputes the leaf, verifies the Merkle inclusion proof (20-depth path) against the committed root, computes `nullifier = SHA256("airdrop_nullifier" || nullifier_secret)`, asserts it is unused, checks the allocation cap, then updates the state (append nullifier, increment `claimed_so_far`). `close` deactivates the distribution.
+
+**Key design decisions and trade-offs considered:**
+
+- *Merkle root commitment vs. full-list publication.* A public Merkle-root airdrop (the Uniswap baseline) reveals only the root but still links eligibility when inclusion proofs are submitted. We keep the root commitment but make claims unlinkable by exposing only a nullifier on-chain. The remaining leak (the root and total claimed) is documented in the privacy model.
+- *Public execution vs. shielded submission.* LEZ's current public execution model means claim transactions are re-executed by the sequencer; the program output is committed. We exploit this by making the guest the verifier, so the recipient address never needs to appear in a transaction signature — the recipient is simply an input to the leaf computation. This is stronger than an EVM Merkle airdrop, where the claimant's address is the transaction sender.
+- *Nullifier scheme.* Each claim appends `SHA256("airdrop_nullifier" || secret)` to a state vector. A replay of the same secret is rejected, preventing double claims. We considered a Semaphore-style nullifier but a plain keyed hash is sufficient for the claimed threat model and avoids an extra group-settings dependency.
+- *Two-account signing model.* Because the guest claims the state account via `Claim::Authorized`, both the distributor (admin) and the state account must sign each public transaction. This was the main integration bug during development: the initial `init` used a single account and was rejected with `ClaimedUnauthorizedAccount` by the sequencer until we built a custom wallet `call` command that accepts multiple signing accounts (`--accounts "Public/<ADMIN>" "Public/<STATE>"`).
+- *Program ID byte order.* The image ID reported by the build is byte-reversed (big-endian display) relative to the hex LEZ expects; the deployed program ID used by the CLI is the little-endian word order of the same image ID. This cost several failed transactions until the mapping was confirmed against the on-chain deployment.
+
+**Why the Logos stack.** LEZ's program-owned shielded accounts and public re-execution model let the verification logic itself be the trust anchor, unlike a centralised gating service which requires the operator to hold (and be forced to reveal) the eligibility list. On a centralised alternative the distributor is a choke point that can be pressured, seized, or front-run; on LEZ, censorship resistance and trustless execution are inherited properties, and the shielded account model gives us a natural home for the distribution state.
+
+## Success Criteria Checklist
+
+- [x] **A distributor can commit to an eligibility set on-chain without revealing individual addresses.** `initialize` commits only `SHA256` Merkle root; the recipient list and salts are never published. See `docs/protocol.md`.
+- [x] **An eligible recipient can claim their allocation without revealing which address they hold.** The claim transaction exposes only a nullifier; the recipient address is an input to the leaf hash inside the guest and never appears in transaction metadata.
+- [x] **A recipient cannot claim more than once.** Nullifier set stored in state; reusing a secret is rejected (`nullifier already claimed`).
+- [x] **An on-chain observer cannot link a completed claim to any specific address.** Each claim emits a fresh, unlinkable nullifier; the privacy model and residual leakage are documented in `docs/protocol.md`.
+- [x] **The submission documents its full privacy model.** See `docs/protocol.md` (what observers learn, what the distributor learns, residual trade-offs).
+- [x] **A working demo on LEZ testnet.** Live deployment, 43 claims on-chain (evidence below and in `docs/deployments.md`).
+- [x] **At least 2 distinct distributions with a combined total of at least 20 unique claims.** Distribution A: 22 claims, Distribution B: 21 claims = 43 total, reproducible via `scripts/demo.sh` / `demo/demo_verify.sh`.
+- [x] **Full documentation and a clean public repository.** Repo `dhozil/logos-airdrop` with `README.md`, `docs/`, `sdk/`, `programs/`, CI green on `master`.
+- [x] **Module/SDK to build Logos modules.** `sdk/airdrop-cli` provides manifest generation, proof preparation, and claim serialization (`sdk/` crate with library + CLI).
+- [ ] **Logos Basecamp app GUI.** Not delivered in this submission (out of scope for this iteration).
+- [ ] **IDL via the SPEL framework.** Not delivered; the program uses the LEZ raw instruction-word ABI (`airdrop-cli serialize`).
+- [x] **Graceful proof-generation failure handling.** Claims that fail on the sequencer are retryable; the state is only mutated on success, so a rejected claim never marks the recipient as claimed.
+- [x] **Deterministic, documented error codes.** Guest returns structured error codes for invalid inclusion proof, double-claim, and allocation-cap violations (see `programs/airdrop/src/main.rs`).
+- [x] **CU cost of each on-chain operation documented.** `docs/cu-costs.md`: initialize 82,576 cycles, claim 751,132 cycles.
+- [x] **Program deployed and tested on LEZ testnet.** Program ID `26d7fafc8e6d6ce035979a9b5c692e5367e3e2ec6123116b1f75edef13bd8721`.
+- [x] **End-to-end integration tests against a LEZ sequencer in CI.** CI runs on `master` (`.github/workflows/build.yml`); guest integration tests exercise init + claim against a local sequencer.
+- [x] **CI green on default branch.** See repository Actions.
+- [x] **README documents deployment, program addresses, step-by-step usage.** `docs/deployments.md`, `README.md`.
+- [x] **Reproducible end-to-end demo script against a real local sequencer with `RISC0_DEV_MODE=0`.** `scripts/demo.sh` (and `demo/demo_verify.sh` for the live testnet proof).
+- [x] **Recorded video demo showing the end-to-end flow.** See Supporting Materials (recording shows terminal output with proof generation).
+
+## FURPS Self-Assessment
+
+### Functionality
+
+The program supports three instructions — `initialize`, `claim`, `close` — covering commitment, claim, and distribution teardown. The SDK generates manifests, prepares Merkle inclusion proofs, and serializes instruction words for the wallet. Limitations: the eligibility set is fixed at setup (by design, per the prize scope); the program does not currently perform shielded token transfers (integration with LEZ token transfers is future work).
+
+### Usability
+
+The workflow is CLI-driven (`airdrop-cli` + LEZ wallet): `generate` → `init` → `proof` → `serialize` → `call`. Onboarding requires the recipient list in CSV, then two signing accounts for each transaction. The README and `docs/deployments.md` give copy-paste steps for every phase.
+
+### Reliability
+
+Claims are only recorded when the sequencer confirms them; a failed/rejected claim leaves the nullifier set untouched, so retries are safe. The state account is program-owned, so no external party can mutate distribution state. During the demo we observed poller timeouts that occasionally reported "all pollers failed" even when the transaction was in-block; the canonical source of truth is the on-chain transaction + state query (`wallet chain-info transaction`), which is what the verification script uses.
+
+### Performance
+
+Measured on LEZ testnet (public execution): initialize 82,576 cycles, claim 751,132 cycles (20-depth Merkle verification dominates). Full details in `docs/cu-costs.md`. Proof generation is performed by the sequencer during public re-execution; local guest runs confirm the same cycle counts.
+
+### Supportability
+
+Tests: guest integration tests (`programs/airdrop/tests/`) covering init, claim, double-claim rejection, and unauthorized-account rejection; CI runs on `master`. Structure: `programs/airdrop` (guest), `sdk` (CLI/library), `docs` (protocol, deployments, CU costs), `scripts` + `demo` (reproducibility). Deployment and troubleshooting notes are in the README.
+
+## Supporting Materials
+
+- **Video demo (MP4):** <https://github.com/dhozil/logos-airdrop/releases/download/demo-v1/demo.video.mp4> — narrated walkthrough of architecture, claim flow, and the live on-chain verification.
+- **Architecture diagram:** `demo/airdrop-architecture.svg`
+- **Claim-flow diagram:** `demo/airdrop-claimflow.svg`
+- **Live deployment evidence:** `docs/deployments.md` (program ID, deployment TX, init TXs, block ids, claim counts)
+- **Protocol + privacy model:** `docs/protocol.md`
+- **CU benchmarks:** `docs/cu-costs.md`
+- **Reproducible demo script:** `scripts/demo.sh`, `demo/demo_verify.sh`
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](../TERMS.md).

--- a/solutions/LP-0003.md
+++ b/solutions/LP-0003.md
@@ -81,6 +81,7 @@ Tests: guest integration tests (`programs/airdrop/tests/`) covering init, claim,
 - **Video demo (Google Drive preview):** <https://drive.google.com/file/d/1BNkKe2BEY6b1dEZeVZOIanqiSzvJrnXl/view> — narrated walkthrough of architecture, claim flow, and the live on-chain verification. (MP4 download backup: <https://github.com/dhozil/logos-airdrop/releases/download/demo-v1/demo.video.mp4>)
 - **Architecture diagram:** `demo/airdrop-architecture.svg`
 - **Claim-flow diagram:** `demo/airdrop-claimflow.svg`
+- **Basecamp app:** `basecamp/` (QML GUI + `manifest.json`; `module.json` at repo root)
 - **Live deployment evidence:** `docs/deployments.md` (program ID, deployment TX, init TXs, block ids, claim counts)
 - **Protocol + privacy model:** `docs/protocol.md`
 - **CU benchmarks:** `docs/cu-costs.md`


### PR DESCRIPTION
## Solution: LP-0003 — Private Allowlist / Airdrop Distributor

Private airdrop/allowlist primitive for LEZ. Distributor commits to a hidden eligibility set (Merkle root) on-chain; recipients claim via public LEZ transactions that re-execute the airdrop program in the RISC0 zkVM. Claims reveal only fresh nullifiers.

- **Repo:** https://github.com/dhozil/logos-airdrop (branch `master`)
- **Live on LEZ testnet:** 2 distributions, 43 claims (22 + 21)
- **Program ID:** `26d7fafc8e6d6ce035979a9b5c692e5367e3e2ec6123116b1f75edef13bd8721`

### Video demo
- Preview (Google Drive): *will update*
- Download (MP4): https://github.com/dhozil/logos-airdrop/releases/download/demo-v1/demo.video.mp4