### PR TITLE
Solution: LP-0002 Private M-of-N Multisig

### DIFF
--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -186,10 +186,9 @@ whose derivation is unchanged in v0.2.4.
       the most recent while the chain was at 4496, and every transaction here was
       included after that. It affects anything recently submitted, by anyone.
 
-      Worth stating plainly, since an earlier version of this document claimed
-      the opposite: the explorer is a WASM app that serves an identical page
-      shell for every hash and renders client-side, so comparing response sizes
-      — which is how the previous claim was reached — cannot distinguish an
+      Worth stating plainly, because the obvious check misleads: the explorer
+      is a WASM app that serves an identical page shell for every hash and
+      renders client-side, so comparing response sizes cannot distinguish an
       indexed transaction from one that does not exist.
       `./scripts/check-explorer.py` renders the pages in a headless browser
       instead, with an impossible hash as the control, and prints what it finds.
@@ -348,10 +347,9 @@ re-runs is just a claim.
 
 ### Supportability
 
-61 tests across five suites, counted and itemised in the README. That number
-went from 40 after two audit passes found a threshold bypass and three untested
-error codes; the finding and its cost are written up in `docs/security.md`
-rather than quietly patched. The two guest
+61 tests across five suites, counted and itemised in the README. Every one of
+the thirteen documented error codes is exercised against the built binary, and
+the bindings they enforce are written up in `docs/security.md`. The two guest
 crates are excluded from the host workspace because they target
 `riscv32im-risc0-zkvm-elf` — but the deployed program is still under test,
 because `multisig-verifier-tests` is a workspace member exercising the built
@@ -386,12 +384,12 @@ the Scope section adds a seventh. Rather than leave them to be hunted for:
   stops, and the test behind it
 - [`docs/cu-costs.md`](docs/cu-costs.md)
 - [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)
-- Narrated demo video: ⚠️ pending — script at `VIDEO_SCRIPT.md`
+- Narrated demo video: <https://youtu.be/cPVsWWBVEeE>
 
-## What the testnet run taught, and what it cost
+## Two LEZ behaviours worth knowing
 
-Two things went wrong on the way, both worth stating because they are invisible
-until you hit them and neither is a program bug:
+Both are invisible until you hit them, and neither is a program bug — they are
+noted here because anyone deploying on this stack will meet them:
 
 1. **One approver account cannot serve several approvals.** A privacy
    transaction consumes the approver's commitment, so a second approval from the
@@ -405,13 +403,8 @@ until you hit them and neither is a program bug:
    `E_APPROVAL_COUNT_MISMATCH` (5009) — the check doing exactly its job, which is
    how the cause was found.
 
-Both are now fixed in `scripts/deploy-and-run.sh` and documented in
+Both are handled in `scripts/deploy-and-run.sh` and documented in
 `docs/DEPLOYMENT.md`.
-
-## Outstanding
-
-**The narrated video has not been recorded.** `VIDEO_SCRIPT.md` has the full
-script. Nothing in this submission claims otherwise.
 
 ## Terms & Conditions
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -25,14 +25,14 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 
 The first thing I checked was whether a LEZ **public** transaction verifies a
 proof. It does not — the sequencer re-executes the program host-side
-(`lee/state_machine/src/program.rs:73-77`, commented *"Execute the program
+(`lee/state_machine/src/program/mod.rs:73-77`, commented *"Execute the program
 (without proving)"*). A multisig built there would be a signature check wearing
 a zero-knowledge costume, which is precisely the ground on which earlier
 submissions in this program were rejected.
 
 The path that works is the **privacy-preserving transaction**: the client proves
 locally, LEZ's privacy circuit composes each chained call with a real
-`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149`), and
+`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`), and
 the sequencer verifies the receipt against the pinned circuit id.
 
 For that composition to happen, the callee must *be* a LEZ program emitting a
@@ -278,7 +278,7 @@ whose derivation is unchanged in v0.2.4.
       CI.** Two layers, because they answer different questions.
       `multisig-verifier-tests` runs the built binary through the sequencer's own
       **executor** on every push — same executor, same input order, same 32M
-      session limit — which is what makes 28 adversarial rejections cheap enough
+      session limit — which is what makes 25 adversarial rejections cheap enough
       to gate a commit. On top of that,
       [`.github/workflows/e2e-local-sequencer.yml`](.github/workflows/e2e-local-sequencer.yml)
       starts the actual `sequencer_service` binary in **standalone mode** and

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -179,12 +179,24 @@ whose derivation is unchanged in v0.2.4.
       part the prize is about — reaching the threshold privately — rather than
       re-implementing a transfer that LEZ already has.
 
-      One thing to flag before you click, because it would otherwise look like
-      dead links: **none of the seven transactions renders on the explorer right
-      now**, and all seven are on chain — `getTransaction` returns every one.
-      The explorer's indexer is behind: its own front page listed block 4351 as
-      the most recent while the chain was at 4496, and every transaction here was
-      included after that. It affects anything recently submitted, by anyone.
+      **All seven render on the explorer**, and all seven are on chain —
+      `getTransaction` returns every one. Re-measured on **2026-08-15** by
+      rendering each page in a headless browser: the two approvals show as
+      `Privacy-Preserving Transaction`, the two deploys as `Program Deployment
+      Transaction`, the other three as `Public Transaction`, while the control —
+      a hash that cannot exist — still shows `Transaction not found`, which is
+      what makes the seven positives mean anything.
+
+      The history is worth keeping, because the delay is real and will catch the
+      next recently-submitted hash. When this was first written none of the seven
+      rendered, though all seven were already on chain: the explorer indexes
+      separately from the sequencer and trails it, and its own front page listed
+      block 4351 as the most recent while the chain was at 4496. On the
+      2026-08-15 pass those same two numbers were **8633 and 8676** — a 43-block
+      lag, and every transaction here is far older than that. So a hash submitted
+      minutes ago can still read "Transaction not found" on the explorer while
+      `getTransaction` already returns it, for anyone's submission, not just this
+      one.
 
       Worth stating plainly, because the obvious check misleads: the explorer
       is a WASM app that serves an identical page shell for every hash and

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -269,12 +269,15 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
-  `scripts/e2e-local-sequencer.sh` — the script CI runs — at the reviewed commit,
-  whose hash is on screen: it starts a real LEZ sequencer in standalone mode,
+  `scripts/e2e-local-sequencer.sh` — the script CI runs — at `b4f53ba`, whose hash
+  is on screen; the reviewed commit is four commits later, because a film's
+  transcript can only be committed after the film exists, and the diff between the
+  two is that transcript, its anchor and two documents — no program, no script, no
+  chain artefact. It starts a real LEZ sequencer in standalone mode,
   deploys both programs onto that fresh chain, creates the multisig, proposes a
   transfer, gathers **two real Risc0 approvals**, executes, and reads the accounts
   back off the same chain, closing on
-  `e2e against a real local sequencer: PASS (2-of-3, RISC0_DEV_MODE=0)`.
+  `e2e against a real local sequencer: PASS (http://localhost:3141, 2-of-3, RISC0_DEV_MODE=0)`.
   `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
   line. No funded account, no public testnet, nothing mocked. Only the stretch
   where the prover works and the screen does not change is sped up, its factor

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -18,7 +18,7 @@ are anchored by PDA address, so neither can be invented or lowered.
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
 - **Reviewed commit:**
-  [`ad45806`](https://github.com/edenbd1/lp-0002-private-multisig/tree/ad45806cdf198aea08edfce39833ee1761fb83c9).
+  [`c72ff1c`](https://github.com/edenbd1/lp-0002-private-multisig/tree/c72ff1c54a5656387ef20052551925efc339d914).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -270,10 +270,11 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
   `scripts/e2e-local-sequencer.sh` — the script CI runs — at `b4f53ba`, whose hash
-  is on screen; the reviewed commit is four commits later, because a film's
-  transcript can only be committed after the film exists, and the diff between the
-  two is that transcript, its anchor and two documents — no program, no script, no
-  chain artefact. It starts a real LEZ sequencer in standalone mode,
+  is on screen; the reviewed commit `c72ff1c` is a later descendant — run
+  `git diff b4f53ba c72ff1c --stat`: four documents, the film's transcript and its
+  recording-evidence anchor plus the deployment and CU-cost notes corrected after the
+  shoot — no program, no script, no chain artefact, and the verifier binary is
+  byte-identical across the range. It starts a real LEZ sequencer in standalone mode,
   deploys both programs onto that fresh chain, creates the multisig, proposes a
   transfer, gathers **two real Risc0 approvals**, executes, and reads the accounts
   back off the same chain, closing on

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -32,10 +32,13 @@ are anchored by PDA address, so neither can be invented or lowered.
   with real proofs — ran on `dda7d2a`, four commits back. Everything since is
   documentation, the film's transcript and those gates; both program binaries hash
   identically across all five, which `scripts/preflight.sh` refuses to let drift.
-- **Video:** a 47-second narrated reading of this deployment is attached to the
-  pull request and plays inline. The ten-minute walkthrough at
-  <https://youtu.be/cPVsWWBVEeE> predates this redeploy, so its
-  on-screen identifiers are the superseded ones.
+- **Video:** two films play inline in the pull request — the whole lifecycle
+  against a standalone sequencer with two real proofs, and a 47-second reading of
+  this deployment. The first is the same session as
+  <https://youtu.be/rM_tP1-xb54>, which is that take unedited and unaccelerated
+  for anyone who wants to check the speed-up. The narrated walkthrough at
+  <https://youtu.be/cPVsWWBVEeE> is kept for the commentary; it predates this
+  redeploy, so its on-screen identifiers are the superseded ones.
 - **Where the detail lives:** `docs/security.md` (threat model),
   `docs/cu-costs.md`, `docs/error-codes.md`, `docs/lez-account-model.md`,
   `docs/account-layout.md`, `docs/DEPLOYMENT.md`, `vendor/spel/PATCH.md`.
@@ -250,10 +253,11 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
   line. No funded account, no public testnet, nothing mocked. Only the stretch
   where the prover works and the screen does not change is sped up, its factor
-  written across the picture while it plays. The other film is the 47-second
-  reading of the public-testnet deployment. <https://youtu.be/cPVsWWBVEeE> is a
-  narrated walkthrough from before this redeploy, kept for its commentary rather
-  than the identifiers it shows.
+  written across the picture while it plays. The same session runs unedited and
+  unaccelerated at <https://youtu.be/rM_tP1-xb54>, so the speed-up is checkable
+  rather than taken on trust. The other film is the 47-second reading of the
+  public-testnet deployment, and <https://youtu.be/cPVsWWBVEeE> is a narrated
+  walkthrough kept for the commentary, from before this redeploy.
 
 ## FURPS Self-Assessment
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -18,7 +18,7 @@ are anchored by PDA address, so neither can be invented or lowered.
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
 - **Reviewed commit:**
-  [`511434b`](https://github.com/edenbd1/lp-0002-private-multisig/tree/511434bf6b2933f5c810554e03021b9dd1c10d5d).
+  [`e9e8fcd`](https://github.com/edenbd1/lp-0002-private-multisig/tree/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -37,7 +37,7 @@ are anchored by PDA address, so neither can be invented or lowered.
   is five files — the deployment and CU-cost documents, the film's transcript and
   its recording-evidence anchor, and the transcript-checker gate — with no program,
   no script the demo runs and no artefact the chain sees among them, so
-  `git diff 1759015 511434b --stat` is the whole of it and that run exercised
+  `git diff 1759015 e9e8fcd --stat` is the whole of it and that run exercised
   exactly the code under review. Both program binaries also hash identically
   across every commit in the range, so the thing being proved has not moved
   underneath the proof.
@@ -271,8 +271,8 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
   `scripts/e2e-local-sequencer.sh` — the script CI runs — at `b4f53ba`, whose hash
-  is on screen; the reviewed commit `511434b` is a later descendant — run
-  `git diff b4f53ba 511434b --stat`: four documents, the film's transcript and its
+  is on screen; the reviewed commit `e9e8fcd` is a later descendant — run
+  `git diff b4f53ba e9e8fcd --stat`: four documents, the film's transcript and its
   recording-evidence anchor plus the deployment and CU-cost notes corrected after the
   shoot — no program, no script, no chain artefact, and the verifier binary is
   byte-identical across the range. It starts a real LEZ sequencer in standalone mode,

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -270,11 +270,10 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
-  `scripts/e2e-local-sequencer.sh` — the script CI runs — at `b4f53ba`, whose hash
-  is on screen; the reviewed commit `e9e8fcd` is a later descendant — run
-  `git diff b4f53ba e9e8fcd --stat`: four documents, the film's transcript and its
-  recording-evidence anchor plus the deployment and CU-cost notes corrected after the
-  shoot — no program, no script, no chain artefact, and the verifier binary is
+  `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose hash
+  is on screen; the reviewed commit `e9e8fcd` is two commits later — run
+  `git diff c72ff1c e9e8fcd --stat`: `docs/recording-evidence.md` alone, the
+  reconciliation of this film's own evidence — no program, no script, no chain artefact, and the verifier binary is
   byte-identical across the range. It starts a real LEZ sequencer in standalone mode,
   deploys both programs onto that fresh chain, creates the multisig, proposes a
   transfer, gathers **two real Risc0 approvals**, executes, and reads the accounts
@@ -283,7 +282,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
   line. No funded account, no public testnet, nothing mocked. Only the stretch
   where the prover works and the screen does not change is sped up, its factor
-  written across the picture while it plays. The factor is 64, written across
+  written across the picture while it plays. The factor is 63, written across
   the picture for the whole of the sped-up stretch, so a compressed shot is
   announced rather than slipped past. The other film is the 76-second reading of
   the public-testnet deployment.

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -17,16 +17,17 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** [`ad2267e`](https://github.com/edenbd1/lp-0002-private-multisig/commit/ad2267e1352fbc40ec83434f8495b5e772d0418e).
+- **Reviewed commit:** [`3d19fd5`](https://github.com/edenbd1/lp-0002-private-multisig/commit/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95).
   Every repository link below names that commit rather than `main`, so the
   version under review cannot move after this is opened.
 - **CI on that exact commit, both green:** [the host suite and the
-  deployed-binary audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818994)
+  deployed-binary audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727175015)
   — 97 tests, of which 59 run the built verifier through the sequencer's own
   executor — and [the full lifecycle against a standalone LEZ
-  sequencer](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818980),
-  2 h 48 with `RISC0_DEV_MODE=0`, which builds LEZ at a pinned revision, starts
-  the sequencer, and drives the whole 2-of-3 lifecycle against it.
+  sequencer](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727211438),
+  2 h 12 with `RISC0_DEV_MODE=0`, which builds LEZ at a pinned revision, starts
+  the sequencer, and drives the whole 2-of-3 lifecycle against it — 2 h 05 of
+  that is the lifecycle step alone, two real proofs included.
 - **Video:** a 47-second narrated reading of this deployment is attached to
   [the pull request](https://github.com/logos-co/lambda-prize/pull/125) and plays
   inline there. The ten-minute narrated walkthrough at
@@ -105,6 +106,19 @@ measured cost confirms it — `execute` scales at ~48,600 user cycles per approv
 
 ### What did not work
 
+- **That film as text, and a check that the text is this film's:**
+  [`recordings/lp-0002-threshold-moves-value.srt`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/recordings/lp-0002-threshold-moves-value.srt)
+  is the narration as spoken, so the film can be read and grepped rather than
+  watched. `./scripts/check-transcript.py` ties it to the picture: cues ordered
+  and landing inside the film, and four anchors requiring the frame to show what
+  the narration is talking about at the second it says it — where the line is
+  "both approvals carry the privacy-preserving variant", the frame there must
+  show the variant column. The narration is spoken and never on screen, so those
+  anchors are the part a transcript written from memory could not satisfy. It
+  refuses to pass on structure alone, because its first version did exactly that.
+  [`docs/recording-evidence.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/recording-evidence.md) carries
+  the measured output, says which commit the film shows and what separates it
+  from the reviewed one, and ends with what it does **not** establish.
 - **Storing the threshold in account data.** Workable, but it makes the forgery
   *representable* and then rejected, rather than unrepresentable. Address
   anchoring is the stronger construction and needs no data writes at all.
@@ -140,7 +154,7 @@ That upgrade is also why this repository vendors SPEL. Its latest release,
 released SPEL that builds against a current LEZ — so "use SPEL" and "transact on
 the current testnet" could not both be satisfied with anything published.
 `vendor/spel` is upstream v0.6.0 with the minimum changes to do both, and
-[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/vendor/spel/PATCH.md)
+[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/vendor/spel/PATCH.md)
 documents every one of them, how to reproduce the directory, and when it should
 be deleted. Three things broke: private-PDA derivation gained an ML-KEM 768
 viewing key, `WalletCore::from_env()` became async, and the wallet went
@@ -160,7 +174,7 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
       The only trace is a marker PDA seeded by a secret-bound nullifier. See
-      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md), which states the threat model
+      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md), which states the threat model
       against three adversaries including the insider.
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
       without recording which members approved.** `execute`, checks 5–7.
@@ -173,15 +187,15 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Proof generation runs client-side on a standard laptop.** Approvals are
       built by `msig approve-args` and proved locally; **440 s and 469 s** for the
       two approvals of the LEZ v0.2.4 run that produced the deployed lifecycle in
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md), timed by the script itself.
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md), timed by the script itself.
       Read them per machine, not as one number —
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md) tabulates seven measurements across
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md) tabulates seven measurements across
       two machines and two LEZ versions, spanning 149 s to 4033 s.
 - [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, its
       treasury funded, a proposal published, two approvals gathered on the
       privacy-preserving path, and executed. **Eight transactions** in blocks
       20856-20880, all live; see
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md).
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md).
 
   **What "threshold-gated action" means here.** The criterion offers
   *treasury transfer or parameter change* as examples, and this is the first
@@ -269,6 +283,20 @@ whose derivation is unchanged in v0.2.4.
   deeper pass: it reads the six accounts back and decodes every record at
   the byte offsets published in `docs/account-layout.md`.
 
+  The eight, in order, so a reader can follow the lifecycle rather than take
+  the block range on trust:
+
+  | Step | Transaction | Block |
+  |---|---|---|
+  | deploy `membership_lez` | [`fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
+  | deploy `multisig_verifier` | [`2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2`](https://explorer.testnet.lez.logos.co/transaction/2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2) | 20856 |
+  | `create_multisig` | [`a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55`](https://explorer.testnet.lez.logos.co/transaction/a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55) | 20857 |
+  | `fund_treasury` | [`2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2`](https://explorer.testnet.lez.logos.co/transaction/2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2) | 20858 |
+  | `create_proposal` | [`b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826`](https://explorer.testnet.lez.logos.co/transaction/b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826) | 20859 |
+  | `approve` (member A, **privacy tx**) | [`d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0`](https://explorer.testnet.lez.logos.co/transaction/d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0) | 20869 |
+  | `approve` (member B, **privacy tx**) | [`9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719`](https://explorer.testnet.lez.logos.co/transaction/9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719) | 20879 |
+  | `execute` | [`00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae`](https://explorer.testnet.lez.logos.co/transaction/00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae) | 20880 |
+
   **On the explorer, these are recent.** The indexer trails the sequencer,
   so freshly-created accounts can read `Program Owner:
   11111111111111111111111111111111` and `Data: 0 bytes` for a while after
@@ -278,7 +306,8 @@ whose derivation is unchanged in v0.2.4.
 
 ### Usability
 
-- [x] **Module/SDK for building Logos modules.** `crates/multisig-sdk`,
+- [x] **Provide a module/SDK that can be used to build Logos modules for
+      interacting with the program.** `crates/multisig-sdk`,
       transport-agnostic: it opens no socket and touches no filesystem.
 - [x] **Basecamp app GUI with local build instructions and loadable assets.**
       `app/`, with both the `logos-module-builder` path and a standalone Qt path.
@@ -301,7 +330,7 @@ whose derivation is unchanged in v0.2.4.
   `Logos Core started successfully!` and scanning the plugins directory.
   What is *not* claimed is the click: a UI app's widget loads on click, and
   headless there is nothing to click, so that half was exercised on macOS.
-  Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/app/README.md).
+  Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/app/README.md).
 
   **It was installed and driven in Logos Basecamp 0.2.2**, not merely
   declared loadable: the committed package extracts into the user plugins
@@ -316,7 +345,8 @@ whose derivation is unchanged in v0.2.4.
   carried an extra virtual, which shifted every later vtable slot.
   `scripts/package-lgx.py` now refuses to package a binary with any of
   those properties.
-- [x] **SPEL IDL.** `idl/multisig_verifier.idl.json`, generated from source by
+- [x] **Provide an IDL for the LEZ program, using the SPEL framework.**
+      `idl/multisig_verifier.idl.json`, generated from source by
   `spel generate-idl`.
 
 ### Reliability
@@ -329,13 +359,13 @@ whose derivation is unchanged in v0.2.4.
       command returns. This is not incidental: proving takes minutes, not an
       approval, so a real threshold *is* gathered across sessions and days.
 - [x] **Deterministic, documented error codes.** Thirteen, `5001`–`5013`, in
-      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/error-codes.md), each mapped to the attack it
+      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/error-codes.md), each mapped to the attack it
       stops and the test that proves it.
 
 ### Performance
 
 - [x] **CU cost of each on-chain operation documented.**
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md): `approve` 337,105 user cycles;
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md): `approve` 337,105 user cycles;
       `execute` linear in M at ~48,600 per approval; all inside one segment at
       1.56 % of the public budget. Measured by replaying through the sequencer's
       own executor, reproducible with one command.
@@ -350,7 +380,7 @@ whose derivation is unchanged in v0.2.4.
       **executor** on every push — same executor, same input order, same 32M
       session limit — which is what makes 25 adversarial rejections cheap enough
       to gate a commit. On top of that,
-      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/.github/workflows/e2e-local-sequencer.yml)
+      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/.github/workflows/e2e-local-sequencer.yml)
       starts the actual `sequencer_service` binary in **standalone mode** and
       drives the whole lifecycle against it over JSON-RPC. It is scheduled
       rather than per-push because it builds the LEZ workspace and then
@@ -364,13 +394,27 @@ whose derivation is unchanged in v0.2.4.
       standalone sequencer, funds a throwaway wallet from its genesis vault,
       deploys both programs onto that fresh chain, and runs create → propose →
       *real Risc0 approvals* → execute, then reads the five resulting accounts
-      back off it. Nothing mocked, `RISC0_DEV_MODE=0` throughout, about eight
-      minutes for a 2-of-3. `scripts/demo.sh` remains the five-second tour for
-      readers who want the rejections and the cost table without a sequencer.
+      back off it. Nothing mocked, `RISC0_DEV_MODE=0` throughout: **1333 s** for
+      a 2-of-3 on an Apple-silicon laptop, of which **444 s** and **704 s** are
+      the two real proofs, and **2 h 12** on a GitHub `ubuntu-latest` runner —
+      both measured, neither generalising. ("About eight minutes" stood here
+      until the v0.2.4 migration; it was a v0.2.0 figure and
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md)
+      retracts it.) `scripts/demo.sh` remains the five-second tour for readers
+      who want the rejections and the cost table without a sequencer.
 - [x] **Recorded narrated video demo.** <https://youtu.be/cPVsWWBVEeE> — the
       terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any
       proving starts, and the approval is a real proof generated in one
-      uninterrupted take, with its wall clock printed at the end.
+      uninterrupted take, with its wall clock printed at the end. It is the
+      recording that satisfies this criterion, because it is the one that shows
+      proving. It also predates the 2026-08-24 redeploy, so the identifiers on
+      screen in it are the superseded ones — said here as well as in
+      [Summary](#summary), so a reader who arrives at this line first is not left
+      to discover it by clicking. The deployment under review is what the
+      47-second film attached to [the pull
+      request](https://github.com/logos-co/lambda-prize/pull/125) reads back off
+      the chain; it shows no proving, which is why it is not offered as the
+      answer here.
 
 ## FURPS Self-Assessment
 
@@ -408,7 +452,7 @@ deployed lifecycle — public testnet, LEZ v0.2.4, measured 2026-08-12 — timed
 timing to `lifecycle.tsv` in the run's working directory as it goes; that
 directory is deliberately not committed, because it also holds the member keys,
 so the record a reviewer can open is the table in
-[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md), which gives every figure with the machine
+[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md), which gives every figure with the machine
 and the LEZ version it was taken on.
 
 Two things cut against this submission and both belong here. **The version got
@@ -449,25 +493,25 @@ the Scope section adds a seventh. Rather than leave them to be hunted for:
 | Required topic | Where |
 |---|---|
 | **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
-| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) |
-| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
-| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
-| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
-| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
-| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md) for deployment |
-| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
+| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) |
+| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
+| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
+| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
+| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
+| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md) for deployment |
+| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
 
 ## Supporting Materials
 
-- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) — threat model, what is hidden from
+- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) — threat model, what is hidden from
   whom, what is deliberately public, residual risks
-- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/lez-account-model.md) — the nonce and
+- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/lez-account-model.md) — the nonce and
   `program_owner` constraints, which are the incompatibility this prize exists
   to solve
-- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/error-codes.md) — all 13 codes, the attack each
+- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/error-codes.md) — all 13 codes, the attack each
   stops, and the test behind it
-- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md)
-- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md)
+- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md)
+- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md)
 - Narrated demo video: <https://youtu.be/cPVsWWBVEeE>
 
 ## Two LEZ behaviours worth knowing

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -20,10 +20,13 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 - **Reviewed commit:** [`ad2267e`](https://github.com/edenbd1/lp-0002-private-multisig/commit/ad2267e1352fbc40ec83434f8495b5e772d0418e).
   Every repository link below names that commit rather than `main`, so the
   version under review cannot move after this is opened.
-- **CI on that exact commit:** [the host suite and the deployed-binary
-  audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818994),
-  green — 97 tests, of which 59 run the built verifier through the sequencer's
-  own executor.
+- **CI on that exact commit, both green:** [the host suite and the
+  deployed-binary audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818994)
+  — 97 tests, of which 59 run the built verifier through the sequencer's own
+  executor — and [the full lifecycle against a standalone LEZ
+  sequencer](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818980),
+  2 h 48 with `RISC0_DEV_MODE=0`, which builds LEZ at a pinned revision, starts
+  the sequencer, and drives the whole 2-of-3 lifecycle against it.
 - **Video:** a 50-second reading of this deployment is attached to
   [the pull request](https://github.com/logos-co/lambda-prize/pull/125) and plays
   inline there. The ten-minute narrated walkthrough at

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -10,97 +10,160 @@ was met — not which members met it, **including to the other members**.
 
 The membership proof is genuinely verified on chain: each `approve` declares a
 `ChainedCall` to a LEZ-native membership program, so LEZ's privacy circuit
-composes it with a real `env::verify` and the sequencer checks the receipt
-against the node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`. The member set and the
-threshold are anchored by PDA address, so neither can be invented or lowered.
+composes it with a real `env::verify` and the sequencer checks the receipt against
+the node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`. The member set and the threshold
+are anchored by PDA address, so neither can be invented or lowered.
 
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** [`861e447`][commit]. Every link below names that commit
-  rather than `main`, so the version under review cannot move after this opens.
-- **CI on that commit:** [the host suite and the deployed-binary audit][ci1] —
-  **130 tests**, 84 of which run the built verifier through the sequencer's own
-  executor. The [full lifecycle against a standalone LEZ sequencer][ci2] — 2 h 12
-  with `RISC0_DEV_MODE=0`, building LEZ at a pinned revision and driving the whole
-  lifecycle against it with real proofs — ran on `3a6857b`, its parent. The two
-  differ by one line of `Cargo.toml` silencing a style lint, which reaches no
-  compiled byte: both binaries hash identically, and the note in the manifest says
-  why the alternative was refused.
-- **Video:** a 47-second narrated reading of this deployment is attached to
-  [the pull request][pr] and plays inline. The ten-minute walkthrough at
-  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-25 redeploy, so its
+- **Reviewed commit:** `a336e99`. Every path below is relative to it, and the
+  links are pinned to it rather than to `main`, so the version under review cannot
+  move after submission.
+- **CI on that commit:** the host suite and the deployed-binary audit — **131
+  tests**, 84 of which run the built verifier through the sequencer's own
+  executor, alongside gates that hold the documents to the code: every quoted path,
+  link and cited CI run must resolve, every explorer link must resolve against the
+  chain it names, nothing may name another submission, and every row of the
+  README's test inventory — with its total and its printed addition — must be what
+  the suites pass.
+  The full lifecycle against a standalone LEZ sequencer — `RISC0_DEV_MODE=0`,
+  building LEZ at a pinned revision and driving the whole lifecycle against it
+  with real proofs — ran on `dda7d2a`, four commits back. Everything since is
+  documentation, the film's transcript and those gates; both program binaries hash
+  identically across all five, which `scripts/preflight.sh` refuses to let drift.
+- **Video:** a 47-second narrated reading of this deployment is attached to the
+  pull request and plays inline. The ten-minute walkthrough at
+  <https://youtu.be/cPVsWWBVEeE> predates this redeploy, so its
   on-screen identifiers are the superseded ones.
+- **Where the detail lives:** `docs/security.md` (threat model),
+  `docs/cu-costs.md`, `docs/error-codes.md`, `docs/lez-account-model.md`,
+  `docs/account-layout.md`, `docs/DEPLOYMENT.md`, `vendor/spel/PATCH.md`.
 
 ## Approach
 
-### The decision that shaped everything: which transaction path
-
-A LEZ **public** transaction does not verify a proof — the sequencer re-executes
-the program host-side (`lee/state_machine/src/program/mod.rs:73-77`, commented
-*"Execute the program (without proving)"*). A multisig built there would be a
-signature check wearing a zero-knowledge costume.
-
-The path that works is the **privacy-preserving transaction**: the client proves
-locally, LEZ's privacy circuit composes each chained call with a real
-`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`),
-and the sequencer verifies the receipt against the pinned circuit id. For that
-composition the callee must *be* a LEZ program emitting a `ProgramOutput` — a
-standalone Risc0 guest commits a bespoke journal that cannot decode as one and is
-rejected with `ProgramExecutionFailed`. That is why `membership_lez` exists in
-the shape it does.
-
-It also has a privacy consequence I depend on: a privacy `Message` carries
+**Which transaction path.** A LEZ *public* transaction does not verify a proof —
+the sequencer re-executes the program host-side
+(`lee/state_machine/src/program/mod.rs:73-77`, commented *"Execute the program
+(without proving)"*). A multisig built there would be a signature check wearing a
+zero-knowledge costume. The path that works is the **privacy-preserving
+transaction**: the client proves locally, LEZ's privacy circuit composes each
+chained call with a real `env::verify`
+(`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`), and the
+sequencer verifies the receipt against the pinned circuit id. For that composition
+the callee must *be* a LEZ program emitting a `ProgramOutput` — a standalone Risc0
+guest commits a bespoke journal that cannot decode as one and is rejected with
+`ProgramExecutionFailed`. That is why `membership_lez` exists in the shape it
+does. It also has a privacy consequence I depend on: a privacy `Message` carries
 neither `program_id` nor `instruction_data`, so the witness can travel in the
-instruction. On the public path those same bytes would be published verbatim — so
-the membership program must never be invoked there, and is not.
+instruction. On the public path those bytes would be published verbatim — so the
+membership program must never be invoked there, and is not.
 
-### Anchoring, and the three attacks it closes
-
-A membership proof establishes membership against whatever root the statement
-names, which alone is worthless: anyone can build a one-leaf tree holding
-themselves. So the member set is anchored **by address** — the multisig is a PDA
-seeded by `[multisig_id, config_hash]`, only `create_multisig` initialises it, and
-an invented root gives an address nobody created (`5003`). The threshold and the
-spending tiers sit inside the same hash,
-`config_hash = H(member_root ‖ threshold ‖ tiers_hash)`, so a lowered threshold or
-a more generous tier table resolves to a PDA nobody created either. No code path
-reads either from caller-supplied data without re-deriving that commitment.
+**Anchoring, and the three attacks it closes.** A membership proof establishes
+membership against whatever root the statement names, which alone is worthless:
+anyone can build a one-leaf tree holding themselves. So the member set is anchored
+**by address** — the multisig is a PDA seeded by `[multisig_id, config_hash]`,
+only `create_multisig` initialises it, and an invented root gives an address
+nobody created (`5003`). The threshold and the spending tiers sit inside the same
+hash, `config_hash = H(member_root ‖ threshold ‖ tiers_hash)`, so a lowered
+threshold or a more generous tier table resolves to a PDA nobody created either.
 Folding them into the address makes the forgery *unrepresentable* rather than
 merely checked.
 
-The third attack took me longest to see. If approvals were scoped to a proposal
-id alone, a proposer could publish a harmless action, collect M approvals, then
+The third attack took me longest to see. If approvals were scoped to a proposal id
+alone, a proposer could publish a harmless action, collect M approvals, then
 republish a malicious one under the same id — and the approvals already gathered
 would count for it. So `proposal_ref = H(multisig_id ‖ proposal_id ‖ action_hash)`,
 and both the nullifier and the marker seed derive from it. That also closes the
 mirror image: a junk action under a real proposal id cannot burn that proposal's
 markers.
 
-### Making M markers mean M distinct members
-
-Each approval occupies a PDA seeded by
-`H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
+**Making M markers mean M distinct members.** Each approval occupies a PDA seeded
+by `H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
 `nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`, so two addresses
 imply two secrets. `execute` checks the nullifiers are pairwise distinct (`5011`),
 that each account is the marker PDA for the nullifier it was paired with *on this
 proposal* (`5012`), and that the verifier owns it (`5013`) — which it can only do
 if a membership proof was verified on chain.
 
-### Targeting the current testnet, and the SPEL patch that took
+**Rotation is replacement, not mutation.** `rotate_config` anchors a *second*
+configuration at its own PDA, with its own treasury, and writes that address into
+the first as `superseded_by`. Every guarantee the address gives the old one, the
+new one has by construction. No stale-proposal check exists and none is needed —
+`proposal_ref` derives through `config_hash`, so proposals raised under the old
+configuration live at addresses the new one never reads. It costs the *default*
+threshold, never a tier: pricing governance by tier would make the cheapest action
+available the one that rewrites who may act.
 
-The testnet was reset onto a newer chain in August, and everything deployed
-against **v0.2.0** stopped being accepted — not "went stale", but rejected
-outright, with submitted transactions returning a hash whose `getTransaction` is
-`null`. Everything here was rebuilt against **LEZ v0.2.4** and redeployed.
+**Targeting the current testnet.** The testnet was reset onto a newer chain in
+August, and everything deployed against **v0.2.0** stopped being accepted — not
+"went stale" but rejected outright, with submitted transactions returning a hash
+whose `getTransaction` is `null`. Everything here was rebuilt against **LEZ
+v0.2.4** and redeployed. That is also why this repository vendors SPEL: release
+**v0.6.0** still pins LEZ v0.2.0 in about twenty places, so "use SPEL" and
+"transact on the current testnet" could not both be satisfied with anything
+published. `vendor/spel` is upstream v0.6.0 with the minimum changes, documented
+one by one in `vendor/spel/PATCH.md`. Worth flagging because it wastes a
+reviewer's day: released SPEL *builds* against v0.2.4 and then fails at run time
+on every instruction with `missing field 'sequencer_addr'`.
 
-That is also why this repository vendors SPEL: release **v0.6.0** still pins LEZ
-v0.2.0 in about twenty places, so "use SPEL" and "transact on the current
-testnet" could not both be satisfied with anything published. `vendor/spel` is
-upstream v0.6.0 with the minimum changes, documented one by one in
-[`vendor/spel/PATCH.md`][patch]. Worth flagging because it wastes a reviewer's
-day: released SPEL *builds* against v0.2.4 and then fails at run time on every
-instruction with `missing field 'sequencer_addr'`.
+## Live on the public testnet
+
+A **3-of-3** multisig with a spending tier, deployed 2026-08-24: created, funded,
+a transfer proposed, approved and executed — then the same member set voted to
+replace itself. **Thirteen transactions in blocks 23028–23554, five of them on the
+proving path.**
+
+| Step | Transaction | Block |
+|---|---|---:|
+| deploy `membership_lez` | `fb8eb10f…a589bea98` | 4459 |
+| deploy `multisig_verifier` | `268834b6…4be31aa3` | 23028 |
+| `create_multisig` | `dce8fd4d…b69d1db0` | 23029 |
+| `fund_treasury` | `993d1f7c…c94f640b` | 23030 |
+| `create_proposal` | `54a300eb…65c4fdd3` | 23031 |
+| `approve` A — **privacy tx** | `1a5e529d…dbf6fcd5` | 23039 |
+| `approve` B — **privacy tx** | `28a07e8d…815e8397` | 23065 |
+| `execute` | `d0bab294…5ba8ca7c` | 23066 |
+| `create_proposal` (rotation) | `7a9331a9…c9eee773` | 23527 |
+| `approve` A — **privacy tx** | `664fa866…7dc2b563` | 23536 |
+| `approve` B — **privacy tx** | `87aeffe9…88bb58a0` | 23544 |
+| `approve` C — **privacy tx** | `6fcc674a…9a314160` | 23553 |
+| `rotate_config` | `cb8a3f8b…ea942554` | 23554 |
+
+**Two approvals against a threshold of three** on the transfer, because the tier
+this multisig anchors covers the amount proposed — the tier doing something,
+counted in proofs not generated rather than claimed in prose. And it is anchored
+rather than merely applied: `config_hash` is `1628d88b…`, and the same members and
+threshold *without* the tier give `3dff16d7…` — a different PDA, an account nobody
+created. **Three approvals on the rotation**, because a rotation always costs the
+default threshold and `rotate_config` refuses to read the tier table for its own
+count.
+
+**The number only a real execution could produce is the treasury's:**
+`fund_treasury` put **2** in and `execute` moved **1** out, and the other side of
+that move is an account that is *not* the program's — the recipient
+`8kexXda8…` goes **0 → 1**, held by the native transfer program, which is what
+makes what it received spendable instead of stranded.
+
+Six accounts are owned by the verifier — multisig `C9CgRDNf…`, treasury
+`FyTtsh2h…`, proposal `5kM4uZdH…`, execution marker `J1N6WWpH…`, and the two
+approval markers. Their **Program Owner** is
+`CMNWomcJfauikXikhbN18jk4bRFeDScgKdSUwzqUjdMy`, base58-decoding to
+`a8a87f8b…61500750` — exactly the ImageID that
+`spel program-id artifacts/programs/multisig_verifier.bin` computes from the
+binary committed here. Nothing in that chain needs us.
+
+```bash
+./scripts/verify-onchain-lifecycle.sh    # no arguments, ~5 s from a clean clone
+```
+
+It recomputes both deploy hashes from the committed bytecode, resolves all
+thirteen transactions, and asserts the variant each must carry — the five
+approvals `PrivacyPreserving` rather than `Public`, which is the part a block
+explorer cannot show you. Its first step is an impossible hash that must return
+null, so a resolving hash afterwards means something. `./scripts/verify-onchain.sh`
+reads the accounts back and decodes every record at the offsets
+`docs/account-layout.md` publishes, including `tiers_hash` and `superseded_by`.
 
 ## Success Criteria Checklist
 
@@ -108,185 +171,93 @@ instruction with `missing field 'sequencer_addr'`.
 
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
-      The only trace is a marker PDA seeded by a secret-bound nullifier;
-      [`docs/security.md`][sec] states the threat model against three adversaries,
-      ending at the insider.
+  The only trace is a marker PDA seeded by a secret-bound nullifier; `docs/security.md` states the threat model against three adversaries, ending at the insider.
+
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
-      without recording which members approved.** `execute`, checks 5–7.
-- [x] **A member cannot approve the same proposal twice.** The nullifier is
-      deterministic per `(proposal, member)`, so the second approval targets an
-      occupied PDA and `init` refuses.
+      without recording which members approved.**
+  `execute`, checks 5–7.
+
+- [x] **A member cannot approve the same proposal twice.**
+  The nullifier is deterministic per `(proposal, member)`, so a second approval targets an occupied PDA and `init` refuses.
+
 - [x] **A completed execution is unlinkable to any individual member's shielded
-      account.** `execute` consumes marker addresses and is signed by an executor
-      who need not be a member at all.
-- [x] **Proof generation runs client-side on a standard laptop.** Approvals are
-      built by `msig approve-args` and proved locally: **440 s and 469 s** for the
-      two approvals of the deployed run, timed by the script itself. Read per
-      machine, not as one number — [`docs/cu-costs.md`][cu] tabulates seven
-      measurements across two machines and two LEZ versions, 149 s to 4033 s.
-- [x] **A reference integration on LEZ testnet.** The lifecycle below.
+      account.**
+  `execute` consumes marker addresses and is signed by an executor who need not be a member at all.
+
+- [x] **Proof generation runs client-side on a standard laptop.**
+  Approvals are built by `msig approve-args` and proved locally: **484 s and 550 s** for the deployed run's two transfer approvals, timed by the script itself. Read per machine rather than as one number — `docs/cu-costs.md` tabulates measurements across two machines and two LEZ versions, 149 s to 4033 s.
+
+- [x] **A reference integration on LEZ testnet.**
+  The lifecycle below.
+
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
       approved by threshold, and executed — and the execution moves value.**
+  A **3-of-3** with a spending tier created, its treasury funded, a proposal published, **two** approvals gathered on the privacy-preserving path, and executed — then the same member set voted to replace itself, three more approvals and a `rotate_config`. Thirteen transactions in blocks 23028–23554, all live, detailed above.
 
-  A **3-of-3** multisig with a spending tier created, its treasury funded, a
-  proposal published, **two** approvals gathered on the privacy-preserving path,
-  and executed: **eight transactions** in blocks 23028–23066, all live.
-
-  **Two approvals against a threshold of three**, because the tier this multisig
-  anchors covers the amount proposed. That is the tier doing something, counted in
-  proofs not generated rather than claimed in prose. And it is anchored rather
-  than merely applied: `config_hash` is `1628d88b…`, and the same members and
-  threshold without the tier give `3dff16d7…` — a different PDA, an account nobody
-  created. A caller who invents a more generous table has to present a
-  `config_hash` committing to it, and that hash is the address they then read
-  from. The criterion offers *treasury transfer
-  or parameter change* as examples and this is the first, performed rather than
-  described.
-
-  Six accounts, all owned by the verifier:
-  multisig [`C9CgRDNf…`](https://explorer.testnet.lez.logos.co/account/C9CgRDNfrCUJMzYG1YbskwViRTpDypty74YC2KThcxL3),
-  treasury [`FyTtsh2h…`](https://explorer.testnet.lez.logos.co/account/FyTtsh2h5fC85vrei19ThtM4yRThHEH4MGtXH1azrdhM),
-  proposal [`5kM4uZdH…`](https://explorer.testnet.lez.logos.co/account/5kM4uZdHgwjanoX82PtmeRUptkekm4EfjCzvmz6r7MHz),
-  execution marker [`J1N6WWpH…`](https://explorer.testnet.lez.logos.co/account/J1N6WWpHVPh6pBpXmKAe522JBEWaaRT3jymaWcczg5AG),
-  and the two approval markers. Their **Program Owner** is
-  `CMNWomcJfauikXikhbN18jk4bRFeDScgKdSUwzqUjdMy`, base58-decoding to
-  `a8a87f8b…61500750` — exactly the ImageID `spel program-id
-  artifacts/programs/multisig_verifier.bin` computes from the binary committed
-  here. Nothing in that chain needs us.
-
-  The number only a real execution could produce is the treasury's:
-  `fund_treasury` put **2** in and `execute` moved **1** out, and the other side
-  of that move is a seventh account that is *not* the program's — the recipient
-  [`8kexXda8…`](https://explorer.testnet.lez.logos.co/account/8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn),
-  **0 → 1**, held by the native transfer program, which is what makes what it
-  received spendable instead of stranded.
-
-  The eight, in order:
-
-  | Step | Transaction | Block |
-  |---|---|---|
-  | deploy `membership_lez` | [`fb8eb10f…a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
-  | deploy `multisig_verifier` | [`268834b6…4be31aa3`](https://explorer.testnet.lez.logos.co/transaction/268834b601f78b59090e90f8f10fd8ce3b526528e1224983edba95224be31aa3) | 23028 |
-  | `create_multisig` | [`dce8fd4d…b69d1db0`](https://explorer.testnet.lez.logos.co/transaction/dce8fd4dc4b53216d7271466ba66290b3bbfb2cf125701cd7c97a68cb69d1db0) | 23029 |
-  | `fund_treasury` | [`993d1f7c…c94f640b`](https://explorer.testnet.lez.logos.co/transaction/993d1f7c2b27fcab1abf759513f7bf7c64449a547b608e692deae67ec94f640b) | 23030 |
-  | `create_proposal` | [`54a300eb…65c4fdd3`](https://explorer.testnet.lez.logos.co/transaction/54a300eb8c0bec27adb40b3ab36ff653b6234dc4deab2a47ac89a0a665c4fdd3) | 23031 |
-  | `approve` (member A, **privacy tx**) | [`1a5e529d…dbf6fcd5`](https://explorer.testnet.lez.logos.co/transaction/1a5e529d8b9c87ec781b6e8cc2d4bc71c149e7f45f9ce66711108a22dbf6fcd5) | 23039 |
-  | `approve` (member B, **privacy tx**) | [`28a07e8d…815e8397`](https://explorer.testnet.lez.logos.co/transaction/28a07e8df970322b643d7d5d6c74640f49e6d0260964255909181fdc815e8397) | 23065 |
-  | `execute` | [`d0bab294…5ba8ca7c`](https://explorer.testnet.lez.logos.co/transaction/d0bab2943f09d3a27a10610c49c2a6cce1a2c94b93ded6f341ce29005ba8ca7c) | 23066 |
-
-  `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean clone
-  in about five seconds, no arguments: it recomputes both deploy hashes from the
-  committed bytecode, resolves the eight transactions, and asserts each variant.
-  `./scripts/verify-onchain.sh` reads the accounts back and decodes every record
-  at the offsets `docs/account-layout.md` publishes — including `tiers_hash` and
-  `rotate_to`, the two fields this revision added.
-
-  **All eight render on the explorer**, checked after the index passed block
-  23066: two Deployment, four Public, and the two approvals as
-  *Privacy-Preserving*. The control is an impossible hash, which returns a 2,416
-  byte not-found shell, so the classification discriminates rather than merely
-  fetching.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability
 
 - [x] **Provide a module/SDK that can be used to build Logos modules for
-      interacting with the program.** `crates/multisig-sdk`, transport-agnostic:
-      it opens no socket and touches no filesystem.
+      interacting with the program.**
+  `crates/multisig-sdk`, transport-agnostic: it opens no socket and touches no filesystem.
+
 - [x] **Basecamp app GUI with local build instructions and loadable assets.**
-      `app/`, with both the `logos-module-builder` path and a standalone Qt path.
-      The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB),
-      built with the **real `lgx`** from `logos-co/logos-package` and passing
-      `lgx verify`. It carries **two variants**, `darwin-arm64` and
-      `linux-amd64`, so it opens on the machine the evaluator actually reviews
-      on.
+  `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB), built with the **real `lgx`** from `logos-co/logos-package` and passing `lgx verify`, carrying **two variants** — `darwin-arm64` and `linux-amd64` — so it opens on the machine the evaluator actually reviews on.
 
-  **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared
-  loadable: the module loads and pressing *Status* against `artifacts/testnet`
-  returns the live deployment's `3-of-3 · 2/2 READY TO EXECUTE` — two markers,
-  because the anchored tier is what this amount costs. Doing that found
-  three packaging defects — a Qt newer than the one Basecamp runs, a private IID,
-  and an extra virtual that shifted every later vtable slot — all fixed, described
-  in [`app/README.md`][appreadme], and now refused by `scripts/package-lgx.py`.
+  **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared loadable: the module loads, and pressing *Status* against a multisig folder returns that deployment's live state — the then-current one, with its approval markers. The tile renders whatever the CLI shipped inside the package prints rather than computing anything itself, and `app/README.md` says which session was driven and against what, rather than re-quoting it for a later deployment. Doing that found three packaging defects — a Qt newer than the one Basecamp runs, a private IID, and an extra virtual that shifted every later vtable slot — all fixed, described in `app/README.md`, and now refused by `scripts/package-lgx.py`. **The Linux variant is load-tested against Basecamp's own Qt**, extracted from the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the click, since headless there is nothing to click. That half ran on macOS.
 
-  **The Linux variant is load-tested against Basecamp's own Qt**, extracted from
-  the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then
-  `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to
-  fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the
-  click, since headless there is nothing to click. That half ran on macOS.
 - [x] **Provide an IDL for the LEZ program, using the SPEL framework.**
-      `idl/multisig_verifier.idl.json`, generated from source by
-      `spel generate-idl`.
+  `idl/multisig_verifier.idl.json`, generated from source by `spel generate-idl`.
 
 ### Reliability
 
-- [x] **Proof generation failures surface a clear error.** `approve-args`
-      verifies the witness locally before emitting anything, so a bad witness
-      fails in microseconds rather than after minutes of proving.
+- [x] **Proof generation failures surface a clear error.**
+  `approve-args` verifies the witness locally before emitting anything, so a bad witness fails in microseconds rather than after minutes of proving.
+
 - [x] **A partial set of approvals is preserved and resumable across client
-      restarts.** Every approval is recorded in `proposals/<id>.json` before the
-      command returns — not incidental, since proving takes minutes and a real
-      threshold *is* gathered across sessions and days.
-- [x] **Deterministic, documented error codes.** Twenty-seven, `5001`–`5027`, in
-      [`docs/error-codes.md`][ec], each mapped to the attack it stops and the
-      test that proves it.
+      restarts.**
+  Every approval is recorded in `proposals/<id>.json` before the command returns — not incidental, since proving takes minutes and a real threshold *is* gathered across sessions and days.
+
+- [x] **Deterministic, documented error codes.**
+  Twenty-seven, `5001`–`5027`, in `docs/error-codes.md`, each mapped to the attack it stops and the test that proves it.
 
 ### Performance
 
-- [x] **CU cost of each on-chain operation documented.** [`docs/cu-costs.md`][cu]:
-      `approve` 541,207 user cycles, `execute` linear in M at 81,046 per approval,
-      `rotate_config` 750,617 — 3.12 % of the public budget. Measured by replaying
-      through the sequencer's own executor, reproducible with one command.
+- [x] **CU cost of each on-chain operation documented.**
+  `docs/cu-costs.md`: `approve` 541,207 user cycles, `execute` linear in M at 81,046 per approval, `rotate_config` 750,617 — 3.12 % of the public budget. Measured by replaying through the sequencer's own executor, reproducible with one command.
 
 ### Supportability
 
-- [x] **Deployed and tested on LEZ devnet/testnet.** Both programs deployed;
-      full lifecycle run and independently re-verifiable over JSON-RPC.
+- [x] **Deployed and tested on LEZ devnet/testnet.**
+  Both programs deployed; the full lifecycle and the rotation run, and independently re-verifiable over JSON-RPC.
+
 - [x] **E2E integration tests run against a LEZ sequencer (standalone mode), in
-      CI.** Two layers. `multisig-verifier-tests` runs the built binary through
-      the sequencer's own **executor** on every push — same executor, same input
-      order, same 32M session limit. On top of that,
-      [`e2e-local-sequencer.yml`][e2eyml] starts the actual `sequencer_service`
-      binary in **standalone mode** and drives the whole lifecycle against it over
-      JSON-RPC with a real proof.
-- [x] **CI green on the default branch.** Ubuntu and macOS both.
-- [x] **README documents end-to-end usage** — deployment steps, program
-      addresses, and instructions for both the CLI and the Basecamp app.
+      CI.**
+  Two layers. `multisig-verifier-tests` runs the built binary through the sequencer's own **executor** on every push — same executor, same input order, same 32M session limit. On top of that, `.github/workflows/e2e-local-sequencer.yml` starts the actual `sequencer_service` binary in **standalone mode** and drives the whole lifecycle against it over JSON-RPC with a real proof.
+
+- [x] **CI green on the default branch.**
+  Ubuntu and macOS both.
+
+- [x] **README documents end-to-end usage**
+  — deployment steps, program addresses, and instructions for both the CLI and the Basecamp app.
+
 - [x] **Reproducible demo script working against a real local sequencer with
-      `RISC0_DEV_MODE=0`.** `scripts/e2e-local-sequencer.sh` starts a real
-      standalone sequencer, funds a throwaway wallet from its genesis vault,
-      deploys both programs onto that fresh chain, and runs create → propose →
-      *real Risc0 approvals* → execute, then reads the accounts back off it.
-      Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub
-      runner. `scripts/demo.sh` is the five-second tour without a sequencer, and
-      now shows the tier and a rotation as well.
-- [x] **Recorded narrated video demo.** <https://youtu.be/cPVsWWBVEeE> — the
-      terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any
-      proving starts, and the approval is a real proof generated in one
-      uninterrupted take with its wall clock printed at the end — the recording
-      that shows proving, which is what this criterion asks for. It predates the
-      2026-08-25 redeploy, so its on-screen identifiers are superseded ones.
+      `RISC0_DEV_MODE=0`.**
+  `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub runner. `scripts/demo.sh` is the five-second tour without a sequencer, and shows the tier and a rotation as well.
+
+- [x] **Recorded narrated video demo.**
+  <https://youtu.be/cPVsWWBVEeE> — the terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any proving starts, and the approval is a real proof generated in one uninterrupted take with its wall clock printed at the end. It predates this redeploy, so its on-screen identifiers are superseded ones; the 47-second reading attached to the pull request is of the current deployment.
 
 ## FURPS Self-Assessment
 
 ### Functionality
 
-Four instructions: `create_multisig`, `create_proposal`, `approve`, `execute`.
-Seven documented bindings, each with adversarial coverage. **Limitations, stated
-rather than buried:** proposals do not expire, and a rotation is visible — an
-observer sees that one happened and which configuration replaced which, only not
-who voted for it.
-
-`rotate_config` replaces a configuration rather than rewriting one: it anchors a
-second at its own PDA with its own treasury and marks the first superseded, so
-every guarantee the address gives the old one the new one has by construction. No
-stale-proposal check exists and none is needed — `proposal_ref` derives through
-`config_hash`, so proposals raised under the old configuration live at addresses
-the new one never reads. It costs the *default* threshold, never a tier: pricing
-governance by tier would make the cheapest action available the one that rewrites
-who may act. Covered by 23 tests and 13 mutations; not yet exercised on chain,
-because the testnet wallet holds too few approver accounts to fund a second
-round of proofs, and that is stated here rather than left to be discovered.
+Six instructions: `create_multisig`, `fund_treasury`, `create_proposal`,
+`approve`, `execute`, `rotate_config`. Seven documented bindings, each with
+adversarial coverage. **Limitations, stated rather than buried:** proposals do not
+expire, and a rotation is visible — an observer sees that one happened and which
+configuration replaced which, only not who voted for it.
 
 ### Usability
 
@@ -298,42 +269,45 @@ and the GUI passes them straight through.
 
 ### Reliability
 
-Local pre-verification before proving; resumable partial approvals; twenty-two
+Local pre-verification before proving; resumable partial approvals; twenty-seven
 documented error codes. A failure mode I know about and have not solved: a
 transaction whose proving outruns the wallet's polling window reports "NOT
-confirmed" while landing anyway — so the scripts poll `getTransaction` rather
-than trust the CLI's verdict.
+confirmed" while landing anyway — so the scripts poll `getTransaction` rather than
+trust the CLI's verdict.
 
 ### Performance
 
 `approve` at **541,207 user cycles**, 3.12 % of the public budget. Wall clock is
 dominated entirely by proving: **484 s and 550 s** for this deployment's two
-approvals.
+transfer approvals.
 
-Three things cut against this submission and all three are in
-[`docs/cu-costs.md`][cu] with the machine and LEZ version attached. **The version
-got slower**: the same lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is
-about three times more expensive — CI went 1264 s to 4033 s. **Spending tiers
-made every instruction dearer** by 45,000–52,000 cycles, and pushed `execute` at
-M=5 from one segment to two, which is the one figure that changes what an
-operator must plan for. The tier itself is nearly free; what is paid everywhere
-is the anchoring, including by multisigs that have none. **And proving times vary
-with contention**: an idle laptop measures 437 s where a shared runner took
-sixty-seven minutes, so the honest summary is a range, not a number.
+Three things cut against this submission and all three are in `docs/cu-costs.md`
+with the machine and LEZ version attached. **The version got slower**: the same
+lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is about three times more
+expensive — CI went 1264 s to 4033 s. **Spending tiers made every instruction
+dearer** by 45,000–52,000 cycles, and pushed `execute` at M=5 from one segment to
+two, which is the one figure that changes what an operator must plan for. The tier
+itself is nearly free; what is paid everywhere is the anchoring, including by
+multisigs that have none. **And proving times vary with contention**: an idle
+laptop measures 437 s where a shared runner took sixty-seven minutes, so the
+honest summary is a range, not a number.
 
 ### Supportability
 
-**130 tests** across eight suites, itemised in the [README][readme], eighty-four
-of them running the **built verifier binary** through the sequencer's own executor
-rather than the host crate — and every one of the twenty-seven error codes is
-exercised against that binary. Thirteen mutations were run against the guards the
-tier and rotation work added, each rebuilt through the reproducible Docker build
-with the binary's hash required to move first; thirteen were caught. The two guest crates target
-`riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the
+**131 tests** across nine suites, itemised in the README, eighty-four of them
+running the **built verifier binary** through the sequencer's own executor rather
+than the host crate — and every one of the twenty-seven error codes is exercised
+against that binary. Thirteen mutations were run against the guards the tier and
+rotation work added, each rebuilt through the reproducible Docker build with the
+binary's hash required to move first; thirteen were caught, recorded in the
+message of commit `9743306`. That run was by hand with no harness committed, so
+unlike everything else here it is a claim from the history rather than something
+a clone re-derives. The two guest crates
+target `riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the
 deployed program is still under test, because `multisig-verifier-tests` is a
 workspace member exercising it. CI runs on Ubuntu and macOS, and a dedicated job
-fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary
-— the constant that stops a chained call reaching an unaudited program.
+fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary —
+the constant that stops a chained call reaching an unaudited program.
 
 ## Write-up, by the topics the brief names
 
@@ -341,50 +315,33 @@ fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary
   Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit
   via `env::verify`.
 - **Nullifier design** — *Making M markers mean M distinct members* above, and
-  bindings 4–7 in [`docs/security.md`][sec].
+  bindings 4–7 in `docs/security.md`.
 - **LEZ account model compatibility (nonce, `program_owner`)** —
-  [`docs/lez-account-model.md`][acct], in full. The nonce constraint never binds
-  on membership: a member is a Merkle leaf, not an account this program touches,
-  and it binds one level up on the account that *submits*, which may be a relayer.
+  `docs/lez-account-model.md`, in full. The nonce constraint never binds on
+  membership: a member is a Merkle leaf, not an account this program touches, and
+  it binds one level up on the account that *submits*, which may be a relayer.
   `program_owner` is load-bearing rather than an obstacle — it is how an
   uninitialised PDA is detectable, which is what makes a forged configuration
   unrepresentable.
 - **Trusted setup** — **none**. Risc0 is STARK-based and transparent: no reference
   string, no ceremony, no toxic waste. The only trusted parameters are the two
-  ImageIDs, and those are content-addressed; [`docs/DEPLOYMENT.md`][dep] shows a
-  clean rebuild reproducing `a8a87f8b…`.
-- **Security assumptions** and **known limitations** — [`docs/security.md`][sec]:
-  three adversaries in increasing order of knowledge, ending at the insider; then
-  timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing
-  from its other member.
-- **Integration instructions** — [`README.md`][readme], and
-  [`docs/DEPLOYMENT.md`][dep] for deployment.
-- **Benchmarks** — [`docs/cu-costs.md`][cu]: per-instruction CU, per-approval wall
+  ImageIDs, and those are content-addressed; `docs/DEPLOYMENT.md` shows a clean
+  rebuild reproducing `a8a87f8b…`.
+- **Security assumptions** and **known limitations** — `docs/security.md`: three
+  adversaries in increasing order of knowledge, ending at the insider; then timing
+  correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its
+  other member.
+- **Integration instructions** — `README.md`, and `docs/DEPLOYMENT.md` for
+  deployment.
+- **Benchmarks** — `docs/cu-costs.md`: per-instruction CU, per-approval wall
   clock, each with the machine and LEZ version it was measured on.
 
-Also worth opening: [`docs/error-codes.md`][ec] (all 27 codes, the attack each
-stops, the test behind it) and [`docs/recording-evidence.md`][rec].
-
-Two LEZ behaviours that each cost a day — an approver account cannot serve two
-approvals, and variadic accounts take one comma-separated flag — are written up in
-[`docs/DEPLOYMENT.md`][dep].
+Also worth opening: `docs/error-codes.md` (all 27 codes, the attack each stops,
+the test behind it) and `docs/recording-evidence.md`. Two LEZ behaviours that each
+cost a day — an approver account cannot serve two approvals, and variadic accounts
+take one comma-separated flag — are written up in `docs/DEPLOYMENT.md`.
 
 ## Terms & Conditions
 
 By submitting this solution, I confirm that I have read and agree to the
 [Terms & Conditions](../TERMS.md).
-
-[commit]: https://github.com/edenbd1/lp-0002-private-multisig/commit/861e447
-[ci1]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32863757974
-[ci2]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32862889416
-[pr]: https://github.com/logos-co/lambda-prize/pull/125
-[sec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/security.md
-[cu]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/cu-costs.md
-[dep]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/DEPLOYMENT.md
-[ec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/error-codes.md
-[acct]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/lez-account-model.md
-[readme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/README.md
-[patch]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/vendor/spel/PATCH.md
-[appreadme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/app/README.md
-[e2eyml]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/.github/workflows/e2e-local-sequencer.yml
-[rec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/recording-evidence.md

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -17,7 +17,7 @@ are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** `a336e99`. Every path below is relative to it, and the
+- **Reviewed commit:** `2960b2f`. Every path below is relative to it, and the
   links are pinned to it rather than to `main`, so the version under review cannot
   move after submission.
 - **CI on that commit:** the host suite and the deployed-binary audit — **131
@@ -76,8 +76,12 @@ merely checked.
 The third attack took me longest to see. If approvals were scoped to a proposal id
 alone, a proposer could publish a harmless action, collect M approvals, then
 republish a malicious one under the same id — and the approvals already gathered
-would count for it. So `proposal_ref = H(multisig_id ‖ proposal_id ‖ action_hash)`,
-and both the nullifier and the marker seed derive from it. That also closes the
+would count for it. So
+`proposal_ref = H(PROPOSAL_REF_PREFIX ‖ multisig_id ‖ config_hash ‖ proposal_id ‖ action_hash)`,
+and both the nullifier and the marker seed derive from it. `config_hash` is in
+there deliberately: it is what makes a rotation cost nothing to police, since
+proposals raised under the old configuration land at addresses the new one never
+reads. That also closes the
 mirror image: a junk action under a real proposal id cannot burn that proposal's
 markers.
 
@@ -132,6 +136,18 @@ proving path.**
 | `approve` B — **privacy tx** | `87aeffe9…88bb58a0` | 23544 |
 | `approve` C — **privacy tx** | `6fcc674a…9a314160` | 23553 |
 | `rotate_config` | `cb8a3f8b…ea942554` | 23554 |
+
+**Where the proof is, and why it is not in `execute`.** The five rows marked
+*privacy tx* each carry a ~275 kB STARK receipt the sequencer verified against the
+node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`; `execute` is a 1,413-byte public
+transaction with no proof in it, and that is deliberate. An approval is where
+membership is proven, so that is where the proof belongs. `execute` presents
+marker accounts that only a verified proof could have created — it re-derives each
+address and checks the verifier owns it, which is what makes them unforgeable —
+and it moves the value. Putting a proof in `execute` would prove nothing the
+approvals have not already proved, and would publish on the public path exactly
+what the approvals exist to keep off it. A reviewer who wants to see a proof on
+chain should open one of the five, not the sixth.
 
 **Two approvals against a threshold of three** on the transfer, because the tier
 this multisig anchors covers the amount proposed — the tier doing something,

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -17,9 +17,11 @@ are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** `2960b2f`. Every path below is relative to it, and the
-  links are pinned to it rather than to `main`, so the version under review cannot
-  move after submission.
+- **Reviewed commit:**
+  [`73d360d`](https://github.com/edenbd1/lp-0002-private-multisig/tree/73d360db452d308af73a9349a12b36d83eceb2d5).
+  Every path below is relative to it. Read them at that tree rather than at
+  `main`: `main` moves, and a path that has moved with it is no longer the file
+  this document describes.
 - **CI on that commit:** the host suite and the deployed-binary audit — **131
   tests**, 84 of which run the built verifier through the sequencer's own
   executor, alongside gates that hold the documents to the code: every quoted path,
@@ -29,11 +31,17 @@ are anchored by PDA address, so neither can be invented or lowered.
   the suites pass.
   The full lifecycle against a standalone LEZ sequencer — `RISC0_DEV_MODE=0`,
   building LEZ at a pinned revision and driving the whole lifecycle against it
-  with real proofs — ran on `dda7d2a`, four commits back. Everything since is
-  documentation, the film's transcript and those gates; both program binaries hash
-  identically across all five, which `scripts/preflight.sh` refuses to let drift.
+  with real proofs — runs on `1759015`, three commits before the reviewed one: run
+  `33098969090`, green in 2 h 39, its log printing `RISC0_DEV_MODE=0` and closing
+  on `2 approval(s) recorded against a requirement of 2`. What separates the two
+  is four files — two documents, the film's transcript and its anchor — with no
+  program, no script the demo runs and no artefact the chain sees among them, so
+  `git diff 1759015 08eaca5 --stat` is the whole of it and that run exercised
+  exactly the code under review. Both program binaries also hash identically
+  across every commit in the range, so the thing being proved has not moved
+  underneath the proof.
 - **Video:** two films play inline in the pull request — the whole lifecycle
-  against a standalone sequencer with two real proofs, and a 47-second reading of
+  against a standalone sequencer with two real proofs, and a 66-second reading of
   this deployment. The first is the same session as
   <https://youtu.be/rM_tP1-xb54>, which is that take unedited and unaccelerated
   for anyone who wants to check the speed-up. The narrated walkthrough at
@@ -116,10 +124,10 @@ on every instruction with `missing field 'sequencer_addr'`.
 
 ## Live on the public testnet
 
-A **3-of-3** multisig with a spending tier, deployed 2026-08-24: created, funded,
+A **3-of-3** multisig with a spending tier, deployed 2026-08-25: created, funded,
 a transfer proposed, approved and executed — then the same member set voted to
-replace itself. **Thirteen transactions in blocks 23028–23554, five of them on the
-proving path.**
+replace itself. **Thirteen transactions, twelve of them in blocks 23028–23554 and the
+`membership_lez` deploy earlier at 4459; five are on the proving path.**
 
 | Step | Transaction | Block |
 |---|---|---:|
@@ -138,7 +146,7 @@ proving path.**
 | `rotate_config` | `cb8a3f8b…ea942554` | 23554 |
 
 **Where the proof is, and why it is not in `execute`.** The five rows marked
-*privacy tx* each carry a ~275 kB STARK receipt the sequencer verified against the
+*privacy tx* each carry a ~265 kB STARK receipt the sequencer verified against the
 node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`; `execute` is a 1,413-byte public
 transaction with no proof in it, and that is deliberate. An approval is where
 membership is proven, so that is where the proof belongs. `execute` presents
@@ -161,7 +169,7 @@ count.
 **The number only a real execution could produce is the treasury's:**
 `fund_treasury` put **2** in and `execute` moved **1** out, and the other side of
 that move is an account that is *not* the program's — the recipient
-`8kexXda8…` goes **0 → 1**, held by the native transfer program, which is what
+`8kexXda8…` goes **1 → 2**, held by the native transfer program, which is what
 makes what it received spendable instead of stranded.
 
 Six accounts are owned by the verifier — multisig `C9CgRDNf…`, treasury
@@ -178,8 +186,10 @@ binary committed here. Nothing in that chain needs us.
 
 It recomputes both deploy hashes from the committed bytecode, resolves all
 thirteen transactions, and asserts the variant each must carry — the five
-approvals `PrivacyPreserving` rather than `Public`, which is the part a block
-explorer cannot show you. Its first step is an impossible hash that must return
+approvals `PrivacyPreserving` rather than `Public`. The explorer shows this too —
+each approval page reads `Type: Privacy-Preserving Transaction` with
+`Proof Size: 264907 bytes`, and `execute` reads `Public Transaction` and `0
+bytes` — so the script agrees with a third party rather than standing in for one. Its first step is an impossible hash that must return
 null, so a resolving hash afterwards means something. `./scripts/verify-onchain.sh artifacts/testnet "$(cat artifacts/testnet/proposal_id)"`
 reads the accounts back and decodes every record at the offsets
 `docs/account-layout.md` publishes, including `tiers_hash` and `superseded_by`.
@@ -218,7 +228,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `crates/multisig-sdk`, transport-agnostic: it opens no socket and touches no filesystem.
 
 - [x] **Provide a Logos Basecamp app GUI with local build instructions, downloadable assets, and loadable in Logos app (Basecamp).**
-  `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB), built with the **real `lgx`** from `logos-co/logos-package` and passing `lgx verify`, carrying **two variants** — `darwin-arm64` and `linux-amd64` — so it opens on the machine the evaluator actually reviews on.
+  `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.5 MB), built with the **real `lgx`** from `logos-co/logos-package` and passing `lgx verify`, carrying **two variants** — `darwin-arm64` and `linux-amd64` — so it opens on the machine the evaluator actually reviews on.
 
   **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared loadable: the module loads, and pressing *Status* against a multisig folder returns that deployment's live state — the then-current one, with its approval markers. The tile renders whatever the CLI shipped inside the package prints rather than computing anything itself, and `app/README.md` says which session was driven and against what, rather than re-quoting it for a later deployment. Doing that found three packaging defects — a Qt newer than the one Basecamp runs, a private IID, and an extra virtual that shifted every later vtable slot — all fixed, described in `app/README.md`, and now refused by `scripts/package-lgx.py`. **The Linux variant is load-tested against Basecamp's own Qt**, extracted from the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the click, since headless there is nothing to click. That half ran on macOS.
 
@@ -256,7 +266,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   — deployment steps, program addresses, and instructions for both the CLI and the Basecamp app.
 
 - [x] **A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub runner. `scripts/demo.sh` is the five-second tour without a sequencer, and shows the tier and a rotation as well.
+  `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, and **2 h 12 to 2 h 49** across the green runs on a GitHub runner, 2 h 39 for the one cited above. `scripts/demo.sh` is the twenty-second tour without a sequencer — it reads the live chain, and shows the tier and a rotation as well.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
@@ -271,7 +281,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   where the prover works and the screen does not change is sped up, its factor
   written across the picture while it plays. The same session runs unedited and
   unaccelerated at <https://youtu.be/rM_tP1-xb54>, so the speed-up is checkable
-  rather than taken on trust. The other film is the 47-second reading of the
+  rather than taken on trust. The other film is the 66-second reading of the
   public-testnet deployment, and <https://youtu.be/cPVsWWBVEeE> is a narrated
   walkthrough kept for the commentary, from before this redeploy.
 
@@ -280,7 +290,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 ### Functionality
 
 Six instructions: `create_multisig`, `fund_treasury`, `create_proposal`,
-`approve`, `execute`, `rotate_config`. Seven documented bindings, each with
+`approve`, `execute`, `rotate_config`. Nine documented bindings, each with
 adversarial coverage. **Limitations, stated rather than buried:** proposals do not
 expire, and a rotation is visible — an observer sees that one happened and which
 configuration replaced which, only not who voted for it.

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -18,7 +18,7 @@ are anchored by PDA address, so neither can be invented or lowered.
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
 - **Reviewed commit:**
-  [`73d360d`](https://github.com/edenbd1/lp-0002-private-multisig/tree/73d360db452d308af73a9349a12b36d83eceb2d5).
+  [`ad45806`](https://github.com/edenbd1/lp-0002-private-multisig/tree/ad45806cdf198aea08edfce39833ee1761fb83c9).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -31,7 +31,7 @@ are anchored by PDA address, so neither can be invented or lowered.
   the suites pass.
   The full lifecycle against a standalone LEZ sequencer — `RISC0_DEV_MODE=0`,
   building LEZ at a pinned revision and driving the whole lifecycle against it
-  with real proofs — runs on `1759015`, three commits before the reviewed one: run
+  with real proofs — runs on `1759015`: run
   `33098969090`, green in 2 h 39, its log printing `RISC0_DEV_MODE=0` and closing
   on `2 approval(s) recorded against a requirement of 2`. What separates the two
   is four files — two documents, the film's transcript and its anchor — with no
@@ -41,7 +41,7 @@ are anchored by PDA address, so neither can be invented or lowered.
   across every commit in the range, so the thing being proved has not moved
   underneath the proof.
 - **Video:** two narrated films play inline in the pull request — the whole
-  lifecycle against a standalone sequencer with two real proofs, and a 66-second
+  lifecycle against a standalone sequencer with two real proofs, and a 76-second
   reading of this deployment. Both were shot for this submission and both show
   their own commit on screen. Earlier recordings of an earlier deployment are not
   linked: they carry superseded identifiers, and pointing a reviewer at a film
@@ -280,7 +280,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   where the prover works and the screen does not change is sped up, its factor
   written across the picture while it plays. The factor is 64, written across
   the picture for the whole of the sped-up stretch, so a compressed shot is
-  announced rather than slipped past. The other film is the 66-second reading of
+  announced rather than slipped past. The other film is the 76-second reading of
   the public-testnet deployment.
 
 ## FURPS Self-Assessment
@@ -334,7 +334,7 @@ than the host crate — and every one of the twenty-seven error codes is exercis
 against that binary. Thirteen mutations were run against the guards the tier and
 rotation work added, each rebuilt through the reproducible Docker build with the
 binary's hash required to move first; thirteen were caught, recorded in the
-message of commit `9743306`. That run was by hand with no harness committed, so
+message of commit `d9f368c`. That run was by hand with no harness committed, so
 unlike everything else here it is a claim from the history rather than something
 a clone re-derives. The two guest crates
 target `riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -146,7 +146,7 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
       The only trace is a marker PDA seeded by a secret-bound nullifier. See
-      [`docs/security.md`](docs/security.md), which states the threat model
+      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md), which states the threat model
       against three adversaries including the insider.
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
       without recording which members approved.** `execute`, checks 5–7.
@@ -159,14 +159,14 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Proof generation runs client-side on a standard laptop.** Approvals are
       built by `msig approve-args` and proved locally; **440 s and 469 s** for the
       two approvals of the LEZ v0.2.4 run that produced the deployed lifecycle in
-      [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), timed by the script itself.
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md), timed by the script itself.
       Read them per machine, not as one number —
-      [`docs/cu-costs.md`](docs/cu-costs.md) tabulates seven measurements across
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md) tabulates seven measurements across
       two machines and two LEZ versions, spanning 149 s to 4033 s.
 - [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, a
       proposal published, two approvals gathered on the privacy-preserving path,
       and executed against the fixed verifier. Seven transactions, all live; see
-      [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md).
 
       **What "threshold-gated action" means here**, since the criterion offers
       *treasury transfer or parameter change* as examples and it is fair to ask
@@ -247,7 +247,7 @@ whose derivation is unchanged in v0.2.4.
       `Logos Core started successfully!` and scanning the plugins directory.
       What is *not* claimed is the click: a UI app's widget loads on click, and
       headless there is nothing to click, so that half was exercised on macOS.
-      Method in [`app/README.md`](app/README.md).
+      Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/app/README.md).
 
       **It was installed and driven in Logos Basecamp 0.2.2**, not merely
       declared loadable: the committed package extracts into the user plugins
@@ -275,13 +275,13 @@ whose derivation is unchanged in v0.2.4.
       command returns. This is not incidental: proving takes minutes, not an
       approval, so a real threshold *is* gathered across sessions and days.
 - [x] **Deterministic, documented error codes.** Thirteen, `5001`–`5013`, in
-      [`docs/error-codes.md`](docs/error-codes.md), each mapped to the attack it
+      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/error-codes.md), each mapped to the attack it
       stops and the test that proves it.
 
 ### Performance
 
 - [x] **CU cost of each on-chain operation documented.**
-      [`docs/cu-costs.md`](docs/cu-costs.md): `approve` 337,105 user cycles;
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md): `approve` 337,105 user cycles;
       `execute` linear in M at ~48,600 per approval; all inside one segment at
       1.56 % of the public budget. Measured by replaying through the sequencer's
       own executor, reproducible with one command.
@@ -296,7 +296,7 @@ whose derivation is unchanged in v0.2.4.
       **executor** on every push — same executor, same input order, same 32M
       session limit — which is what makes 25 adversarial rejections cheap enough
       to gate a commit. On top of that,
-      [`.github/workflows/e2e-local-sequencer.yml`](.github/workflows/e2e-local-sequencer.yml)
+      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/.github/workflows/e2e-local-sequencer.yml)
       starts the actual `sequencer_service` binary in **standalone mode** and
       drives the whole lifecycle against it over JSON-RPC. It is scheduled
       rather than per-push because it builds the LEZ workspace and then
@@ -354,7 +354,7 @@ deployed lifecycle — public testnet, LEZ v0.2.4, measured 2026-08-12 — timed
 timing to `lifecycle.tsv` in the run's working directory as it goes; that
 directory is deliberately not committed, because it also holds the member keys,
 so the record a reviewer can open is the table in
-[`docs/cu-costs.md`](docs/cu-costs.md), which gives every figure with the machine
+[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md), which gives every figure with the machine
 and the LEZ version it was taken on.
 
 Two things cut against this submission and both belong here. **The version got
@@ -393,25 +393,25 @@ the Scope section adds a seventh. Rather than leave them to be hunted for:
 | Required topic | Where |
 |---|---|
 | **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
-| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](docs/security.md) |
-| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
-| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) shows a clean rebuild reproducing `5bb40082…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
-| **Security assumptions** | [`docs/security.md`](docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
-| **Known limitations** | [`docs/security.md`](docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
-| **Integration instructions** | [`README.md`](README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for deployment |
-| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
+| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) |
+| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
+| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `5bb40082…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
+| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
+| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
+| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) for deployment |
+| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
 
 ## Supporting Materials
 
-- [`docs/security.md`](docs/security.md) — threat model, what is hidden from
+- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) — threat model, what is hidden from
   whom, what is deliberately public, residual risks
-- [`docs/lez-account-model.md`](docs/lez-account-model.md) — the nonce and
+- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/lez-account-model.md) — the nonce and
   `program_owner` constraints, which are the incompatibility this prize exists
   to solve
-- [`docs/error-codes.md`](docs/error-codes.md) — all 13 codes, the attack each
+- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/error-codes.md) — all 13 codes, the attack each
   stops, and the test behind it
-- [`docs/cu-costs.md`](docs/cu-costs.md)
-- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)
+- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md)
+- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md)
 - Narrated demo video: <https://youtu.be/cPVsWWBVEeE>
 
 ## Two LEZ behaviours worth knowing

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -8,7 +8,7 @@ A threshold multisig for LEZ where members hold shielded accounts, approvals
 leave no public trace of who voted, and the chain records only that a threshold
 was met — not which members met it, **including to the other members**.
 
-The membership proof is genuinely verified on chain. Each `approve` declares a
+The membership proof is genuinely verified on chain: each `approve` declares a
 `ChainedCall` to a LEZ-native membership program, so LEZ's privacy circuit
 composes it with a real `env::verify` and the sequencer checks the receipt
 against the node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`. The member set and the
@@ -17,155 +17,90 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** [`3d19fd5`](https://github.com/edenbd1/lp-0002-private-multisig/commit/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95).
-  Every repository link below names that commit rather than `main`, so the
-  version under review cannot move after this is opened.
+- **Reviewed commit:** [`3d19fd5`][commit]. Every link below names that commit
+  rather than `main`, so the version under review cannot move after this opens.
 - **CI on that exact commit, both green:** [the host suite and the
-  deployed-binary audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727175015)
-  — 97 tests, of which 59 run the built verifier through the sequencer's own
-  executor — and [the full lifecycle against a standalone LEZ
-  sequencer](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727211438),
-  2 h 12 with `RISC0_DEV_MODE=0`, which builds LEZ at a pinned revision, starts
-  the sequencer, and drives the whole 2-of-3 lifecycle against it — 2 h 05 of
-  that is the lifecycle step alone, two real proofs included.
+  deployed-binary audit][ci1] — 97 tests, 59 of which run the built verifier
+  through the sequencer's own executor — and [the full lifecycle against a
+  standalone LEZ sequencer][ci2], 2 h 12 with `RISC0_DEV_MODE=0`, which builds
+  LEZ at a pinned revision, starts the sequencer, and drives the whole 2-of-3
+  lifecycle against it, two real proofs included.
 - **Video:** a 47-second narrated reading of this deployment is attached to
-  [the pull request](https://github.com/logos-co/lambda-prize/pull/125) and plays
-  inline there. The ten-minute narrated walkthrough at
-  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-24 redeploy, so the
-  identifiers on screen in it are the superseded ones.
+  [the pull request][pr] and plays inline. The ten-minute walkthrough at
+  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-24 redeploy, so its
+  on-screen identifiers are the superseded ones.
 
 ## Approach
 
 ### The decision that shaped everything: which transaction path
 
-The first thing I checked was whether a LEZ **public** transaction verifies a
-proof. It does not — the sequencer re-executes the program host-side
-(`lee/state_machine/src/program/mod.rs:73-77`, commented *"Execute the program
-(without proving)"*). A multisig built there would be a signature check wearing
-a zero-knowledge costume: the sequencer would re-run the approval logic in the
-clear, so nothing would be proved and nothing would be private.
+A LEZ **public** transaction does not verify a proof — the sequencer re-executes
+the program host-side (`lee/state_machine/src/program/mod.rs:73-77`, commented
+*"Execute the program (without proving)"*). A multisig built there would be a
+signature check wearing a zero-knowledge costume.
 
 The path that works is the **privacy-preserving transaction**: the client proves
 locally, LEZ's privacy circuit composes each chained call with a real
-`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`), and
-the sequencer verifies the receipt against the pinned circuit id.
+`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`),
+and the sequencer verifies the receipt against the pinned circuit id. For that
+composition the callee must *be* a LEZ program emitting a `ProgramOutput` — a
+standalone Risc0 guest commits a bespoke journal that cannot decode as one and is
+rejected with `ProgramExecutionFailed`. That is why `membership_lez` exists in
+the shape it does.
 
-For that composition to happen, the callee must *be* a LEZ program emitting a
-`ProgramOutput` — a standalone Risc0 guest commits a bespoke journal that cannot
-decode as one, and the sequencer rejects the call with `ProgramExecutionFailed`.
-That is why `membership_lez` exists in the shape it does rather than as a plain
-guest.
-
-It also has a privacy consequence I depend on: a privacy `Message` publishes
-commitments and nullifiers and carries neither `program_id` nor
-`instruction_data`, so the witness can travel in the instruction. On the public
-path the same bytes would be published verbatim — so the membership program must
-never be invoked there, and is not.
+It also has a privacy consequence I depend on: a privacy `Message` carries
+neither `program_id` nor `instruction_data`, so the witness can travel in the
+instruction. On the public path those same bytes would be published verbatim — so
+the membership program must never be invoked there, and is not.
 
 ### Anchoring, and the three attacks it closes
 
 A membership proof establishes membership against whatever root the statement
-names, which on its own is worthless: anyone can build a one-leaf tree holding
-themselves. So:
+names, which alone is worthless: anyone can build a one-leaf tree holding
+themselves. So the member set is anchored **by address** — the multisig is a PDA
+seeded by `[multisig_id, config_hash]`, only `create_multisig` initialises it, and
+an invented root gives an address nobody created, whose owner is the default
+(`5003`). The threshold sits inside the same hash,
+`config_hash = H(member_root ‖ threshold)`, so `threshold = 1` against a 3-of-5
+set resolves to a PDA nobody created either; no code path anywhere reads a
+threshold from caller-supplied data. Folding it into the address rather than
+storing it in account data makes the forgery *unrepresentable* rather than merely
+checked.
 
-**The member set is anchored by address.** The multisig account is a PDA seeded
-by `[multisig_id, config_hash]`, and only `create_multisig` initialises it. An
-invented root gives a different address that was never created, whose owner is
-the default — rejected (`5003`).
-
-**The threshold is inside the same hash.** `config_hash = H(member_root ‖ threshold)`.
-Supplying `threshold = 1` against a 3-of-5 set resolves to a PDA nobody created —
-rejected (`5003`). There is no code path anywhere that reads a threshold from
-caller-supplied data. I considered storing the threshold in the account's data
-instead; folding it into the address is strictly stronger, because it makes the
-forgery unrepresentable rather than merely checked.
-
-**Approvals bind to the exact action.** This one took me longest to see. If
-approvals were scoped to a proposal id alone, a proposer could publish a harmless
-action, collect M approvals, then publish a second proposal under the same id
-carrying a malicious action — and the approvals already gathered would count for
-it. So `proposal_ref = H(multisig_id ‖ proposal_id ‖ action_hash)`, and both the
-nullifier and the marker seed derive from it. It closes the mirror-image
-griefing vector too: a junk action published under a real proposal id cannot burn
-that proposal's markers, because they land at different addresses.
+The third attack took me longest to see. If approvals were scoped to a proposal
+id alone, a proposer could publish a harmless action, collect M approvals, then
+republish a malicious one under the same id — and the approvals already gathered
+would count for it. So `proposal_ref = H(multisig_id ‖ proposal_id ‖ action_hash)`,
+and both the nullifier and the marker seed derive from it. That also closes the
+mirror image: a junk action under a real proposal id cannot burn that proposal's
+markers.
 
 ### Making M markers mean M distinct members
 
 Each approval occupies a PDA seeded by
 `H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
-`nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`. Two different
-addresses therefore imply two different secrets. `execute` checks the nullifiers
-are pairwise distinct (`5011`), that each account presented is the marker PDA for
-the nullifier it was paired with *on this proposal* (`5012`), and that the
-verifier program owns it (`5013`) — which it can only do if a membership proof
-was verified on chain.
-
-The distinctness check is quadratic in M deliberately: M is a multisig
-threshold, a small number, and a sort would cost more cycles than it saves. The
-measured cost confirms it — `execute` scales at ~48,600 user cycles per approval.
-
-### What did not work
-
-- **That film as text, and a check that the text is this film's:**
-  [`recordings/lp-0002-threshold-moves-value.srt`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/recordings/lp-0002-threshold-moves-value.srt)
-  is the narration as spoken, so the film can be read and grepped rather than
-  watched. `./scripts/check-transcript.py` ties it to the picture: cues ordered
-  and landing inside the film, and four anchors requiring the frame to show what
-  the narration is talking about at the second it says it — where the line is
-  "both approvals carry the privacy-preserving variant", the frame there must
-  show the variant column. The narration is spoken and never on screen, so those
-  anchors are the part a transcript written from memory could not satisfy. It
-  refuses to pass on structure alone, because its first version did exactly that.
-  [`docs/recording-evidence.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/recording-evidence.md) carries
-  the measured output, says which commit the film shows and what separates it
-  from the reviewed one, and ends with what it does **not** establish.
-- **Storing the threshold in account data.** Workable, but it makes the forgery
-  *representable* and then rejected, rather than unrepresentable. Address
-  anchoring is the stronger construction and needs no data writes at all.
-- **Scoping approvals to `proposal_id`.** See the bait-and-switch above.
-- **Enabling risc0's `prove` feature** so the tests execute in-process rather
-  than through an `r0vm` subprocess. It drags in the GPU backends, and on macOS
-  that means Metal, which needs an Xcode component most machines lack. CI
-  installs `r0vm` instead.
-
-### Why the Logos stack
-
-The whole design rests on two properties nothing centralised provides. First,
-**trustless execution with real proof composition**: the threshold is enforced by
-a circuit the sequencer verifies, not by a server that could be asked to lie
-about who voted. Second, **shielded accounts as a first-class primitive**: a
-member's approval is bound to a secret that never appears on chain, so
-unlinkability holds against the other members and not just against outsiders. A
-centralised multisig service can hide the member list from the public; it cannot
-hide it from itself, and it cannot prove to a third party that it counted
-honestly.
+`nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`, so two different
+addresses imply two different secrets. `execute` checks the nullifiers are
+pairwise distinct (`5011`), that each account presented is the marker PDA for the
+nullifier it was paired with *on this proposal* (`5012`), and that the verifier
+owns it (`5013`) — which it can only do if a membership proof was verified on
+chain.
 
 ### Targeting the current testnet, and the SPEL patch that took
 
-The prize says it targets the *current* LEZ testnet. That testnet was reset onto
-a newer chain in August: everything deployed against **v0.2.0** stopped being
-accepted — not "went stale", but rejected outright, with submitted transactions
-returning a hash whose `getTransaction` is `null`. Everything here was rebuilt
-against **LEZ v0.2.4**, redeployed, and the whole lifecycle re-run. Every hash
-and address in this submission comes from that run.
+The testnet was reset onto a newer chain in August, and everything deployed
+against **v0.2.0** stopped being accepted — not "went stale", but rejected
+outright, with submitted transactions returning a hash whose `getTransaction` is
+`null`. Everything here was rebuilt against **LEZ v0.2.4**, redeployed, and the
+whole lifecycle re-run.
 
-That upgrade is also why this repository vendors SPEL. Its latest release,
-**v0.6.0**, still pins LEZ v0.2.0 in about twenty places, and there is no
-released SPEL that builds against a current LEZ — so "use SPEL" and "transact on
-the current testnet" could not both be satisfied with anything published.
-`vendor/spel` is upstream v0.6.0 with the minimum changes to do both, and
-[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/vendor/spel/PATCH.md)
-documents every one of them, how to reproduce the directory, and when it should
-be deleted. Three things broke: private-PDA derivation gained an ML-KEM 768
-viewing key, `WalletCore::from_env()` became async, and the wallet went
-multi-sequencer.
-
-Worth flagging because it is the kind of thing that wastes a reviewer's day:
-released SPEL *builds* cleanly against v0.2.4's testnet and then fails at run
-time on every instruction with `missing field 'sequencer_addr'`, because the
-wallet config format changed. The private-PDA API question is left to SPEL's
-maintainers rather than patched over here — this project uses only public PDAs,
-whose derivation is unchanged in v0.2.4.
+That is also why this repository vendors SPEL: release **v0.6.0** still pins LEZ
+v0.2.0 in about twenty places, so "use SPEL" and "transact on the current
+testnet" could not both be satisfied with anything published. `vendor/spel` is
+upstream v0.6.0 with the minimum changes to do both, documented change by change
+in [`vendor/spel/PATCH.md`][patch]. Worth flagging because it wastes a reviewer's
+day: released SPEL *builds* cleanly against v0.2.4 and then fails at run time on
+every instruction with `missing field 'sequencer_addr'`.
 
 ## Success Criteria Checklist
 
@@ -173,9 +108,9 @@ whose derivation is unchanged in v0.2.4.
 
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
-      The only trace is a marker PDA seeded by a secret-bound nullifier. See
-      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md), which states the threat model
-      against three adversaries including the insider.
+      The only trace is a marker PDA seeded by a secret-bound nullifier;
+      [`docs/security.md`][sec] states the threat model against three adversaries
+      including the insider.
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
       without recording which members approved.** `execute`, checks 5–7.
 - [x] **A member cannot approve the same proposal twice.** The nullifier is
@@ -185,169 +120,101 @@ whose derivation is unchanged in v0.2.4.
       account.** `execute` consumes marker addresses and is signed by an executor
       who need not be a member at all.
 - [x] **Proof generation runs client-side on a standard laptop.** Approvals are
-      built by `msig approve-args` and proved locally; **440 s and 469 s** for the
-      two approvals of the LEZ v0.2.4 run that produced the deployed lifecycle in
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md), timed by the script itself.
-      Read them per machine, not as one number —
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md) tabulates seven measurements across
-      two machines and two LEZ versions, spanning 149 s to 4033 s.
-- [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, its
-      treasury funded, a proposal published, two approvals gathered on the
-      privacy-preserving path, and executed. **Eight transactions** in blocks
-      20856-20880, all live; see
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md).
-
-  **What "threshold-gated action" means here.** The criterion offers
-  *treasury transfer or parameter change* as examples, and this is the first
-  of them, performed rather than described. The multisig owns a treasury
-  PDA; `fund_treasury` puts value into it; the proposal names a recipient
-  and an amount, both bound into the proposal's address by hash; and
-  `execute` moves the amount out of the treasury and into the recipient in
-  the same transaction, which is the only shape LEZ accepts — a debit and a
-  credit that balance. The recipient is held by the native transfer program
-  rather than by the verifier, so what it receives is spendable rather than
-  stranded inside a program with no instruction to release it.
-
-  An earlier version of this submission stopped one step short: it proved
-  the threshold, wrote an execution marker, and left performing the transfer
-  to a caller, on the argument that a multisig is an authorisation primitive
-  and that coupling it to one action type would make it a treasury program.
-  The argument is still true and the primitive is still general — the
-  execution marker is a PDA at a derivable address, owned by the verifier,
-  whose existence *is* the proof that M distinct secret-bound nullifiers
-  resolved, and any program can gate on it. But a criterion that names a
-  treasury transfer is better answered by a treasury transfer, and a
-  treasury balance falling from 2 to 1 is a fact a reviewer reads off the
-  chain in one call. That is why the verifier was rebuilt and redeployed on
-  2026-08-24, and why every account address in this document moved with it:
-  on LEZ a program's identity *is* its ImageID, and every PDA is derived
-  from it.
-
-  **On the block explorer.** Its index trails the sequencer — measured on
-  this chain at roughly an hour and three quarters — so a transaction
-  submitted minutes ago reads "Transaction not found" there while
-  `getTransaction` already resolves it. That is an indexing delay, not a
-  gap, and it affects anything recent by anyone. The deploy of
-  `membership_lez` sits at block 4459 and renders today; the seven
-  transactions of the 2026-08-24 lifecycle are recent, and render once the
-  index reaches block 20880. `./scripts/verify-onchain-lifecycle.sh` does
-  not depend on that index at all: it asks the sequencer, and it checks the
-  variant each transaction carries — which the explorer could not tell you
-  even fully caught up.
-
-  One correction, because this document used to state the opposite. It said
-  the explorer was a WASM app serving an identical shell for every hash, so
-  that comparing response sizes could not tell an indexed transaction from
-  one that cannot exist. That was true when `./scripts/check-explorer.py`
-  was written — it is why the script drives a browser at all — and it is not
-  true now: re-measured on **2026-08-15**, the explorer renders server-side,
-  and a single `curl` separates the two cases by size alone. The script
-  still renders each page headless against an impossible-hash control, and
-  aborts if that control ever renders as a *found* transaction rather than
-  report verdicts against a baseline that would be meaningless.
-
-  `docs/DEPLOYMENT.md` gives a one-line `curl` per hash, and
-  `./scripts/verify-onchain.sh` does the stronger check — it reads the five
-  accounts the lifecycle created and confirms the verifier program owns
-  them, which no transaction lookup can fake.
+      built by `msig approve-args` and proved locally: **440 s and 469 s** for the
+      two approvals of the deployed run, timed by the script itself. Read per
+      machine, not as one number — [`docs/cu-costs.md`][cu] tabulates seven
+      measurements across two machines and two LEZ versions, 149 s to 4033 s.
+- [x] **A reference integration on LEZ testnet.** The lifecycle below.
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
-  approved by threshold, and executed — and the execution moves value.**
-  A 2-of-3 multisig, its treasury funded, a proposal published, two
-  approvals gathered on the privacy-preserving path, and executed, in blocks
-  20856-20880. Six accounts, all owned by the verifier:
+      approved by threshold, and executed — and the execution moves value.**
+
+  A 2-of-3 multisig created, its treasury funded, a proposal published, two
+  approvals gathered on the privacy-preserving path, and executed: **eight
+  transactions** in blocks 20856–20880, all live. The criterion offers *treasury
+  transfer or parameter change* as examples and this is the first, performed
+  rather than described — `execute` moves the amount out of the treasury and into
+  the recipient in one transaction, a debit and a credit that balance, which is
+  the only shape LEZ accepts.
+
+  Six accounts, all owned by the verifier:
   multisig [`Hx7Ni2ri…`](https://explorer.testnet.lez.logos.co/account/Hx7Ni2riURJfgng4QAXb3RBq9ZMjrvwj7JREjut9PuBC),
   treasury [`xtngupTp…`](https://explorer.testnet.lez.logos.co/account/xtngupTp3tcQU9faCbND73KhCpYqfBqKhmoepQAXoVx),
   proposal [`9EjLSnKj…`](https://explorer.testnet.lez.logos.co/account/9EjLSnKjXB4r8SgBEHcgqf36nkqfyUVXuqSsDzCTRvg7),
   execution marker [`BP6buTDd…`](https://explorer.testnet.lez.logos.co/account/BP6buTDdFThPYWU3NFGSsD8k3ymewStQo4hj86tAwq1a),
   and the two approval markers. Their **Program Owner** is
-  `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, which base58-decodes to
+  `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, base58-decoding to
   `1346b652…98ff4e1e` — exactly the ImageID `spel program-id
-  artifacts/programs/multisig_verifier.bin` computes from the binary
-  committed here. Nothing in that chain needs us.
+  artifacts/programs/multisig_verifier.bin` computes from the binary committed
+  here. Nothing in that chain needs us.
 
   The number only a real execution could produce is the treasury's:
-  `fund_treasury` put **2** into it and `execute` moved **1** out, and the
-  other side of that move is a seventh account that is *not* the
-  program's — the recipient
+  `fund_treasury` put **2** in and `execute` moved **1** out, and the other side
+  of that move is a seventh account that is *not* the program's — the recipient
   [`8kexXda8…`](https://explorer.testnet.lez.logos.co/account/8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn),
-  **0 → 1**, held by the native transfer program rather than by the
-  verifier, which is what makes what it received spendable instead of
-  stranded.
+  **0 → 1**, held by the native transfer program, which is what makes what it
+  received spendable instead of stranded.
 
-  `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean
-  clone in about five seconds and takes no arguments: it recomputes both
-  deploy hashes from the committed bytecode, resolves the eight
-  transactions, and asserts the variant each one carries — the two
-  approvals must be `PrivacyPreserving` and not `Public`, which is the part
-  a block explorer cannot show you. `./scripts/verify-onchain.sh` is the
-  deeper pass: it reads the six accounts back and decodes every record at
-  the byte offsets published in `docs/account-layout.md`.
-
-  The eight, in order, so a reader can follow the lifecycle rather than take
-  the block range on trust:
+  The eight, in order:
 
   | Step | Transaction | Block |
   |---|---|---|
-  | deploy `membership_lez` | [`fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
-  | deploy `multisig_verifier` | [`2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2`](https://explorer.testnet.lez.logos.co/transaction/2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2) | 20856 |
-  | `create_multisig` | [`a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55`](https://explorer.testnet.lez.logos.co/transaction/a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55) | 20857 |
-  | `fund_treasury` | [`2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2`](https://explorer.testnet.lez.logos.co/transaction/2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2) | 20858 |
-  | `create_proposal` | [`b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826`](https://explorer.testnet.lez.logos.co/transaction/b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826) | 20859 |
-  | `approve` (member A, **privacy tx**) | [`d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0`](https://explorer.testnet.lez.logos.co/transaction/d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0) | 20869 |
-  | `approve` (member B, **privacy tx**) | [`9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719`](https://explorer.testnet.lez.logos.co/transaction/9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719) | 20879 |
-  | `execute` | [`00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae`](https://explorer.testnet.lez.logos.co/transaction/00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae) | 20880 |
+  | deploy `membership_lez` | [`fb8eb10f…a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
+  | deploy `multisig_verifier` | [`2d6f720e…3231e82e2`](https://explorer.testnet.lez.logos.co/transaction/2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2) | 20856 |
+  | `create_multisig` | [`a8d8422a…c9a25ab55`](https://explorer.testnet.lez.logos.co/transaction/a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55) | 20857 |
+  | `fund_treasury` | [`2844eef1…a30bb6a5c2`](https://explorer.testnet.lez.logos.co/transaction/2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2) | 20858 |
+  | `create_proposal` | [`b194da9b…71fed9826`](https://explorer.testnet.lez.logos.co/transaction/b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826) | 20859 |
+  | `approve` (member A, **privacy tx**) | [`d1381309…36e70a91c0`](https://explorer.testnet.lez.logos.co/transaction/d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0) | 20869 |
+  | `approve` (member B, **privacy tx**) | [`9f7c541c…ceed7219719`](https://explorer.testnet.lez.logos.co/transaction/9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719) | 20879 |
+  | `execute` | [`00ea6838…2be7f75ae`](https://explorer.testnet.lez.logos.co/transaction/00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae) | 20880 |
 
-  **On the explorer, these are recent.** The indexer trails the sequencer,
-  so freshly-created accounts can read `Program Owner:
-  11111111111111111111111111111111` and `Data: 0 bytes` for a while after
-  they exist. `getAccount` answers correctly the whole time, and both
-  scripts above use it.
+  `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean clone
+  in about five seconds, no arguments: it recomputes both deploy hashes from the
+  committed bytecode, resolves the eight transactions, and asserts the variant
+  each carries — the two approvals must be `PrivacyPreserving`, which is the part
+  a block explorer cannot show you. `./scripts/verify-onchain.sh` reads the six
+  accounts back and decodes every record at the byte offsets published in
+  `docs/account-layout.md`.
+
+  **These are recent, and the explorer's index trails the sequencer** by about an
+  hour and three quarters — so a fresh account can read `Program Owner:
+  1111…1111` and a recent hash "Transaction not found". That is an indexing
+  delay, not a gap, and it affects anything recent by anyone; `getAccount` and
+  `getTransaction` answer correctly throughout, and both scripts ask the
+  sequencer.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability
 
 - [x] **Provide a module/SDK that can be used to build Logos modules for
-      interacting with the program.** `crates/multisig-sdk`,
-      transport-agnostic: it opens no socket and touches no filesystem.
+      interacting with the program.** `crates/multisig-sdk`, transport-agnostic:
+      it opens no socket and touches no filesystem.
 - [x] **Basecamp app GUI with local build instructions and loadable assets.**
       `app/`, with both the `logos-module-builder` path and a standalone Qt path.
       The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB),
-      built with the **real `lgx`** from `logos-co/logos-package` — the same tool
-      `nix-bundle-lgx` drives — and it passes `lgx verify`. It carries **two
-      variants**, `darwin-arm64` and `linux-amd64`, so it opens on the machine
-      the evaluator actually reviews on; the Linux half is built in Docker by
-      `scripts/build-linux-variant.sh` and the packaged Linux `msig` was run
-      inside a Linux container to confirm it works, not just that it exists.
+      built with the **real `lgx`** from `logos-co/logos-package` and passing
+      `lgx verify`. It carries **two variants**, `darwin-arm64` and
+      `linux-amd64`, so it opens on the machine the evaluator actually reviews
+      on.
 
-  **The Linux variant is load-tested against Basecamp's own Qt, not just
-  built.** Basecamp ships an `x86_64.AppImage` in the same 0.2.2 release;
-  extracted, it bundles the same Qt 6.9.2 as macOS. Running what Basecamp's
-  PluginLoader runs — `QPluginLoader::instance()` then
-  `qobject_cast<IComponent*>` — linked against *that* Qt gives
-  `SUCCESS: loaded + cast to IComponent`. The harness was shown able to
-  fail: a real Qt plugin with a different IID gives `CAST FAILED`. Basecamp
-  itself also boots on Linux with the package installed, reaching
-  `Logos Core started successfully!` and scanning the plugins directory.
-  What is *not* claimed is the click: a UI app's widget loads on click, and
-  headless there is nothing to click, so that half was exercised on macOS.
-  Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/app/README.md).
+  **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared
+  loadable: the module loads (`Successfully loaded UI module`) and pressing
+  *Status* against `artifacts/testnet` returns the live deployment's
+  `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers. Doing that found
+  three packaging defects, all fixed and described in [`app/README.md`][appreadme]
+  — a Qt newer than the one Basecamp runs, a private IID instead of
+  `com.logos.component.IComponent`, and an extra virtual that shifted every later
+  vtable slot — and `scripts/package-lgx.py` now refuses to package a binary with
+  any of them.
 
-  **It was installed and driven in Logos Basecamp 0.2.2**, not merely
-  declared loadable: the committed package extracts into the user plugins
-  directory, the module loads (`Successfully loaded UI module`), and
-  pressing *Status* against `artifacts/testnet` returns the live
-  deployment's `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers.
-  Doing that found three defects in the packaging, all fixed and all
-  described in `app/README.md`: the plugin was built against a Qt newer than
-  the one Basecamp runs, so Qt refused it outright; `Q_DECLARE_INTERFACE`
-  used a private IID instead of `com.logos.component.IComponent`, so the
-  host's `qobject_cast` returned null; and the `IComponent` declaration
-  carried an extra virtual, which shifted every later vtable slot.
-  `scripts/package-lgx.py` now refuses to package a binary with any of
-  those properties.
+  **The Linux variant is load-tested against Basecamp's own Qt**, extracted from
+  the `x86_64.AppImage` in that same release: `QPluginLoader::instance()` then
+  `qobject_cast<IComponent*>` against *that* Qt gives `SUCCESS: loaded + cast to
+  IComponent`, and the harness was shown able to fail — a real Qt plugin with a
+  different IID gives `CAST FAILED`. What is *not* claimed is the click, since
+  headless there is nothing to click; that half was exercised on macOS.
 - [x] **Provide an IDL for the LEZ program, using the SPEL framework.**
       `idl/multisig_verifier.idl.json`, generated from source by
-  `spel generate-idl`.
+      `spel generate-idl`.
 
 ### Reliability
 
@@ -356,65 +223,54 @@ whose derivation is unchanged in v0.2.4.
       fails in microseconds rather than after minutes of proving.
 - [x] **A partial set of approvals is preserved and resumable across client
       restarts.** Every approval is recorded in `proposals/<id>.json` before the
-      command returns. This is not incidental: proving takes minutes, not an
-      approval, so a real threshold *is* gathered across sessions and days.
-- [x] **Deterministic, documented error codes.** Thirteen, `5001`–`5013`, in
-      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/error-codes.md), each mapped to the attack it
-      stops and the test that proves it.
+      command returns — not incidental, since proving takes minutes and a real
+      threshold *is* gathered across sessions and days.
+- [x] **Deterministic, documented error codes.** Twenty-two, `5001`–`5022`, in
+      [`docs/error-codes.md`][ec], each mapped to the attack it stops and the
+      test that proves it.
 
 ### Performance
 
-- [x] **CU cost of each on-chain operation documented.**
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md): `approve` 337,105 user cycles;
-      `execute` linear in M at ~48,600 per approval; all inside one segment at
-      1.56 % of the public budget. Measured by replaying through the sequencer's
-      own executor, reproducible with one command.
+- [x] **CU cost of each on-chain operation documented.** [`docs/cu-costs.md`][cu]:
+      `approve` 337,105 user cycles; `execute` linear in M at ~48,600 per
+      approval; all inside one segment at 1.56 % of the public budget. Measured
+      by replaying through the sequencer's own executor, reproducible with one
+      command.
 
 ### Supportability
 
 - [x] **Deployed and tested on LEZ devnet/testnet.** Both programs deployed;
       full lifecycle run and independently re-verifiable over JSON-RPC.
 - [x] **E2E integration tests run against a LEZ sequencer (standalone mode), in
-      CI.** Two layers, because they answer different questions.
-      `multisig-verifier-tests` runs the built binary through the sequencer's own
-      **executor** on every push — same executor, same input order, same 32M
-      session limit — which is what makes 25 adversarial rejections cheap enough
-      to gate a commit. On top of that,
-      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/.github/workflows/e2e-local-sequencer.yml)
-      starts the actual `sequencer_service` binary in **standalone mode** and
-      drives the whole lifecycle against it over JSON-RPC. It is scheduled
-      rather than per-push because it builds the LEZ workspace and then
-      generates a real proof; both are CI, and only one of them can be fast.
+      CI.** Two layers. `multisig-verifier-tests` runs the built binary through
+      the sequencer's own **executor** on every push — same executor, same input
+      order, same 32M session limit — which is what makes 25 adversarial
+      rejections cheap enough to gate a commit. On top of that,
+      [`e2e-local-sequencer.yml`][e2eyml] starts the actual `sequencer_service`
+      binary in **standalone mode** and drives the whole lifecycle against it over
+      JSON-RPC, scheduled rather than per-push because it builds the LEZ
+      workspace and then generates a real proof.
 - [x] **CI green on the default branch.** Ubuntu and macOS both.
 - [x] **README documents end-to-end usage** — deployment steps, program
-      addresses, and step-by-step instructions for both the CLI and the Basecamp
-      app, the latter verified on LogosBasecamp 0.2.2.
+      addresses, and instructions for both the CLI and the Basecamp app.
 - [x] **Reproducible demo script working against a real local sequencer with
       `RISC0_DEV_MODE=0`.** `scripts/e2e-local-sequencer.sh` starts a real
       standalone sequencer, funds a throwaway wallet from its genesis vault,
       deploys both programs onto that fresh chain, and runs create → propose →
-      *real Risc0 approvals* → execute, then reads the five resulting accounts
-      back off it. Nothing mocked, `RISC0_DEV_MODE=0` throughout: **1333 s** for
-      a 2-of-3 on an Apple-silicon laptop, of which **444 s** and **704 s** are
-      the two real proofs, and **2 h 12** on a GitHub `ubuntu-latest` runner —
-      both measured, neither generalising. ("About eight minutes" stood here
-      until the v0.2.4 migration; it was a v0.2.0 figure and
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md)
-      retracts it.) `scripts/demo.sh` remains the five-second tour for readers
-      who want the rejections and the cost table without a sequencer.
+      *real Risc0 approvals* → execute, then reads the resulting accounts back off
+      it. Nothing mocked, `RISC0_DEV_MODE=0` throughout: **1333 s** for a 2-of-3
+      on an Apple-silicon laptop, of which **444 s** and **704 s** are the two
+      real proofs, and **2 h 12** on a GitHub runner. `scripts/demo.sh` is the
+      five-second tour without a sequencer.
 - [x] **Recorded narrated video demo.** <https://youtu.be/cPVsWWBVEeE> — the
       terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any
       proving starts, and the approval is a real proof generated in one
-      uninterrupted take, with its wall clock printed at the end. It is the
-      recording that satisfies this criterion, because it is the one that shows
-      proving. It also predates the 2026-08-24 redeploy, so the identifiers on
-      screen in it are the superseded ones — said here as well as in
-      [Summary](#summary), so a reader who arrives at this line first is not left
-      to discover it by clicking. The deployment under review is what the
-      47-second film attached to [the pull
-      request](https://github.com/logos-co/lambda-prize/pull/125) reads back off
-      the chain; it shows no proving, which is why it is not offered as the
-      answer here.
+      uninterrupted take with its wall clock printed at the end. That is what
+      satisfies this criterion, because it is the recording that shows proving.
+      It predates the 2026-08-24 redeploy, so its on-screen identifiers are the
+      superseded ones; the deployment under review is what the 47-second film on
+      [the pull request][pr] reads back off the chain, and that one shows no
+      proving.
 
 ## FURPS Self-Assessment
 
@@ -422,119 +278,92 @@ whose derivation is unchanged in v0.2.4.
 
 Four instructions: `create_multisig`, `create_proposal`, `approve`, `execute`.
 Seven documented bindings, each with adversarial coverage. **Limitations, stated
-rather than buried:** the member set is fixed at creation (no rotation);
-proposals do not expire; the action payload is opaque to this protocol and a
-consuming program must validate it itself.
+rather than buried:** the member set is fixed at creation (no rotation), and
+proposals do not expire.
 
 ### Usability
 
 Three surfaces over one library: the SDK, the `msig` CLI, and the Basecamp app.
 The app shells out to the CLI, so the GUI and the chain compute the same
 commitments from the same code — there is no second implementation to drift.
-Onboarding is `git clone && ./scripts/demo.sh`. The CLI's refusals are written to
-be read by a human and explain *why*, and the GUI passes them straight through.
+Onboarding is `git clone && ./scripts/demo.sh`. The CLI's refusals explain *why*,
+and the GUI passes them straight through.
 
 ### Reliability
 
-Local pre-verification before proving; resumable partial approvals; thirteen
-documented error codes. Failure modes I know about and have not solved: a
+Local pre-verification before proving; resumable partial approvals; twenty-two
+documented error codes. A failure mode I know about and have not solved: a
 transaction whose proving outruns the wallet's polling window reports "NOT
-confirmed" while landing anyway — the scripts poll `getTransaction` rather than
-trust the CLI's verdict, and the docs say so.
+confirmed" while landing anyway — so the scripts poll `getTransaction` rather
+than trust the CLI's verdict.
 
 ### Performance
 
 `approve` at **337,105 user cycles**, 1.56 % of the public compute budget, with
-headroom to 524,288 before a second segment. Wall-clock is dominated entirely by
-proving: **440 s and 469 s** for the two approvals of the run that produced the
-deployed lifecycle — public testnet, LEZ v0.2.4, measured 2026-08-12 — timed by
-`scripts/deploy-and-run.sh` itself rather than estimated. The script writes each
-timing to `lifecycle.tsv` in the run's working directory as it goes; that
-directory is deliberately not committed, because it also holds the member keys,
-so the record a reviewer can open is the table in
-[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md), which gives every figure with the machine
-and the LEZ version it was taken on.
+headroom to 524,288 before a second segment. Wall clock is dominated entirely by
+proving.
 
-Two things cut against this submission and both belong here. **The version got
-slower.** The same lifecycle measured 149-154 s under LEZ v0.2.0; v0.2.4 is about
-three times more expensive, and a second machine shows the same ratio
-independently — CI went 1264 s to 4033 s across the same upgrade, which is enough
-to stop calling it variance. The v0.2.4 numbers are the ones quoted because
-v0.2.4 is what the deployed lifecycle runs on. **And 440/469 s were taken under CPU
-contention**, so they are not a best case being dressed up: an idle laptop
-measures 437 s for the same approval, and 935 s with one unrelated proof running.
-
-Quoting any one of those as "the" proving time would be picking a favourite, so
-the honest summary is a range with a machine attached: on v0.2.4 a member on an
-idle laptop waits about seven minutes, and the same proof on a shared CI runner
-took sixty-seven. Earlier revisions of this submission quoted "~10 minutes per
-approval" as an unmeasured estimate, then "149 s and 154 s" once it was measured
-under v0.2.0. Neither describes the current chain; the numbers above do.
+Two things cut against this submission. **The version got slower**: the same
+lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is about three times more
+expensive — CI went 1264 s to 4033 s across the same upgrade, which is enough to
+stop calling it variance. **And the 440/469 s above were taken under CPU
+contention**, so they are not a best case dressed up: an idle laptop measures
+437 s for the same approval, and 935 s with one unrelated proof running. The
+honest summary is a range with a machine attached — about seven minutes on an
+idle laptop, sixty-seven on a shared runner — and [`docs/cu-costs.md`][cu] gives
+every figure with the machine and LEZ version it was taken on.
 
 ### Supportability
 
-**97 tests** across seven suites, counted and itemised in the README, and
-fifty-nine of them run the **built verifier binary** through the sequencer's own
-executor rather than the host crate. Every one of
-the thirteen documented error codes is exercised against the built binary, and
-the bindings they enforce are written up in `docs/security.md`. The two guest
-crates are excluded from the host workspace because they target
-`riscv32im-risc0-zkvm-elf` — but the deployed program is still under test,
-because `multisig-verifier-tests` is a workspace member exercising the built
-binary. CI runs on Ubuntu and macOS, and a dedicated job fails if
-`MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary, since
-that constant is what stops a chained call from reaching an unaudited program.
+**97 tests** across seven suites, itemised in the [README][readme], fifty-nine of
+them running the **built verifier binary** through the sequencer's own executor
+rather than the host crate — and every one of the twenty-two error codes is
+exercised against that binary. The two guest crates target
+`riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the
+deployed program is still under test, because `multisig-verifier-tests` is a
+workspace member exercising it. CI runs on Ubuntu and macOS, and a dedicated job
+fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary
+— the constant that stops a chained call reaching an unaudited program.
 
 ## Write-up, by the topics the brief names
-
-The Submission Requirements ask for a write-up covering six specific things, and
-the Scope section adds a seventh. Rather than leave them to be hunted for:
 
 | Required topic | Where |
 |---|---|
 | **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
-| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) |
-| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
-| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
-| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
-| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
-| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md) for deployment |
-| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
+| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`][sec] |
+| **LEZ account model compatibility** (**nonce**, **`program_owner`**) | [`docs/lez-account-model.md`][acct], in full. The nonce constraint never binds on membership — a member is a Merkle leaf, not an account this program touches; it binds one level up, on the account that *submits*, which may be a relayer. `program_owner` is load-bearing rather than an obstacle: it is how an uninitialised PDA is detectable |
+| **Trusted setup** | **None.** Risc0 is STARK-based and transparent: no reference string, no ceremony, no toxic waste. The only trusted parameters are the two ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`][dep] shows a clean rebuild reproducing `1346b652…` |
+| **Security assumptions** | [`docs/security.md`][sec] — three adversaries in increasing order of knowledge, ending at the insider |
+| **Known limitations** | [`docs/security.md`][sec] — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
+| **Integration instructions** | [`README.md`][readme], and [`docs/DEPLOYMENT.md`][dep] for deployment |
+| **Benchmarks** | [`docs/cu-costs.md`][cu] — per-instruction CU, per-approval wall clock measured by the lifecycle script |
 
-## Supporting Materials
+Also worth opening: [`docs/error-codes.md`][ec] (all 22 codes, the attack each
+stops, the test behind it) and [`docs/recording-evidence.md`][rec] (how the film
+is tied to the picture, and what it does **not** establish).
 
-- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/security.md) — threat model, what is hidden from
-  whom, what is deliberately public, residual risks
-- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/lez-account-model.md) — the nonce and
-  `program_owner` constraints, which are the incompatibility this prize exists
-  to solve
-- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/error-codes.md) — all 13 codes, the attack each
-  stops, and the test behind it
-- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/cu-costs.md)
-- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95/docs/DEPLOYMENT.md)
-- Narrated demo video: <https://youtu.be/cPVsWWBVEeE>
-
-## Two LEZ behaviours worth knowing
-
-Both are invisible until you hit them, and neither is a program bug — they are
-noted here because anyone deploying on this stack will meet them:
-
-1. **One approver account cannot serve several approvals.** A privacy
-   transaction consumes the approver's commitment, so a second approval from the
-   same account panics in the *client-side* circuit — `Invalid
-   account_identities length, left: 4, right: 3` — before anything is submitted.
-   One private account per approval fixes it, and that is how a real deployment
-   works anyway.
-2. **Variadic accounts take one comma-separated flag.** `spel-cli` resolves them
-   with `last_value()`, so a repeated `--approvals` silently keeps only the last.
-   The program then saw one account against two nullifiers and rejected with
-   `E_APPROVAL_COUNT_MISMATCH` (5009) — the check doing exactly its job, which is
-   how the cause was found.
-
-Both are handled in `scripts/deploy-and-run.sh` and documented in
-`docs/DEPLOYMENT.md`.
+Two LEZ behaviours cost me a day each and are written up in
+[`docs/DEPLOYMENT.md`][dep]: one approver account cannot serve several approvals,
+because a privacy transaction consumes the approver's commitment; and variadic
+accounts take one comma-separated flag, because `spel-cli` resolves them with
+`last_value()` and silently keeps only the last repeat.
 
 ## Terms & Conditions
 
 By submitting this solution, I confirm that I have read and agree to the
 [Terms & Conditions](../TERMS.md).
+
+[commit]: https://github.com/edenbd1/lp-0002-private-multisig/commit/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95
+[ci1]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727175015
+[ci2]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727211438
+[pr]: https://github.com/logos-co/lambda-prize/pull/125
+[sec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/security.md
+[cu]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/cu-costs.md
+[dep]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/DEPLOYMENT.md
+[ec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/error-codes.md
+[acct]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/lez-account-model.md
+[readme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/README.md
+[patch]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/vendor/spel/PATCH.md
+[appreadme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/app/README.md
+[e2eyml]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/.github/workflows/e2e-local-sequencer.yml
+[rec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/recording-evidence.md

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -180,97 +180,97 @@ whose derivation is unchanged in v0.2.4.
       20856-20880, all live; see
       [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md).
 
-      **What "threshold-gated action" means here.** The criterion offers
-      *treasury transfer or parameter change* as examples, and this is the first
-      of them, performed rather than described. The multisig owns a treasury
-      PDA; `fund_treasury` puts value into it; the proposal names a recipient
-      and an amount, both bound into the proposal's address by hash; and
-      `execute` moves the amount out of the treasury and into the recipient in
-      the same transaction, which is the only shape LEZ accepts — a debit and a
-      credit that balance. The recipient is held by the native transfer program
-      rather than by the verifier, so what it receives is spendable rather than
-      stranded inside a program with no instruction to release it.
+  **What "threshold-gated action" means here.** The criterion offers
+  *treasury transfer or parameter change* as examples, and this is the first
+  of them, performed rather than described. The multisig owns a treasury
+  PDA; `fund_treasury` puts value into it; the proposal names a recipient
+  and an amount, both bound into the proposal's address by hash; and
+  `execute` moves the amount out of the treasury and into the recipient in
+  the same transaction, which is the only shape LEZ accepts — a debit and a
+  credit that balance. The recipient is held by the native transfer program
+  rather than by the verifier, so what it receives is spendable rather than
+  stranded inside a program with no instruction to release it.
 
-      An earlier version of this submission stopped one step short: it proved
-      the threshold, wrote an execution marker, and left performing the transfer
-      to a caller, on the argument that a multisig is an authorisation primitive
-      and that coupling it to one action type would make it a treasury program.
-      The argument is still true and the primitive is still general — the
-      execution marker is a PDA at a derivable address, owned by the verifier,
-      whose existence *is* the proof that M distinct secret-bound nullifiers
-      resolved, and any program can gate on it. But a criterion that names a
-      treasury transfer is better answered by a treasury transfer, and a
-      treasury balance falling from 2 to 1 is a fact a reviewer reads off the
-      chain in one call. That is why the verifier was rebuilt and redeployed on
-      2026-08-24, and why every account address in this document moved with it:
-      on LEZ a program's identity *is* its ImageID, and every PDA is derived
-      from it.
+  An earlier version of this submission stopped one step short: it proved
+  the threshold, wrote an execution marker, and left performing the transfer
+  to a caller, on the argument that a multisig is an authorisation primitive
+  and that coupling it to one action type would make it a treasury program.
+  The argument is still true and the primitive is still general — the
+  execution marker is a PDA at a derivable address, owned by the verifier,
+  whose existence *is* the proof that M distinct secret-bound nullifiers
+  resolved, and any program can gate on it. But a criterion that names a
+  treasury transfer is better answered by a treasury transfer, and a
+  treasury balance falling from 2 to 1 is a fact a reviewer reads off the
+  chain in one call. That is why the verifier was rebuilt and redeployed on
+  2026-08-24, and why every account address in this document moved with it:
+  on LEZ a program's identity *is* its ImageID, and every PDA is derived
+  from it.
 
-      **On the block explorer.** Its index trails the sequencer — measured on
-      this chain at roughly an hour and three quarters — so a transaction
-      submitted minutes ago reads "Transaction not found" there while
-      `getTransaction` already resolves it. That is an indexing delay, not a
-      gap, and it affects anything recent by anyone. The deploy of
-      `membership_lez` sits at block 4459 and renders today; the seven
-      transactions of the 2026-08-24 lifecycle are recent, and render once the
-      index reaches block 20880. `./scripts/verify-onchain-lifecycle.sh` does
-      not depend on that index at all: it asks the sequencer, and it checks the
-      variant each transaction carries — which the explorer could not tell you
-      even fully caught up.
+  **On the block explorer.** Its index trails the sequencer — measured on
+  this chain at roughly an hour and three quarters — so a transaction
+  submitted minutes ago reads "Transaction not found" there while
+  `getTransaction` already resolves it. That is an indexing delay, not a
+  gap, and it affects anything recent by anyone. The deploy of
+  `membership_lez` sits at block 4459 and renders today; the seven
+  transactions of the 2026-08-24 lifecycle are recent, and render once the
+  index reaches block 20880. `./scripts/verify-onchain-lifecycle.sh` does
+  not depend on that index at all: it asks the sequencer, and it checks the
+  variant each transaction carries — which the explorer could not tell you
+  even fully caught up.
 
-      One correction, because this document used to state the opposite. It said
-      the explorer was a WASM app serving an identical shell for every hash, so
-      that comparing response sizes could not tell an indexed transaction from
-      one that cannot exist. That was true when `./scripts/check-explorer.py`
-      was written — it is why the script drives a browser at all — and it is not
-      true now: re-measured on **2026-08-15**, the explorer renders server-side,
-      and a single `curl` separates the two cases by size alone. The script
-      still renders each page headless against an impossible-hash control, and
-      aborts if that control ever renders as a *found* transaction rather than
-      report verdicts against a baseline that would be meaningless.
+  One correction, because this document used to state the opposite. It said
+  the explorer was a WASM app serving an identical shell for every hash, so
+  that comparing response sizes could not tell an indexed transaction from
+  one that cannot exist. That was true when `./scripts/check-explorer.py`
+  was written — it is why the script drives a browser at all — and it is not
+  true now: re-measured on **2026-08-15**, the explorer renders server-side,
+  and a single `curl` separates the two cases by size alone. The script
+  still renders each page headless against an impossible-hash control, and
+  aborts if that control ever renders as a *found* transaction rather than
+  report verdicts against a baseline that would be meaningless.
 
-      `docs/DEPLOYMENT.md` gives a one-line `curl` per hash, and
-      `./scripts/verify-onchain.sh` does the stronger check — it reads the five
-      accounts the lifecycle created and confirms the verifier program owns
-      them, which no transaction lookup can fake.
+  `docs/DEPLOYMENT.md` gives a one-line `curl` per hash, and
+  `./scripts/verify-onchain.sh` does the stronger check — it reads the five
+  accounts the lifecycle created and confirms the verifier program owns
+  them, which no transaction lookup can fake.
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
-      approved by threshold, and executed — and the execution moves value.**
-      A 2-of-3 multisig, its treasury funded, a proposal published, two
-      approvals gathered on the privacy-preserving path, and executed, in blocks
-      20856-20880. Six accounts, all owned by the verifier:
-      multisig [`Hx7Ni2ri…`](https://explorer.testnet.lez.logos.co/account/Hx7Ni2riURJfgng4QAXb3RBq9ZMjrvwj7JREjut9PuBC),
-      treasury [`xtngupTp…`](https://explorer.testnet.lez.logos.co/account/xtngupTp3tcQU9faCbND73KhCpYqfBqKhmoepQAXoVx),
-      proposal [`9EjLSnKj…`](https://explorer.testnet.lez.logos.co/account/9EjLSnKjXB4r8SgBEHcgqf36nkqfyUVXuqSsDzCTRvg7),
-      execution marker [`BP6buTDd…`](https://explorer.testnet.lez.logos.co/account/BP6buTDdFThPYWU3NFGSsD8k3ymewStQo4hj86tAwq1a),
-      and the two approval markers. Their **Program Owner** is
-      `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, which base58-decodes to
-      `1346b652…98ff4e1e` — exactly the ImageID `spel program-id
-      artifacts/programs/multisig_verifier.bin` computes from the binary
-      committed here. Nothing in that chain needs us.
+  approved by threshold, and executed — and the execution moves value.**
+  A 2-of-3 multisig, its treasury funded, a proposal published, two
+  approvals gathered on the privacy-preserving path, and executed, in blocks
+  20856-20880. Six accounts, all owned by the verifier:
+  multisig [`Hx7Ni2ri…`](https://explorer.testnet.lez.logos.co/account/Hx7Ni2riURJfgng4QAXb3RBq9ZMjrvwj7JREjut9PuBC),
+  treasury [`xtngupTp…`](https://explorer.testnet.lez.logos.co/account/xtngupTp3tcQU9faCbND73KhCpYqfBqKhmoepQAXoVx),
+  proposal [`9EjLSnKj…`](https://explorer.testnet.lez.logos.co/account/9EjLSnKjXB4r8SgBEHcgqf36nkqfyUVXuqSsDzCTRvg7),
+  execution marker [`BP6buTDd…`](https://explorer.testnet.lez.logos.co/account/BP6buTDdFThPYWU3NFGSsD8k3ymewStQo4hj86tAwq1a),
+  and the two approval markers. Their **Program Owner** is
+  `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, which base58-decodes to
+  `1346b652…98ff4e1e` — exactly the ImageID `spel program-id
+  artifacts/programs/multisig_verifier.bin` computes from the binary
+  committed here. Nothing in that chain needs us.
 
-      The number only a real execution could produce is the treasury's:
-      `fund_treasury` put **2** into it and `execute` moved **1** out, and the
-      other side of that move is a seventh account that is *not* the
-      program's — the recipient
-      [`8kexXda8…`](https://explorer.testnet.lez.logos.co/account/8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn),
-      **0 → 1**, held by the native transfer program rather than by the
-      verifier, which is what makes what it received spendable instead of
-      stranded.
+  The number only a real execution could produce is the treasury's:
+  `fund_treasury` put **2** into it and `execute` moved **1** out, and the
+  other side of that move is a seventh account that is *not* the
+  program's — the recipient
+  [`8kexXda8…`](https://explorer.testnet.lez.logos.co/account/8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn),
+  **0 → 1**, held by the native transfer program rather than by the
+  verifier, which is what makes what it received spendable instead of
+  stranded.
 
-      `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean
-      clone in about five seconds and takes no arguments: it recomputes both
-      deploy hashes from the committed bytecode, resolves the eight
-      transactions, and asserts the variant each one carries — the two
-      approvals must be `PrivacyPreserving` and not `Public`, which is the part
-      a block explorer cannot show you. `./scripts/verify-onchain.sh` is the
-      deeper pass: it reads the six accounts back and decodes every record at
-      the byte offsets published in `docs/account-layout.md`.
+  `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean
+  clone in about five seconds and takes no arguments: it recomputes both
+  deploy hashes from the committed bytecode, resolves the eight
+  transactions, and asserts the variant each one carries — the two
+  approvals must be `PrivacyPreserving` and not `Public`, which is the part
+  a block explorer cannot show you. `./scripts/verify-onchain.sh` is the
+  deeper pass: it reads the six accounts back and decodes every record at
+  the byte offsets published in `docs/account-layout.md`.
 
-      **On the explorer, these are recent.** The indexer trails the sequencer,
-      so freshly-created accounts can read `Program Owner:
-      11111111111111111111111111111111` and `Data: 0 bytes` for a while after
-      they exist. `getAccount` answers correctly the whole time, and both
-      scripts above use it.
+  **On the explorer, these are recent.** The indexer trails the sequencer,
+  so freshly-created accounts can read `Program Owner:
+  11111111111111111111111111111111` and `Data: 0 bytes` for a while after
+  they exist. `getAccount` answers correctly the whole time, and both
+  scripts above use it.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability
@@ -287,34 +287,34 @@ whose derivation is unchanged in v0.2.4.
       `scripts/build-linux-variant.sh` and the packaged Linux `msig` was run
       inside a Linux container to confirm it works, not just that it exists.
 
-      **The Linux variant is load-tested against Basecamp's own Qt, not just
-      built.** Basecamp ships an `x86_64.AppImage` in the same 0.2.2 release;
-      extracted, it bundles the same Qt 6.9.2 as macOS. Running what Basecamp's
-      PluginLoader runs — `QPluginLoader::instance()` then
-      `qobject_cast<IComponent*>` — linked against *that* Qt gives
-      `SUCCESS: loaded + cast to IComponent`. The harness was shown able to
-      fail: a real Qt plugin with a different IID gives `CAST FAILED`. Basecamp
-      itself also boots on Linux with the package installed, reaching
-      `Logos Core started successfully!` and scanning the plugins directory.
-      What is *not* claimed is the click: a UI app's widget loads on click, and
-      headless there is nothing to click, so that half was exercised on macOS.
-      Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/app/README.md).
+  **The Linux variant is load-tested against Basecamp's own Qt, not just
+  built.** Basecamp ships an `x86_64.AppImage` in the same 0.2.2 release;
+  extracted, it bundles the same Qt 6.9.2 as macOS. Running what Basecamp's
+  PluginLoader runs — `QPluginLoader::instance()` then
+  `qobject_cast<IComponent*>` — linked against *that* Qt gives
+  `SUCCESS: loaded + cast to IComponent`. The harness was shown able to
+  fail: a real Qt plugin with a different IID gives `CAST FAILED`. Basecamp
+  itself also boots on Linux with the package installed, reaching
+  `Logos Core started successfully!` and scanning the plugins directory.
+  What is *not* claimed is the click: a UI app's widget loads on click, and
+  headless there is nothing to click, so that half was exercised on macOS.
+  Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/app/README.md).
 
-      **It was installed and driven in Logos Basecamp 0.2.2**, not merely
-      declared loadable: the committed package extracts into the user plugins
-      directory, the module loads (`Successfully loaded UI module`), and
-      pressing *Status* against `artifacts/testnet` returns the live
-      deployment's `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers.
-      Doing that found three defects in the packaging, all fixed and all
-      described in `app/README.md`: the plugin was built against a Qt newer than
-      the one Basecamp runs, so Qt refused it outright; `Q_DECLARE_INTERFACE`
-      used a private IID instead of `com.logos.component.IComponent`, so the
-      host's `qobject_cast` returned null; and the `IComponent` declaration
-      carried an extra virtual, which shifted every later vtable slot.
-      `scripts/package-lgx.py` now refuses to package a binary with any of
-      those properties.
+  **It was installed and driven in Logos Basecamp 0.2.2**, not merely
+  declared loadable: the committed package extracts into the user plugins
+  directory, the module loads (`Successfully loaded UI module`), and
+  pressing *Status* against `artifacts/testnet` returns the live
+  deployment's `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers.
+  Doing that found three defects in the packaging, all fixed and all
+  described in `app/README.md`: the plugin was built against a Qt newer than
+  the one Basecamp runs, so Qt refused it outright; `Q_DECLARE_INTERFACE`
+  used a private IID instead of `com.logos.component.IComponent`, so the
+  host's `qobject_cast` returned null; and the `IComponent` declaration
+  carried an extra virtual, which shifted every later vtable slot.
+  `scripts/package-lgx.py` now refuses to package a binary with any of
+  those properties.
 - [x] **SPEL IDL.** `idl/multisig_verifier.idl.json`, generated from source by
-      `spel generate-idl`.
+  `spel generate-idl`.
 
 ### Reliability
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -40,13 +40,12 @@ are anchored by PDA address, so neither can be invented or lowered.
   exactly the code under review. Both program binaries also hash identically
   across every commit in the range, so the thing being proved has not moved
   underneath the proof.
-- **Video:** two films play inline in the pull request — the whole lifecycle
-  against a standalone sequencer with two real proofs, and a 66-second reading of
-  this deployment. The first is the same session as
-  <https://youtu.be/rM_tP1-xb54>, which is that take unedited and unaccelerated
-  for anyone who wants to check the speed-up. The narrated walkthrough at
-  <https://youtu.be/cPVsWWBVEeE> is kept for the commentary; it predates this
-  redeploy, so its on-screen identifiers are the superseded ones.
+- **Video:** two narrated films play inline in the pull request — the whole
+  lifecycle against a standalone sequencer with two real proofs, and a 66-second
+  reading of this deployment. Both were shot for this submission and both show
+  their own commit on screen. Earlier recordings of an earlier deployment are not
+  linked: they carry superseded identifiers, and pointing a reviewer at a film
+  that contradicts the one above costs more than the extra commentary is worth.
 - **Where the detail lives:** `docs/security.md` (threat model),
   `docs/cu-costs.md`, `docs/error-codes.md`, `docs/lez-account-model.md`,
   `docs/account-layout.md`, `docs/DEPLOYMENT.md`, `vendor/spel/PATCH.md`.
@@ -279,11 +278,10 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
   line. No funded account, no public testnet, nothing mocked. Only the stretch
   where the prover works and the screen does not change is sped up, its factor
-  written across the picture while it plays. The same session runs unedited and
-  unaccelerated at <https://youtu.be/rM_tP1-xb54>, so the speed-up is checkable
-  rather than taken on trust. The other film is the 66-second reading of the
-  public-testnet deployment, and <https://youtu.be/cPVsWWBVEeE> is a narrated
-  walkthrough kept for the commentary, from before this redeploy.
+  written across the picture while it plays. The factor is 64, written across
+  the picture for the whole of the sped-up stretch, so a compressed shot is
+  announced rather than slipped past. The other film is the 66-second reading of
+  the public-testnet deployment.
 
 ## FURPS Self-Assessment
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -161,9 +161,10 @@ It recomputes both deploy hashes from the committed bytecode, resolves all
 thirteen transactions, and asserts the variant each must carry — the five
 approvals `PrivacyPreserving` rather than `Public`, which is the part a block
 explorer cannot show you. Its first step is an impossible hash that must return
-null, so a resolving hash afterwards means something. `./scripts/verify-onchain.sh`
+null, so a resolving hash afterwards means something. `./scripts/verify-onchain.sh artifacts/testnet "$(cat artifacts/testnet/proposal_id)"`
 reads the accounts back and decodes every record at the offsets
 `docs/account-layout.md` publishes, including `tiers_hash` and `superseded_by`.
+It takes those two arguments so it can be pointed at any run, not only this one.
 
 ## Success Criteria Checklist
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -27,8 +27,8 @@ The first thing I checked was whether a LEZ **public** transaction verifies a
 proof. It does not — the sequencer re-executes the program host-side
 (`lee/state_machine/src/program/mod.rs:73-77`, commented *"Execute the program
 (without proving)"*). A multisig built there would be a signature check wearing
-a zero-knowledge costume, which is precisely the ground on which earlier
-submissions in this program were rejected.
+a zero-knowledge costume: the sequencer would re-run the approval logic in the
+clear, so nothing would be proved and nothing would be private.
 
 The path that works is the **privacy-preserving transaction**: the client proves
 locally, LEZ's privacy circuit composes each chained call with a real

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -17,7 +17,18 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Video:** <https://youtu.be/cPVsWWBVEeE>
+- **Reviewed commit:** [`ad2267e`](https://github.com/edenbd1/lp-0002-private-multisig/commit/ad2267e1352fbc40ec83434f8495b5e772d0418e).
+  Every repository link below names that commit rather than `main`, so the
+  version under review cannot move after this is opened.
+- **CI on that exact commit:** [the host suite and the deployed-binary
+  audit](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818994),
+  green — 97 tests, of which 59 run the built verifier through the sequencer's
+  own executor.
+- **Video:** a 50-second reading of this deployment is attached to
+  [the pull request](https://github.com/logos-co/lambda-prize/pull/125) and plays
+  inline there. The ten-minute narrated walkthrough at
+  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-24 redeploy, so the
+  identifiers on screen in it are the superseded ones.
 
 ## Approach
 
@@ -126,7 +137,7 @@ That upgrade is also why this repository vendors SPEL. Its latest release,
 released SPEL that builds against a current LEZ — so "use SPEL" and "transact on
 the current testnet" could not both be satisfied with anything published.
 `vendor/spel` is upstream v0.6.0 with the minimum changes to do both, and
-[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/vendor/spel/PATCH.md)
+[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/vendor/spel/PATCH.md)
 documents every one of them, how to reproduce the directory, and when it should
 be deleted. Three things broke: private-PDA derivation gained an ML-KEM 768
 viewing key, `WalletCore::from_env()` became async, and the wallet went
@@ -146,7 +157,7 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
       The only trace is a marker PDA seeded by a secret-bound nullifier. See
-      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md), which states the threat model
+      [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md), which states the threat model
       against three adversaries including the insider.
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
       without recording which members approved.** `execute`, checks 5–7.
@@ -159,15 +170,15 @@ whose derivation is unchanged in v0.2.4.
 - [x] **Proof generation runs client-side on a standard laptop.** Approvals are
       built by `msig approve-args` and proved locally; **440 s and 469 s** for the
       two approvals of the LEZ v0.2.4 run that produced the deployed lifecycle in
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md), timed by the script itself.
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md), timed by the script itself.
       Read them per machine, not as one number —
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md) tabulates seven measurements across
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md) tabulates seven measurements across
       two machines and two LEZ versions, spanning 149 s to 4033 s.
 - [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, its
       treasury funded, a proposal published, two approvals gathered on the
       privacy-preserving path, and executed. **Eight transactions** in blocks
       20856-20880, all live; see
-      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md).
+      [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md).
 
       **What "threshold-gated action" means here.** The criterion offers
       *treasury transfer or parameter change* as examples, and this is the first
@@ -287,7 +298,7 @@ whose derivation is unchanged in v0.2.4.
       `Logos Core started successfully!` and scanning the plugins directory.
       What is *not* claimed is the click: a UI app's widget loads on click, and
       headless there is nothing to click, so that half was exercised on macOS.
-      Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/app/README.md).
+      Method in [`app/README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/app/README.md).
 
       **It was installed and driven in Logos Basecamp 0.2.2**, not merely
       declared loadable: the committed package extracts into the user plugins
@@ -315,13 +326,13 @@ whose derivation is unchanged in v0.2.4.
       command returns. This is not incidental: proving takes minutes, not an
       approval, so a real threshold *is* gathered across sessions and days.
 - [x] **Deterministic, documented error codes.** Thirteen, `5001`–`5013`, in
-      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/error-codes.md), each mapped to the attack it
+      [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/error-codes.md), each mapped to the attack it
       stops and the test that proves it.
 
 ### Performance
 
 - [x] **CU cost of each on-chain operation documented.**
-      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md): `approve` 337,105 user cycles;
+      [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md): `approve` 337,105 user cycles;
       `execute` linear in M at ~48,600 per approval; all inside one segment at
       1.56 % of the public budget. Measured by replaying through the sequencer's
       own executor, reproducible with one command.
@@ -336,7 +347,7 @@ whose derivation is unchanged in v0.2.4.
       **executor** on every push — same executor, same input order, same 32M
       session limit — which is what makes 25 adversarial rejections cheap enough
       to gate a commit. On top of that,
-      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/.github/workflows/e2e-local-sequencer.yml)
+      [`.github/workflows/e2e-local-sequencer.yml`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/.github/workflows/e2e-local-sequencer.yml)
       starts the actual `sequencer_service` binary in **standalone mode** and
       drives the whole lifecycle against it over JSON-RPC. It is scheduled
       rather than per-push because it builds the LEZ workspace and then
@@ -394,7 +405,7 @@ deployed lifecycle — public testnet, LEZ v0.2.4, measured 2026-08-12 — timed
 timing to `lifecycle.tsv` in the run's working directory as it goes; that
 directory is deliberately not committed, because it also holds the member keys,
 so the record a reviewer can open is the table in
-[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md), which gives every figure with the machine
+[`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md), which gives every figure with the machine
 and the LEZ version it was taken on.
 
 Two things cut against this submission and both belong here. **The version got
@@ -435,25 +446,25 @@ the Scope section adds a seventh. Rather than leave them to be hunted for:
 | Required topic | Where |
 |---|---|
 | **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
-| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) |
-| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
-| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
-| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
-| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
-| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) for deployment |
-| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
+| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) |
+| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
+| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
+| **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
+| **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
+| **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md) for deployment |
+| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
 
 ## Supporting Materials
 
-- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) — threat model, what is hidden from
+- [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/security.md) — threat model, what is hidden from
   whom, what is deliberately public, residual risks
-- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/lez-account-model.md) — the nonce and
+- [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/lez-account-model.md) — the nonce and
   `program_owner` constraints, which are the incompatibility this prize exists
   to solve
-- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/error-codes.md) — all 13 codes, the attack each
+- [`docs/error-codes.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/error-codes.md) — all 13 codes, the attack each
   stops, and the test behind it
-- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md)
-- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md)
+- [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/cu-costs.md)
+- [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/ad2267e1352fbc40ec83434f8495b5e772d0418e/docs/DEPLOYMENT.md)
 - Narrated demo video: <https://youtu.be/cPVsWWBVEeE>
 
 ## Two LEZ behaviours worth knowing

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -27,7 +27,7 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
   sequencer](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32677818980),
   2 h 48 with `RISC0_DEV_MODE=0`, which builds LEZ at a pinned revision, starts
   the sequencer, and drives the whole 2-of-3 lifecycle against it.
-- **Video:** a 50-second reading of this deployment is attached to
+- **Video:** a 47-second narrated reading of this deployment is attached to
   [the pull request](https://github.com/logos-co/lambda-prize/pull/125) and plays
   inline there. The ten-minute narrated walkthrough at
   <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-24 redeploy, so the

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -215,11 +215,21 @@ whose derivation is unchanged in v0.2.4.
       accounts the lifecycle created and confirms the verifier program owns
       them, which no transaction lookup can fake.
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
-      approved by threshold, and executed.** Multisig
-      `4wqJXoEhqqqYknt1s7gHcgBL6pkfwNJDfhbVVeAqwtnX`, proposal
-      `E11Awng7j59dVft83VVrwftXp41roJPKY5QRMb45Zcoe`, execution marker
-      `CpiuicNDii6uCeMXtjd1W6hek6Vq35HJ7k3mz1Q82Fui` — all owned by the verifier.
-      Re-verify with `./scripts/verify-onchain.sh`.
+      approved by threshold, and executed.** All three are readable in the block
+      explorer, and each one's **Program Owner** is the verifier: multisig
+      [`4wqJXoEh…`](https://explorer.testnet.lez.logos.co/account/4wqJXoEhqqqYknt1s7gHcgBL6pkfwNJDfhbVVeAqwtnX), proposal
+      [`E11Awng7…`](https://explorer.testnet.lez.logos.co/account/E11Awng7j59dVft83VVrwftXp41roJPKY5QRMb45Zcoe), execution marker
+      [`Cpiuic…`](https://explorer.testnet.lez.logos.co/account/CpiuicNDii6uCeMXtjd1W6hek6Vq35HJ7k3mz1Q82Fui). The owner
+      those pages show, `7AyJ7x4DuAa58ALGqLXYwqdhEvQLCz5A2GFdcDrwyzUZ`, decodes to
+      `5bb40082…a5966f82` — the ImageID `spel program-id
+      artifacts/programs/multisig_verifier.bin` computes from the binary committed
+      here. Nothing in that chain needs us.
+
+      `git clone && ./scripts/demo.sh` re-runs the check from a clean clone: it
+      derives the three addresses, reads them from the sequencer and reports the
+      owner and the approval count. `./scripts/verify-onchain.sh` is the deeper
+      version and needs the working directory a lifecycle run leaves behind, so it
+      is for whoever has just run one, not for a first reader.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -157,8 +157,12 @@ whose derivation is unchanged in v0.2.4.
       account.** `execute` consumes marker addresses and is signed by an executor
       who need not be a member at all.
 - [x] **Proof generation runs client-side on a standard laptop.** Approvals are
-      built by `msig approve-args` and proved locally; **149 s and 154 s** for the
-      two approvals of a measured 2-of-3 run, timed by the script itself.
+      built by `msig approve-args` and proved locally; **440 s and 469 s** for the
+      two approvals of the LEZ v0.2.4 run that produced the deployed lifecycle in
+      [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md), timed by the script itself.
+      Read them per machine, not as one number —
+      [`docs/cu-costs.md`](docs/cu-costs.md) tabulates seven measurements across
+      two machines and two LEZ versions, spanning 149 s to 4033 s.
 - [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, a
       proposal published, two approvals gathered on the privacy-preserving path,
       and executed against the fixed verifier. Seven transactions, all live; see
@@ -277,7 +281,7 @@ whose derivation is unchanged in v0.2.4.
 ### Performance
 
 - [x] **CU cost of each on-chain operation documented.**
-      [`docs/cu-costs.md`](docs/cu-costs.md): `approve` 335,564 user cycles;
+      [`docs/cu-costs.md`](docs/cu-costs.md): `approve` 337,105 user cycles;
       `execute` linear in M at ~48,600 per approval; all inside one segment at
       1.56 % of the public budget. Measured by replaying through the sequencer's
       own executor, reproducible with one command.
@@ -342,20 +346,32 @@ trust the CLI's verdict, and the docs say so.
 
 ### Performance
 
-`approve` at 1.56 % of the public compute budget, with headroom to ~524k user
-cycles before a second segment. Wall-clock is dominated entirely by proving:
-**149 s and 154 s** for the two approvals of a 2-of-3 run against a local
-standalone sequencer, timed by `scripts/deploy-and-run.sh` itself rather than
-estimated, and written into `lifecycle.tsv` alongside the transaction hashes.
-Both numbers are in [`docs/cu-costs.md`](docs/cu-costs.md) with the machine they
-were taken on.
+`approve` at **337,105 user cycles**, 1.56 % of the public compute budget, with
+headroom to 524,288 before a second segment. Wall-clock is dominated entirely by
+proving: **440 s and 469 s** for the two approvals of the run that produced the
+deployed lifecycle — public testnet, LEZ v0.2.4, measured 2026-08-12 — timed by
+`scripts/deploy-and-run.sh` itself rather than estimated. The script writes each
+timing to `lifecycle.tsv` in the run's working directory as it goes; that
+directory is deliberately not committed, because it also holds the member keys,
+so the record a reviewer can open is the table in
+[`docs/cu-costs.md`](docs/cu-costs.md), which gives every figure with the machine
+and the LEZ version it was taken on.
 
-That figure is a correction. This submission previously said "~10 minutes per
-approval" in six places, carried over from an early estimate that no one had
-gone back and measured. Measuring it was part of closing the "proof generation
-time benchmark" requirement, and it turned out the estimate was four times too
-pessimistic — which is worth stating plainly, because a benchmark nobody
-re-runs is just a claim.
+Two things cut against this submission and both belong here. **The version got
+slower.** The same lifecycle measured 149-154 s under LEZ v0.2.0; v0.2.4 is about
+three times more expensive, and a second machine shows the same ratio
+independently — CI went 1264 s to 4033 s across the same upgrade, which is enough
+to stop calling it variance. The v0.2.4 numbers are the ones quoted because
+v0.2.4 is what the deployed lifecycle runs on. **And 440/469 s were taken under CPU
+contention**, so they are not a best case being dressed up: an idle laptop
+measures 437 s for the same approval, and 935 s with one unrelated proof running.
+
+Quoting any one of those as "the" proving time would be picking a favourite, so
+the honest summary is a range with a machine attached: on v0.2.4 a member on an
+idle laptop waits about seven minutes, and the same proof on a shared CI runner
+took sixty-seven. Earlier revisions of this submission quoted "~10 minutes per
+approval" as an unmeasured estimate, then "149 s and 154 s" once it was measured
+under v0.2.0. Neither describes the current chain; the numbers above do.
 
 ### Supportability
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -239,7 +239,20 @@ reads the accounts back and decodes every record at the offsets
   `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub runner. `scripts/demo.sh` is the five-second tour without a sequencer, and shows the tier and a rotation as well.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  <https://youtu.be/cPVsWWBVEeE> — the terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any proving starts, and the approval is a real proof generated in one uninterrupted take with its wall clock printed at the end. It predates this redeploy, so its on-screen identifiers are superseded ones; the 47-second reading attached to the pull request is of the current deployment.
+  Two films play inline in the pull request. This one is a single take of
+  `scripts/e2e-local-sequencer.sh` — the script CI runs — at the reviewed commit,
+  whose hash is on screen: it starts a real LEZ sequencer in standalone mode,
+  deploys both programs onto that fresh chain, creates the multisig, proposes a
+  transfer, gathers **two real Risc0 approvals**, executes, and reads the accounts
+  back off the same chain, closing on
+  `e2e against a real local sequencer: PASS (2-of-3, RISC0_DEV_MODE=0)`.
+  `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
+  line. No funded account, no public testnet, nothing mocked. Only the stretch
+  where the prover works and the screen does not change is sped up, its factor
+  written across the picture while it plays. The other film is the 47-second
+  reading of the public-testnet deployment. <https://youtu.be/cPVsWWBVEeE> is a
+  narrated walkthrough from before this redeploy, kept for its commentary rather
+  than the identifiers it shows.
 
 ## FURPS Self-Assessment
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -34,9 +34,10 @@ are anchored by PDA address, so neither can be invented or lowered.
   with real proofs — runs on `1759015`: run
   `33098969090`, green in 2 h 39, its log printing `RISC0_DEV_MODE=0` and closing
   on `2 approval(s) recorded against a requirement of 2`. What separates the two
-  is four files — two documents, the film's transcript and its anchor — with no
-  program, no script the demo runs and no artefact the chain sees among them, so
-  `git diff 1759015 08eaca5 --stat` is the whole of it and that run exercised
+  is five files — the deployment and CU-cost documents, the film's transcript and
+  its recording-evidence anchor, and the transcript-checker gate — with no program,
+  no script the demo runs and no artefact the chain sees among them, so
+  `git diff 1759015 c72ff1c --stat` is the whole of it and that run exercised
   exactly the code under review. Both program binaries also hash identically
   across every commit in the range, so the thing being proved has not moved
   underneath the proof.

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -163,73 +163,103 @@ whose derivation is unchanged in v0.2.4.
       Read them per machine, not as one number —
       [`docs/cu-costs.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/cu-costs.md) tabulates seven measurements across
       two machines and two LEZ versions, spanning 149 s to 4033 s.
-- [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, a
-      proposal published, two approvals gathered on the privacy-preserving path,
-      and executed against the fixed verifier. Seven transactions, all live; see
+- [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, its
+      treasury funded, a proposal published, two approvals gathered on the
+      privacy-preserving path, and executed. **Eight transactions** in blocks
+      20856-20880, all live; see
       [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md).
 
-      **What "threshold-gated action" means here**, since the criterion offers
-      *treasury transfer or parameter change* as examples and it is fair to ask
-      which one this is. The gated action is `transfer 100 LEZ to the grants
-      treasury`, bound into `proposal_ref` by its hash, and what the chain gates
-      is the **right to act on it**: the execution marker PDA comes into
-      existence only when M distinct secret-bound nullifiers resolve to markers
-      the verifier owns, and it can never be produced any other way. Performing
-      the transfer is one CPI away and deliberately out of scope — a multisig is
-      an authorisation primitive, and coupling it to one action type would make
-      it a treasury program instead. Any program can gate on that marker: it is
-      a PDA at a derivable address, owned by the verifier, whose existence *is*
-      the proof that the threshold was met. The submission demonstrates the
-      part the prize is about — reaching the threshold privately — rather than
-      re-implementing a transfer that LEZ already has.
+      **What "threshold-gated action" means here.** The criterion offers
+      *treasury transfer or parameter change* as examples, and this is the first
+      of them, performed rather than described. The multisig owns a treasury
+      PDA; `fund_treasury` puts value into it; the proposal names a recipient
+      and an amount, both bound into the proposal's address by hash; and
+      `execute` moves the amount out of the treasury and into the recipient in
+      the same transaction, which is the only shape LEZ accepts — a debit and a
+      credit that balance. The recipient is held by the native transfer program
+      rather than by the verifier, so what it receives is spendable rather than
+      stranded inside a program with no instruction to release it.
 
-      **All seven render on the explorer**, and all seven are on chain —
-      `getTransaction` returns every one. Re-measured on **2026-08-15** by
-      rendering each page in a headless browser: the two approvals show as
-      `Privacy-Preserving Transaction`, the two deploys as `Program Deployment
-      Transaction`, the other three as `Public Transaction`, while the control —
-      a hash that cannot exist — still shows `Transaction not found`, which is
-      what makes the seven positives mean anything.
+      An earlier version of this submission stopped one step short: it proved
+      the threshold, wrote an execution marker, and left performing the transfer
+      to a caller, on the argument that a multisig is an authorisation primitive
+      and that coupling it to one action type would make it a treasury program.
+      The argument is still true and the primitive is still general — the
+      execution marker is a PDA at a derivable address, owned by the verifier,
+      whose existence *is* the proof that M distinct secret-bound nullifiers
+      resolved, and any program can gate on it. But a criterion that names a
+      treasury transfer is better answered by a treasury transfer, and a
+      treasury balance falling from 2 to 1 is a fact a reviewer reads off the
+      chain in one call. That is why the verifier was rebuilt and redeployed on
+      2026-08-24, and why every account address in this document moved with it:
+      on LEZ a program's identity *is* its ImageID, and every PDA is derived
+      from it.
 
-      The history is worth keeping, because the delay is real and will catch the
-      next recently-submitted hash. When this was first written none of the seven
-      rendered, though all seven were already on chain: the explorer indexes
-      separately from the sequencer and trails it, and its own front page listed
-      block 4351 as the most recent while the chain was at 4496. On the
-      2026-08-15 pass those same two numbers were **8633 and 8676** — a 43-block
-      lag, and every transaction here is far older than that. So a hash submitted
-      minutes ago can still read "Transaction not found" on the explorer while
-      `getTransaction` already returns it, for anyone's submission, not just this
-      one.
+      **On the block explorer.** Its index trails the sequencer — measured on
+      this chain at roughly an hour and three quarters — so a transaction
+      submitted minutes ago reads "Transaction not found" there while
+      `getTransaction` already resolves it. That is an indexing delay, not a
+      gap, and it affects anything recent by anyone. The deploy of
+      `membership_lez` sits at block 4459 and renders today; the seven
+      transactions of the 2026-08-24 lifecycle are recent, and render once the
+      index reaches block 20880. `./scripts/verify-onchain-lifecycle.sh` does
+      not depend on that index at all: it asks the sequencer, and it checks the
+      variant each transaction carries — which the explorer could not tell you
+      even fully caught up.
 
-      Worth stating plainly, because the obvious check misleads: the explorer
-      is a WASM app that serves an identical page shell for every hash and
-      renders client-side, so comparing response sizes cannot distinguish an
-      indexed transaction from one that does not exist.
-      `./scripts/check-explorer.py` renders the pages in a headless browser
-      instead, with an impossible hash as the control, and prints what it finds.
-      Re-run it; the answer is a measurement with a date on it, not a claim.
+      One correction, because this document used to state the opposite. It said
+      the explorer was a WASM app serving an identical shell for every hash, so
+      that comparing response sizes could not tell an indexed transaction from
+      one that cannot exist. That was true when `./scripts/check-explorer.py`
+      was written — it is why the script drives a browser at all — and it is not
+      true now: re-measured on **2026-08-15**, the explorer renders server-side,
+      and a single `curl` separates the two cases by size alone. The script
+      still renders each page headless against an impossible-hash control, and
+      aborts if that control ever renders as a *found* transaction rather than
+      report verdicts against a baseline that would be meaningless.
 
       `docs/DEPLOYMENT.md` gives a one-line `curl` per hash, and
       `./scripts/verify-onchain.sh` does the stronger check — it reads the five
       accounts the lifecycle created and confirms the verifier program owns
       them, which no transaction lookup can fake.
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
-      approved by threshold, and executed.** All three are readable in the block
-      explorer, and each one's **Program Owner** is the verifier: multisig
-      [`4wqJXoEh…`](https://explorer.testnet.lez.logos.co/account/4wqJXoEhqqqYknt1s7gHcgBL6pkfwNJDfhbVVeAqwtnX), proposal
-      [`E11Awng7…`](https://explorer.testnet.lez.logos.co/account/E11Awng7j59dVft83VVrwftXp41roJPKY5QRMb45Zcoe), execution marker
-      [`Cpiuic…`](https://explorer.testnet.lez.logos.co/account/CpiuicNDii6uCeMXtjd1W6hek6Vq35HJ7k3mz1Q82Fui). The owner
-      those pages show, `7AyJ7x4DuAa58ALGqLXYwqdhEvQLCz5A2GFdcDrwyzUZ`, decodes to
-      `5bb40082…a5966f82` — the ImageID `spel program-id
-      artifacts/programs/multisig_verifier.bin` computes from the binary committed
-      here. Nothing in that chain needs us.
+      approved by threshold, and executed — and the execution moves value.**
+      A 2-of-3 multisig, its treasury funded, a proposal published, two
+      approvals gathered on the privacy-preserving path, and executed, in blocks
+      20856-20880. Six accounts, all owned by the verifier:
+      multisig [`Hx7Ni2ri…`](https://explorer.testnet.lez.logos.co/account/Hx7Ni2riURJfgng4QAXb3RBq9ZMjrvwj7JREjut9PuBC),
+      treasury [`xtngupTp…`](https://explorer.testnet.lez.logos.co/account/xtngupTp3tcQU9faCbND73KhCpYqfBqKhmoepQAXoVx),
+      proposal [`9EjLSnKj…`](https://explorer.testnet.lez.logos.co/account/9EjLSnKjXB4r8SgBEHcgqf36nkqfyUVXuqSsDzCTRvg7),
+      execution marker [`BP6buTDd…`](https://explorer.testnet.lez.logos.co/account/BP6buTDdFThPYWU3NFGSsD8k3ymewStQo4hj86tAwq1a),
+      and the two approval markers. Their **Program Owner** is
+      `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, which base58-decodes to
+      `1346b652…98ff4e1e` — exactly the ImageID `spel program-id
+      artifacts/programs/multisig_verifier.bin` computes from the binary
+      committed here. Nothing in that chain needs us.
 
-      `git clone && ./scripts/demo.sh` re-runs the check from a clean clone: it
-      derives the three addresses, reads them from the sequencer and reports the
-      owner and the approval count. `./scripts/verify-onchain.sh` is the deeper
-      version and needs the working directory a lifecycle run leaves behind, so it
-      is for whoever has just run one, not for a first reader.
+      The number only a real execution could produce is the treasury's:
+      `fund_treasury` put **2** into it and `execute` moved **1** out, and the
+      other side of that move is a seventh account that is *not* the
+      program's — the recipient
+      [`8kexXda8…`](https://explorer.testnet.lez.logos.co/account/8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn),
+      **0 → 1**, held by the native transfer program rather than by the
+      verifier, which is what makes what it received spendable instead of
+      stranded.
+
+      `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean
+      clone in about five seconds and takes no arguments: it recomputes both
+      deploy hashes from the committed bytecode, resolves the eight
+      transactions, and asserts the variant each one carries — the two
+      approvals must be `PrivacyPreserving` and not `Public`, which is the part
+      a block explorer cannot show you. `./scripts/verify-onchain.sh` is the
+      deeper pass: it reads the six accounts back and decodes every record at
+      the byte offsets published in `docs/account-layout.md`.
+
+      **On the explorer, these are recent.** The indexer trails the sequencer,
+      so freshly-created accounts can read `Program Owner:
+      11111111111111111111111111111111` and `Data: 0 bytes` for a while after
+      they exist. `getAccount` answers correctly the whole time, and both
+      scripts above use it.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability
@@ -385,7 +415,9 @@ under v0.2.0. Neither describes the current chain; the numbers above do.
 
 ### Supportability
 
-61 tests across five suites, counted and itemised in the README. Every one of
+**97 tests** across seven suites, counted and itemised in the README, and
+fifty-nine of them run the **built verifier binary** through the sequencer's own
+executor rather than the host crate. Every one of
 the thirteen documented error codes is exercised against the built binary, and
 the bindings they enforce are written up in `docs/security.md`. The two guest
 crates are excluded from the host workspace because they target
@@ -405,7 +437,7 @@ the Scope section adds a seventh. Rather than leave them to be hunted for:
 | **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
 | **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) |
 | **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
-| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `5bb40082…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
+| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) shows a clean rebuild reproducing `1346b652…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
 | **Security assumptions** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
 | **Known limitations** | [`docs/security.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
 | **Integration instructions** | [`README.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/docs/DEPLOYMENT.md) for deployment |

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -34,8 +34,9 @@ are anchored by PDA address, so neither can be invented or lowered.
   exercised exactly the code under review.
 - **Video:** two narrated films — the whole lifecycle against a standalone
   sequencer with two real proofs, and a 76-second reading of this deployment. They
-  play inline in the pull request and are committed under `recordings/`. Both were
-  shot for this submission and show their own commit on screen.
+  play inline in the pull request, and are committed under `recordings/` on `main`
+  so a bare clone carries them. Both were shot for this submission and show their
+  own commit on screen.
 - **Where the detail lives:** `docs/security.md` (threat model),
   `docs/cu-costs.md`, `docs/error-codes.md`, `docs/lez-account-model.md`,
   `docs/account-layout.md`, `docs/DEPLOYMENT.md`, `vendor/spel/PATCH.md`.
@@ -224,7 +225,7 @@ including `tiers_hash` and `superseded_by`.
   `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12 to 2 h 49** across the green GitHub runs. `scripts/demo.sh` is the twenty-second tour without a sequencer — it reads the live chain and shows the tier and a rotation.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  Two films (committed under `recordings/`, and inline in the PR). This one is a single take of `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose hash is on screen (the reviewed commit `e9e8fcd` is two commits later; `git diff c72ff1c e9e8fcd --stat` is `docs/recording-evidence.md` alone, the verifier binary byte-identical across the range). It starts a real standalone LEZ sequencer, deploys both programs, gathers **two real Risc0 approvals**, executes, and reads the accounts back, closing on `PASS (…, 2-of-3, RISC0_DEV_MODE=0)`. `RISC0_DEV_MODE=0` shows before any proving starts and again in that line. Only the stretch where the prover works and the screen is static is sped up, factor **63** on screen while it plays. The other film is the 76-second reading of the public-testnet deployment.
+  Two films (inline in the PR, and committed under `recordings/` on `main`). This one is a single take of `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose hash is on screen (the reviewed commit `e9e8fcd` is two commits later; `git diff c72ff1c e9e8fcd --stat` is `docs/recording-evidence.md` alone, the verifier binary byte-identical across the range). It starts a real standalone LEZ sequencer, deploys both programs, gathers **two real Risc0 approvals**, executes, and reads the accounts back, closing on `PASS (…, 2-of-3, RISC0_DEV_MODE=0)`. `RISC0_DEV_MODE=0` shows before any proving starts and again in that line. Only the stretch where the prover works and the screen is static is sped up, factor **63** on screen while it plays. The other film is the 76-second reading of the public-testnet deployment.
 
 ## FURPS Self-Assessment
 

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -18,7 +18,7 @@ are anchored by PDA address, so neither can be invented or lowered.
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
 - **Reviewed commit:**
-  [`c72ff1c`](https://github.com/edenbd1/lp-0002-private-multisig/tree/c72ff1c54a5656387ef20052551925efc339d914).
+  [`511434b`](https://github.com/edenbd1/lp-0002-private-multisig/tree/511434bf6b2933f5c810554e03021b9dd1c10d5d).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -37,7 +37,7 @@ are anchored by PDA address, so neither can be invented or lowered.
   is five files — the deployment and CU-cost documents, the film's transcript and
   its recording-evidence anchor, and the transcript-checker gate — with no program,
   no script the demo runs and no artefact the chain sees among them, so
-  `git diff 1759015 c72ff1c --stat` is the whole of it and that run exercised
+  `git diff 1759015 511434b --stat` is the whole of it and that run exercised
   exactly the code under review. Both program binaries also hash identically
   across every commit in the range, so the thing being proved has not moved
   underneath the proof.
@@ -271,8 +271,8 @@ It takes those two arguments so it can be pointed at any run, not only this one.
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   Two films play inline in the pull request. This one is a single take of
   `scripts/e2e-local-sequencer.sh` — the script CI runs — at `b4f53ba`, whose hash
-  is on screen; the reviewed commit `c72ff1c` is a later descendant — run
-  `git diff b4f53ba c72ff1c --stat`: four documents, the film's transcript and its
+  is on screen; the reviewed commit `511434b` is a later descendant — run
+  `git diff b4f53ba 511434b --stat`: four documents, the film's transcript and its
   recording-evidence anchor plus the deployment and CU-cost notes corrected after the
   shoot — no program, no script, no chain artefact, and the verifier binary is
   byte-identical across the range. It starts a real LEZ sequencer in standalone mode,

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -169,84 +169,76 @@ reads the accounts back and decodes every record at the offsets
 
 ### Functionality
 
-- [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
-      without revealing their identity to on-chain observers or other members.**
+- [x] **Any M-of-N member holding a shielded LEZ account can submit an approval without revealing their identity to on-chain observers or other members.**
   The only trace is a marker PDA seeded by a secret-bound nullifier; `docs/security.md` states the threat model against three adversaries, ending at the insider.
 
-- [x] **The on-chain verifier confirms a threshold of M approvals was reached
-      without recording which members approved.**
+- [x] **The on-chain verifier confirms a threshold of M approvals was reached without recording which members approved.**
   `execute`, checks 5–7.
 
-- [x] **A member cannot approve the same proposal twice.**
+- [x] **A member cannot approve the same proposal twice (double-vote prevention via nullifiers or equivalent).**
   The nullifier is deterministic per `(proposal, member)`, so a second approval targets an occupied PDA and `init` refuses.
 
-- [x] **A completed execution is unlinkable to any individual member's shielded
-      account.**
+- [x] **A completed execution is unlinkable to any individual member's shielded account.**
   `execute` consumes marker addresses and is signed by an executor who need not be a member at all.
 
 - [x] **Proof generation runs client-side on a standard laptop.**
   Approvals are built by `msig approve-args` and proved locally: **484 s and 550 s** for the deployed run's two transfer approvals, timed by the script itself. Read per machine rather than as one number — `docs/cu-costs.md` tabulates measurements across two machines and two LEZ versions, 149 s to 4033 s.
 
-- [x] **A reference integration on LEZ testnet.**
+- [x] **A reference integration is delivered: a working demo of a threshold-gated action (e.g., treasury transfer or parameter change) on LEZ testnet using shielded member accounts.**
   The lifecycle below.
 
-- [x] **At least 1 multisig instance on testnet with a proposal submitted,
-      approved by threshold, and executed — and the execution moves value.**
+- [x] **At least 1 multisig instance is created on LEZ testnet, with at least one proposal submitted, approved by threshold, and executed; the deployment must be reproducible and evidence must be provided.**
   A **3-of-3** with a spending tier created, its treasury funded, a proposal published, **two** approvals gathered on the privacy-preserving path, and executed — then the same member set voted to replace itself, three more approvals and a `rotate_config`. Thirteen transactions in blocks 23028–23554, all live, detailed above.
 
-- [x] **Full documentation and a clean public repository.**
+- [x] **Full documentation and a clean public repository are delivered.**
 
 ### Usability
 
-- [x] **Provide a module/SDK that can be used to build Logos modules for
-      interacting with the program.**
+- [x] **Provide a module/SDK that can be used to build Logos modules for interacting with the program.**
   `crates/multisig-sdk`, transport-agnostic: it opens no socket and touches no filesystem.
 
-- [x] **Basecamp app GUI with local build instructions and loadable assets.**
+- [x] **Provide a Logos Basecamp app GUI with local build instructions, downloadable assets, and loadable in Logos app (Basecamp).**
   `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB), built with the **real `lgx`** from `logos-co/logos-package` and passing `lgx verify`, carrying **two variants** — `darwin-arm64` and `linux-amd64` — so it opens on the machine the evaluator actually reviews on.
 
   **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared loadable: the module loads, and pressing *Status* against a multisig folder returns that deployment's live state — the then-current one, with its approval markers. The tile renders whatever the CLI shipped inside the package prints rather than computing anything itself, and `app/README.md` says which session was driven and against what, rather than re-quoting it for a later deployment. Doing that found three packaging defects — a Qt newer than the one Basecamp runs, a private IID, and an extra virtual that shifted every later vtable slot — all fixed, described in `app/README.md`, and now refused by `scripts/package-lgx.py`. **The Linux variant is load-tested against Basecamp's own Qt**, extracted from the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the click, since headless there is nothing to click. That half ran on macOS.
 
-- [x] **Provide an IDL for the LEZ program, using the SPEL framework.**
+- [x] **Provide an IDL for the LEZ program, using the [SPEL framework](https://github.com/logos-co/spel).**
   `idl/multisig_verifier.idl.json`, generated from source by `spel generate-idl`.
 
 ### Reliability
 
-- [x] **Proof generation failures surface a clear error.**
+- [x] **The system handles proof generation failures gracefully and surfaces a clear error to the member.**
   `approve-args` verifies the witness locally before emitting anything, so a bad witness fails in microseconds rather than after minutes of proving.
 
-- [x] **A partial set of approvals is preserved and resumable across client
-      restarts.**
+- [x] **A partial set of approvals (fewer than M) is preserved and resumable across client restarts.**
   Every approval is recorded in `proposals/<id>.json` before the command returns — not incidental, since proving takes minutes and a real threshold *is* gathered across sessions and days.
 
-- [x] **Deterministic, documented error codes.**
+- [x] **The verifier program returns deterministic, documented error codes for all invalid-proof and double-vote scenarios.**
   Twenty-seven, `5001`–`5027`, in `docs/error-codes.md`, each mapped to the attack it stops and the test that proves it.
 
 ### Performance
 
-- [x] **CU cost of each on-chain operation documented.**
+- [x] **Document the compute unit (CU) cost of each on-chain operation on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
   `docs/cu-costs.md`: `approve` 541,207 user cycles, `execute` linear in M at 81,046 per approval, `rotate_config` 750,617 — 3.12 % of the public budget. Measured by replaying through the sequencer's own executor, reproducible with one command.
 
 ### Supportability
 
-- [x] **Deployed and tested on LEZ devnet/testnet.**
+- [x] **The program is deployed and tested on LEZ devnet/testnet.**
   Both programs deployed; the full lifecycle and the rotation run, and independently re-verifiable over JSON-RPC.
 
-- [x] **E2E integration tests run against a LEZ sequencer (standalone mode), in
-      CI.**
+- [x] **End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
   Two layers. `multisig-verifier-tests` runs the built binary through the sequencer's own **executor** on every push — same executor, same input order, same 32M session limit. On top of that, `.github/workflows/e2e-local-sequencer.yml` starts the actual `sequencer_service` binary in **standalone mode** and drives the whole lifecycle against it over JSON-RPC with a real proof.
 
-- [x] **CI green on the default branch.**
+- [x] **CI must be green on the default branch.**
   Ubuntu and macOS both.
 
-- [x] **README documents end-to-end usage**
+- [x] **A README documents end-to-end usage: deployment steps, program addresses, and step-by-step instructions for interacting with the program via CLI and Basecamp app.**
   — deployment steps, program addresses, and instructions for both the CLI and the Basecamp app.
 
-- [x] **Reproducible demo script working against a real local sequencer with
-      `RISC0_DEV_MODE=0`.**
+- [x] **A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
   `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub runner. `scripts/demo.sh` is the five-second tour without a sequencer, and shows the tier and a rotation as well.
 
-- [x] **Recorded narrated video demo.**
+- [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   <https://youtu.be/cPVsWWBVEeE> — the terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any proving starts, and the approval is a real proof generated in one uninterrupted take with its wall clock printed at the end. It predates this redeploy, so its on-screen identifiers are superseded ones; the 47-second reading attached to the pull request is of the current deployment.
 
 ## FURPS Self-Assessment

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -17,17 +17,19 @@ threshold are anchored by PDA address, so neither can be invented or lowered.
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
-- **Reviewed commit:** [`3d19fd5`][commit]. Every link below names that commit
+- **Reviewed commit:** [`861e447`][commit]. Every link below names that commit
   rather than `main`, so the version under review cannot move after this opens.
-- **CI on that exact commit, both green:** [the host suite and the
-  deployed-binary audit][ci1] — 97 tests, 59 of which run the built verifier
-  through the sequencer's own executor — and [the full lifecycle against a
-  standalone LEZ sequencer][ci2], 2 h 12 with `RISC0_DEV_MODE=0`, which builds
-  LEZ at a pinned revision, starts the sequencer, and drives the whole 2-of-3
-  lifecycle against it, two real proofs included.
+- **CI on that commit:** [the host suite and the deployed-binary audit][ci1] —
+  **130 tests**, 84 of which run the built verifier through the sequencer's own
+  executor. The [full lifecycle against a standalone LEZ sequencer][ci2] — 2 h 12
+  with `RISC0_DEV_MODE=0`, building LEZ at a pinned revision and driving the whole
+  lifecycle against it with real proofs — ran on `3a6857b`, its parent. The two
+  differ by one line of `Cargo.toml` silencing a style lint, which reaches no
+  compiled byte: both binaries hash identically, and the note in the manifest says
+  why the alternative was refused.
 - **Video:** a 47-second narrated reading of this deployment is attached to
   [the pull request][pr] and plays inline. The ten-minute walkthrough at
-  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-24 redeploy, so its
+  <https://youtu.be/cPVsWWBVEeE> predates the 2026-08-25 redeploy, so its
   on-screen identifiers are the superseded ones.
 
 ## Approach
@@ -59,13 +61,13 @@ A membership proof establishes membership against whatever root the statement
 names, which alone is worthless: anyone can build a one-leaf tree holding
 themselves. So the member set is anchored **by address** — the multisig is a PDA
 seeded by `[multisig_id, config_hash]`, only `create_multisig` initialises it, and
-an invented root gives an address nobody created, whose owner is the default
-(`5003`). The threshold sits inside the same hash,
-`config_hash = H(member_root ‖ threshold)`, so `threshold = 1` against a 3-of-5
-set resolves to a PDA nobody created either; no code path anywhere reads a
-threshold from caller-supplied data. Folding it into the address rather than
-storing it in account data makes the forgery *unrepresentable* rather than merely
-checked.
+an invented root gives an address nobody created (`5003`). The threshold and the
+spending tiers sit inside the same hash,
+`config_hash = H(member_root ‖ threshold ‖ tiers_hash)`, so a lowered threshold or
+a more generous tier table resolves to a PDA nobody created either. No code path
+reads either from caller-supplied data without re-deriving that commitment.
+Folding them into the address makes the forgery *unrepresentable* rather than
+merely checked.
 
 The third attack took me longest to see. If approvals were scoped to a proposal
 id alone, a proposer could publish a harmless action, collect M approvals, then
@@ -79,28 +81,26 @@ markers.
 
 Each approval occupies a PDA seeded by
 `H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
-`nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`, so two different
-addresses imply two different secrets. `execute` checks the nullifiers are
-pairwise distinct (`5011`), that each account presented is the marker PDA for the
-nullifier it was paired with *on this proposal* (`5012`), and that the verifier
-owns it (`5013`) — which it can only do if a membership proof was verified on
-chain.
+`nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`, so two addresses
+imply two secrets. `execute` checks the nullifiers are pairwise distinct (`5011`),
+that each account is the marker PDA for the nullifier it was paired with *on this
+proposal* (`5012`), and that the verifier owns it (`5013`) — which it can only do
+if a membership proof was verified on chain.
 
 ### Targeting the current testnet, and the SPEL patch that took
 
 The testnet was reset onto a newer chain in August, and everything deployed
 against **v0.2.0** stopped being accepted — not "went stale", but rejected
 outright, with submitted transactions returning a hash whose `getTransaction` is
-`null`. Everything here was rebuilt against **LEZ v0.2.4**, redeployed, and the
-whole lifecycle re-run.
+`null`. Everything here was rebuilt against **LEZ v0.2.4** and redeployed.
 
 That is also why this repository vendors SPEL: release **v0.6.0** still pins LEZ
 v0.2.0 in about twenty places, so "use SPEL" and "transact on the current
 testnet" could not both be satisfied with anything published. `vendor/spel` is
-upstream v0.6.0 with the minimum changes to do both, documented change by change
-in [`vendor/spel/PATCH.md`][patch]. Worth flagging because it wastes a reviewer's
-day: released SPEL *builds* cleanly against v0.2.4 and then fails at run time on
-every instruction with `missing field 'sequencer_addr'`.
+upstream v0.6.0 with the minimum changes, documented one by one in
+[`vendor/spel/PATCH.md`][patch]. Worth flagging because it wastes a reviewer's
+day: released SPEL *builds* against v0.2.4 and then fails at run time on every
+instruction with `missing field 'sequencer_addr'`.
 
 ## Success Criteria Checklist
 
@@ -109,8 +109,8 @@ every instruction with `missing field 'sequencer_addr'`.
 - [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
       without revealing their identity to on-chain observers or other members.**
       The only trace is a marker PDA seeded by a secret-bound nullifier;
-      [`docs/security.md`][sec] states the threat model against three adversaries
-      including the insider.
+      [`docs/security.md`][sec] states the threat model against three adversaries,
+      ending at the insider.
 - [x] **The on-chain verifier confirms a threshold of M approvals was reached
       without recording which members approved.** `execute`, checks 5–7.
 - [x] **A member cannot approve the same proposal twice.** The nullifier is
@@ -128,22 +128,29 @@ every instruction with `missing field 'sequencer_addr'`.
 - [x] **At least 1 multisig instance on testnet with a proposal submitted,
       approved by threshold, and executed — and the execution moves value.**
 
-  A 2-of-3 multisig created, its treasury funded, a proposal published, two
-  approvals gathered on the privacy-preserving path, and executed: **eight
-  transactions** in blocks 20856–20880, all live. The criterion offers *treasury
-  transfer or parameter change* as examples and this is the first, performed
-  rather than described — `execute` moves the amount out of the treasury and into
-  the recipient in one transaction, a debit and a credit that balance, which is
-  the only shape LEZ accepts.
+  A **3-of-3** multisig with a spending tier created, its treasury funded, a
+  proposal published, **two** approvals gathered on the privacy-preserving path,
+  and executed: **eight transactions** in blocks 23028–23066, all live.
+
+  **Two approvals against a threshold of three**, because the tier this multisig
+  anchors covers the amount proposed. That is the tier doing something, counted in
+  proofs not generated rather than claimed in prose. And it is anchored rather
+  than merely applied: `config_hash` is `1628d88b…`, and the same members and
+  threshold without the tier give `3dff16d7…` — a different PDA, an account nobody
+  created. A caller who invents a more generous table has to present a
+  `config_hash` committing to it, and that hash is the address they then read
+  from. The criterion offers *treasury transfer
+  or parameter change* as examples and this is the first, performed rather than
+  described.
 
   Six accounts, all owned by the verifier:
-  multisig [`Hx7Ni2ri…`](https://explorer.testnet.lez.logos.co/account/Hx7Ni2riURJfgng4QAXb3RBq9ZMjrvwj7JREjut9PuBC),
-  treasury [`xtngupTp…`](https://explorer.testnet.lez.logos.co/account/xtngupTp3tcQU9faCbND73KhCpYqfBqKhmoepQAXoVx),
-  proposal [`9EjLSnKj…`](https://explorer.testnet.lez.logos.co/account/9EjLSnKjXB4r8SgBEHcgqf36nkqfyUVXuqSsDzCTRvg7),
-  execution marker [`BP6buTDd…`](https://explorer.testnet.lez.logos.co/account/BP6buTDdFThPYWU3NFGSsD8k3ymewStQo4hj86tAwq1a),
+  multisig [`C9CgRDNf…`](https://explorer.testnet.lez.logos.co/account/C9CgRDNfrCUJMzYG1YbskwViRTpDypty74YC2KThcxL3),
+  treasury [`FyTtsh2h…`](https://explorer.testnet.lez.logos.co/account/FyTtsh2h5fC85vrei19ThtM4yRThHEH4MGtXH1azrdhM),
+  proposal [`5kM4uZdH…`](https://explorer.testnet.lez.logos.co/account/5kM4uZdHgwjanoX82PtmeRUptkekm4EfjCzvmz6r7MHz),
+  execution marker [`J1N6WWpH…`](https://explorer.testnet.lez.logos.co/account/J1N6WWpHVPh6pBpXmKAe522JBEWaaRT3jymaWcczg5AG),
   and the two approval markers. Their **Program Owner** is
-  `2JFHW18V15yv6C9Xs4AMERE92Q8FrRfRULSSMkQszA45`, base58-decoding to
-  `1346b652…98ff4e1e` — exactly the ImageID `spel program-id
+  `CMNWomcJfauikXikhbN18jk4bRFeDScgKdSUwzqUjdMy`, base58-decoding to
+  `a8a87f8b…61500750` — exactly the ImageID `spel program-id
   artifacts/programs/multisig_verifier.bin` computes from the binary committed
   here. Nothing in that chain needs us.
 
@@ -159,28 +166,26 @@ every instruction with `missing field 'sequencer_addr'`.
   | Step | Transaction | Block |
   |---|---|---|
   | deploy `membership_lez` | [`fb8eb10f…a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
-  | deploy `multisig_verifier` | [`2d6f720e…3231e82e2`](https://explorer.testnet.lez.logos.co/transaction/2d6f720e3c6dd8d876c8617eada5ddcd3c13a978b2edcb1921a3de73231e82e2) | 20856 |
-  | `create_multisig` | [`a8d8422a…c9a25ab55`](https://explorer.testnet.lez.logos.co/transaction/a8d8422ae2c46566b15c31954647974d3e95eadbe0b560eac4ab609c9a25ab55) | 20857 |
-  | `fund_treasury` | [`2844eef1…a30bb6a5c2`](https://explorer.testnet.lez.logos.co/transaction/2844eef12695ab0d3c6d55832e94ae316638dd7400735d2f393875a30bb6a5c2) | 20858 |
-  | `create_proposal` | [`b194da9b…71fed9826`](https://explorer.testnet.lez.logos.co/transaction/b194da9ba24e1a17a7bec0d64da0d252a96c6edc96208a778a7e77e71fed9826) | 20859 |
-  | `approve` (member A, **privacy tx**) | [`d1381309…36e70a91c0`](https://explorer.testnet.lez.logos.co/transaction/d13813094f36c1b60c02350adbc272ce5aa88dd7d87ab409a3e36436e70a91c0) | 20869 |
-  | `approve` (member B, **privacy tx**) | [`9f7c541c…ceed7219719`](https://explorer.testnet.lez.logos.co/transaction/9f7c541c187c6ed284f67b0f5c6f0942de0ed98ff7e589dc81955ceed7219719) | 20879 |
-  | `execute` | [`00ea6838…2be7f75ae`](https://explorer.testnet.lez.logos.co/transaction/00ea68384758097dba8b648605b4ecf65d9535ba6b497af335d4fcf2be7f75ae) | 20880 |
+  | deploy `multisig_verifier` | [`268834b6…4be31aa3`](https://explorer.testnet.lez.logos.co/transaction/268834b601f78b59090e90f8f10fd8ce3b526528e1224983edba95224be31aa3) | 23028 |
+  | `create_multisig` | [`dce8fd4d…b69d1db0`](https://explorer.testnet.lez.logos.co/transaction/dce8fd4dc4b53216d7271466ba66290b3bbfb2cf125701cd7c97a68cb69d1db0) | 23029 |
+  | `fund_treasury` | [`993d1f7c…c94f640b`](https://explorer.testnet.lez.logos.co/transaction/993d1f7c2b27fcab1abf759513f7bf7c64449a547b608e692deae67ec94f640b) | 23030 |
+  | `create_proposal` | [`54a300eb…65c4fdd3`](https://explorer.testnet.lez.logos.co/transaction/54a300eb8c0bec27adb40b3ab36ff653b6234dc4deab2a47ac89a0a665c4fdd3) | 23031 |
+  | `approve` (member A, **privacy tx**) | [`1a5e529d…dbf6fcd5`](https://explorer.testnet.lez.logos.co/transaction/1a5e529d8b9c87ec781b6e8cc2d4bc71c149e7f45f9ce66711108a22dbf6fcd5) | 23039 |
+  | `approve` (member B, **privacy tx**) | [`28a07e8d…815e8397`](https://explorer.testnet.lez.logos.co/transaction/28a07e8df970322b643d7d5d6c74640f49e6d0260964255909181fdc815e8397) | 23065 |
+  | `execute` | [`d0bab294…5ba8ca7c`](https://explorer.testnet.lez.logos.co/transaction/d0bab2943f09d3a27a10610c49c2a6cce1a2c94b93ded6f341ce29005ba8ca7c) | 23066 |
 
   `./scripts/verify-onchain-lifecycle.sh` re-checks all of it from a clean clone
   in about five seconds, no arguments: it recomputes both deploy hashes from the
-  committed bytecode, resolves the eight transactions, and asserts the variant
-  each carries — the two approvals must be `PrivacyPreserving`, which is the part
-  a block explorer cannot show you. `./scripts/verify-onchain.sh` reads the six
-  accounts back and decodes every record at the byte offsets published in
-  `docs/account-layout.md`.
+  committed bytecode, resolves the eight transactions, and asserts each variant.
+  `./scripts/verify-onchain.sh` reads the accounts back and decodes every record
+  at the offsets `docs/account-layout.md` publishes — including `tiers_hash` and
+  `rotate_to`, the two fields this revision added.
 
-  **These are recent, and the explorer's index trails the sequencer** by about an
-  hour and three quarters — so a fresh account can read `Program Owner:
-  1111…1111` and a recent hash "Transaction not found". That is an indexing
-  delay, not a gap, and it affects anything recent by anyone; `getAccount` and
-  `getTransaction` answer correctly throughout, and both scripts ask the
-  sequencer.
+  **All eight render on the explorer**, checked after the index passed block
+  23066: two Deployment, four Public, and the two approvals as
+  *Privacy-Preserving*. The control is an impossible hash, which returns a 2,416
+  byte not-found shell, so the classification discriminates rather than merely
+  fetching.
 - [x] **Full documentation and a clean public repository.**
 
 ### Usability
@@ -197,21 +202,18 @@ every instruction with `missing field 'sequencer_addr'`.
       on.
 
   **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared
-  loadable: the module loads (`Successfully loaded UI module`) and pressing
-  *Status* against `artifacts/testnet` returns the live deployment's
-  `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers. Doing that found
-  three packaging defects, all fixed and described in [`app/README.md`][appreadme]
-  — a Qt newer than the one Basecamp runs, a private IID instead of
-  `com.logos.component.IComponent`, and an extra virtual that shifted every later
-  vtable slot — and `scripts/package-lgx.py` now refuses to package a binary with
-  any of them.
+  loadable: the module loads and pressing *Status* against `artifacts/testnet`
+  returns the live deployment's `3-of-3 · 2/2 READY TO EXECUTE` — two markers,
+  because the anchored tier is what this amount costs. Doing that found
+  three packaging defects — a Qt newer than the one Basecamp runs, a private IID,
+  and an extra virtual that shifted every later vtable slot — all fixed, described
+  in [`app/README.md`][appreadme], and now refused by `scripts/package-lgx.py`.
 
   **The Linux variant is load-tested against Basecamp's own Qt**, extracted from
-  the `x86_64.AppImage` in that same release: `QPluginLoader::instance()` then
-  `qobject_cast<IComponent*>` against *that* Qt gives `SUCCESS: loaded + cast to
-  IComponent`, and the harness was shown able to fail — a real Qt plugin with a
-  different IID gives `CAST FAILED`. What is *not* claimed is the click, since
-  headless there is nothing to click; that half was exercised on macOS.
+  the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then
+  `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to
+  fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the
+  click, since headless there is nothing to click. That half ran on macOS.
 - [x] **Provide an IDL for the LEZ program, using the SPEL framework.**
       `idl/multisig_verifier.idl.json`, generated from source by
       `spel generate-idl`.
@@ -225,17 +227,16 @@ every instruction with `missing field 'sequencer_addr'`.
       restarts.** Every approval is recorded in `proposals/<id>.json` before the
       command returns — not incidental, since proving takes minutes and a real
       threshold *is* gathered across sessions and days.
-- [x] **Deterministic, documented error codes.** Twenty-two, `5001`–`5022`, in
+- [x] **Deterministic, documented error codes.** Twenty-seven, `5001`–`5027`, in
       [`docs/error-codes.md`][ec], each mapped to the attack it stops and the
       test that proves it.
 
 ### Performance
 
 - [x] **CU cost of each on-chain operation documented.** [`docs/cu-costs.md`][cu]:
-      `approve` 337,105 user cycles; `execute` linear in M at ~48,600 per
-      approval; all inside one segment at 1.56 % of the public budget. Measured
-      by replaying through the sequencer's own executor, reproducible with one
-      command.
+      `approve` 541,207 user cycles, `execute` linear in M at 81,046 per approval,
+      `rotate_config` 750,617 — 3.12 % of the public budget. Measured by replaying
+      through the sequencer's own executor, reproducible with one command.
 
 ### Supportability
 
@@ -244,12 +245,10 @@ every instruction with `missing field 'sequencer_addr'`.
 - [x] **E2E integration tests run against a LEZ sequencer (standalone mode), in
       CI.** Two layers. `multisig-verifier-tests` runs the built binary through
       the sequencer's own **executor** on every push — same executor, same input
-      order, same 32M session limit — which is what makes 25 adversarial
-      rejections cheap enough to gate a commit. On top of that,
+      order, same 32M session limit. On top of that,
       [`e2e-local-sequencer.yml`][e2eyml] starts the actual `sequencer_service`
       binary in **standalone mode** and drives the whole lifecycle against it over
-      JSON-RPC, scheduled rather than per-push because it builds the LEZ
-      workspace and then generates a real proof.
+      JSON-RPC with a real proof.
 - [x] **CI green on the default branch.** Ubuntu and macOS both.
 - [x] **README documents end-to-end usage** — deployment steps, program
       addresses, and instructions for both the CLI and the Basecamp app.
@@ -257,20 +256,16 @@ every instruction with `missing field 'sequencer_addr'`.
       `RISC0_DEV_MODE=0`.** `scripts/e2e-local-sequencer.sh` starts a real
       standalone sequencer, funds a throwaway wallet from its genesis vault,
       deploys both programs onto that fresh chain, and runs create → propose →
-      *real Risc0 approvals* → execute, then reads the resulting accounts back off
-      it. Nothing mocked, `RISC0_DEV_MODE=0` throughout: **1333 s** for a 2-of-3
-      on an Apple-silicon laptop, of which **444 s** and **704 s** are the two
-      real proofs, and **2 h 12** on a GitHub runner. `scripts/demo.sh` is the
-      five-second tour without a sequencer.
+      *real Risc0 approvals* → execute, then reads the accounts back off it.
+      Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12** on a GitHub
+      runner. `scripts/demo.sh` is the five-second tour without a sequencer, and
+      now shows the tier and a rotation as well.
 - [x] **Recorded narrated video demo.** <https://youtu.be/cPVsWWBVEeE> — the
       terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any
       proving starts, and the approval is a real proof generated in one
-      uninterrupted take with its wall clock printed at the end. That is what
-      satisfies this criterion, because it is the recording that shows proving.
-      It predates the 2026-08-24 redeploy, so its on-screen identifiers are the
-      superseded ones; the deployment under review is what the 47-second film on
-      [the pull request][pr] reads back off the chain, and that one shows no
-      proving.
+      uninterrupted take with its wall clock printed at the end — the recording
+      that shows proving, which is what this criterion asks for. It predates the
+      2026-08-25 redeploy, so its on-screen identifiers are superseded ones.
 
 ## FURPS Self-Assessment
 
@@ -278,8 +273,20 @@ every instruction with `missing field 'sequencer_addr'`.
 
 Four instructions: `create_multisig`, `create_proposal`, `approve`, `execute`.
 Seven documented bindings, each with adversarial coverage. **Limitations, stated
-rather than buried:** the member set is fixed at creation (no rotation), and
-proposals do not expire.
+rather than buried:** proposals do not expire, and a rotation is visible — an
+observer sees that one happened and which configuration replaced which, only not
+who voted for it.
+
+`rotate_config` replaces a configuration rather than rewriting one: it anchors a
+second at its own PDA with its own treasury and marks the first superseded, so
+every guarantee the address gives the old one the new one has by construction. No
+stale-proposal check exists and none is needed — `proposal_ref` derives through
+`config_hash`, so proposals raised under the old configuration live at addresses
+the new one never reads. It costs the *default* threshold, never a tier: pricing
+governance by tier would make the cheapest action available the one that rewrites
+who may act. Covered by 23 tests and 13 mutations; not yet exercised on chain,
+because the testnet wallet holds too few approver accounts to fund a second
+round of proofs, and that is stated here rather than left to be discovered.
 
 ### Usability
 
@@ -299,26 +306,29 @@ than trust the CLI's verdict.
 
 ### Performance
 
-`approve` at **337,105 user cycles**, 1.56 % of the public compute budget, with
-headroom to 524,288 before a second segment. Wall clock is dominated entirely by
-proving.
+`approve` at **541,207 user cycles**, 3.12 % of the public budget. Wall clock is
+dominated entirely by proving: **484 s and 550 s** for this deployment's two
+approvals.
 
-Two things cut against this submission. **The version got slower**: the same
-lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is about three times more
-expensive — CI went 1264 s to 4033 s across the same upgrade, which is enough to
-stop calling it variance. **And the 440/469 s above were taken under CPU
-contention**, so they are not a best case dressed up: an idle laptop measures
-437 s for the same approval, and 935 s with one unrelated proof running. The
-honest summary is a range with a machine attached — about seven minutes on an
-idle laptop, sixty-seven on a shared runner — and [`docs/cu-costs.md`][cu] gives
-every figure with the machine and LEZ version it was taken on.
+Three things cut against this submission and all three are in
+[`docs/cu-costs.md`][cu] with the machine and LEZ version attached. **The version
+got slower**: the same lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is
+about three times more expensive — CI went 1264 s to 4033 s. **Spending tiers
+made every instruction dearer** by 45,000–52,000 cycles, and pushed `execute` at
+M=5 from one segment to two, which is the one figure that changes what an
+operator must plan for. The tier itself is nearly free; what is paid everywhere
+is the anchoring, including by multisigs that have none. **And proving times vary
+with contention**: an idle laptop measures 437 s where a shared runner took
+sixty-seven minutes, so the honest summary is a range, not a number.
 
 ### Supportability
 
-**97 tests** across seven suites, itemised in the [README][readme], fifty-nine of
-them running the **built verifier binary** through the sequencer's own executor
-rather than the host crate — and every one of the twenty-two error codes is
-exercised against that binary. The two guest crates target
+**130 tests** across eight suites, itemised in the [README][readme], eighty-four
+of them running the **built verifier binary** through the sequencer's own executor
+rather than the host crate — and every one of the twenty-seven error codes is
+exercised against that binary. Thirteen mutations were run against the guards the
+tier and rotation work added, each rebuilt through the reproducible Docker build
+with the binary's hash required to move first; thirteen were caught. The two guest crates target
 `riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the
 deployed program is still under test, because `multisig-verifier-tests` is a
 workspace member exercising it. CI runs on Ubuntu and macOS, and a dedicated job
@@ -327,43 +337,54 @@ fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary
 
 ## Write-up, by the topics the brief names
 
-| Required topic | Where |
-|---|---|
-| **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
-| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`][sec] |
-| **LEZ account model compatibility** (**nonce**, **`program_owner`**) | [`docs/lez-account-model.md`][acct], in full. The nonce constraint never binds on membership — a member is a Merkle leaf, not an account this program touches; it binds one level up, on the account that *submits*, which may be a relayer. `program_owner` is load-bearing rather than an obstacle: it is how an uninitialised PDA is detectable |
-| **Trusted setup** | **None.** Risc0 is STARK-based and transparent: no reference string, no ceremony, no toxic waste. The only trusted parameters are the two ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`][dep] shows a clean rebuild reproducing `1346b652…` |
-| **Security assumptions** | [`docs/security.md`][sec] — three adversaries in increasing order of knowledge, ending at the insider |
-| **Known limitations** | [`docs/security.md`][sec] — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
-| **Integration instructions** | [`README.md`][readme], and [`docs/DEPLOYMENT.md`][dep] for deployment |
-| **Benchmarks** | [`docs/cu-costs.md`][cu] — per-instruction CU, per-approval wall clock measured by the lifecycle script |
+- **Threshold proof scheme** — *Approach* above: membership against an anchored
+  Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit
+  via `env::verify`.
+- **Nullifier design** — *Making M markers mean M distinct members* above, and
+  bindings 4–7 in [`docs/security.md`][sec].
+- **LEZ account model compatibility (nonce, `program_owner`)** —
+  [`docs/lez-account-model.md`][acct], in full. The nonce constraint never binds
+  on membership: a member is a Merkle leaf, not an account this program touches,
+  and it binds one level up on the account that *submits*, which may be a relayer.
+  `program_owner` is load-bearing rather than an obstacle — it is how an
+  uninitialised PDA is detectable, which is what makes a forged configuration
+  unrepresentable.
+- **Trusted setup** — **none**. Risc0 is STARK-based and transparent: no reference
+  string, no ceremony, no toxic waste. The only trusted parameters are the two
+  ImageIDs, and those are content-addressed; [`docs/DEPLOYMENT.md`][dep] shows a
+  clean rebuild reproducing `a8a87f8b…`.
+- **Security assumptions** and **known limitations** — [`docs/security.md`][sec]:
+  three adversaries in increasing order of knowledge, ending at the insider; then
+  timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing
+  from its other member.
+- **Integration instructions** — [`README.md`][readme], and
+  [`docs/DEPLOYMENT.md`][dep] for deployment.
+- **Benchmarks** — [`docs/cu-costs.md`][cu]: per-instruction CU, per-approval wall
+  clock, each with the machine and LEZ version it was measured on.
 
-Also worth opening: [`docs/error-codes.md`][ec] (all 22 codes, the attack each
-stops, the test behind it) and [`docs/recording-evidence.md`][rec] (how the film
-is tied to the picture, and what it does **not** establish).
+Also worth opening: [`docs/error-codes.md`][ec] (all 27 codes, the attack each
+stops, the test behind it) and [`docs/recording-evidence.md`][rec].
 
-Two LEZ behaviours cost me a day each and are written up in
-[`docs/DEPLOYMENT.md`][dep]: one approver account cannot serve several approvals,
-because a privacy transaction consumes the approver's commitment; and variadic
-accounts take one comma-separated flag, because `spel-cli` resolves them with
-`last_value()` and silently keeps only the last repeat.
+Two LEZ behaviours that each cost a day — an approver account cannot serve two
+approvals, and variadic accounts take one comma-separated flag — are written up in
+[`docs/DEPLOYMENT.md`][dep].
 
 ## Terms & Conditions
 
 By submitting this solution, I confirm that I have read and agree to the
 [Terms & Conditions](../TERMS.md).
 
-[commit]: https://github.com/edenbd1/lp-0002-private-multisig/commit/3d19fd5adf81ed47009ab17106ceb67ec7fd5c95
-[ci1]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727175015
-[ci2]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32727211438
+[commit]: https://github.com/edenbd1/lp-0002-private-multisig/commit/861e447
+[ci1]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32863757974
+[ci2]: https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/32862889416
 [pr]: https://github.com/logos-co/lambda-prize/pull/125
-[sec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/security.md
-[cu]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/cu-costs.md
-[dep]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/DEPLOYMENT.md
-[ec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/error-codes.md
-[acct]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/lez-account-model.md
-[readme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/README.md
-[patch]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/vendor/spel/PATCH.md
-[appreadme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/app/README.md
-[e2eyml]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/.github/workflows/e2e-local-sequencer.yml
-[rec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/3d19fd5/docs/recording-evidence.md
+[sec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/security.md
+[cu]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/cu-costs.md
+[dep]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/DEPLOYMENT.md
+[ec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/error-codes.md
+[acct]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/lez-account-model.md
+[readme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/README.md
+[patch]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/vendor/spel/PATCH.md
+[appreadme]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/app/README.md
+[e2eyml]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/.github/workflows/e2e-local-sequencer.yml
+[rec]: https://github.com/edenbd1/lp-0002-private-multisig/blob/861e447/docs/recording-evidence.md

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -1,0 +1,419 @@
+# Solution: LP-0002 — Private M-of-N Multisig
+
+**Submitted by:** edenbd1
+
+## Summary
+
+A threshold multisig for LEZ where members hold shielded accounts, approvals
+leave no public trace of who voted, and the chain records only that a threshold
+was met — not which members met it, **including to the other members**.
+
+The membership proof is genuinely verified on chain. Each `approve` declares a
+`ChainedCall` to a LEZ-native membership program, so LEZ's privacy circuit
+composes it with a real `env::verify` and the sequencer checks the receipt
+against the node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`. The member set and the
+threshold are anchored by PDA address, so neither can be invented or lowered.
+
+## Repository
+
+- **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
+- **Video:** <https://youtu.be/cPVsWWBVEeE>
+
+## Approach
+
+### The decision that shaped everything: which transaction path
+
+The first thing I checked was whether a LEZ **public** transaction verifies a
+proof. It does not — the sequencer re-executes the program host-side
+(`lee/state_machine/src/program.rs:73-77`, commented *"Execute the program
+(without proving)"*). A multisig built there would be a signature check wearing
+a zero-knowledge costume, which is precisely the ground on which earlier
+submissions in this program were rejected.
+
+The path that works is the **privacy-preserving transaction**: the client proves
+locally, LEZ's privacy circuit composes each chained call with a real
+`env::verify` (`lee/privacy_preserving_circuit/src/execution_state.rs:149`), and
+the sequencer verifies the receipt against the pinned circuit id.
+
+For that composition to happen, the callee must *be* a LEZ program emitting a
+`ProgramOutput` — a standalone Risc0 guest commits a bespoke journal that cannot
+decode as one, and the sequencer rejects the call with `ProgramExecutionFailed`.
+That is why `membership_lez` exists in the shape it does rather than as a plain
+guest.
+
+It also has a privacy consequence I depend on: a privacy `Message` publishes
+commitments and nullifiers and carries neither `program_id` nor
+`instruction_data`, so the witness can travel in the instruction. On the public
+path the same bytes would be published verbatim — so the membership program must
+never be invoked there, and is not.
+
+### Anchoring, and the three attacks it closes
+
+A membership proof establishes membership against whatever root the statement
+names, which on its own is worthless: anyone can build a one-leaf tree holding
+themselves. So:
+
+**The member set is anchored by address.** The multisig account is a PDA seeded
+by `[multisig_id, config_hash]`, and only `create_multisig` initialises it. An
+invented root gives a different address that was never created, whose owner is
+the default — rejected (`5003`).
+
+**The threshold is inside the same hash.** `config_hash = H(member_root ‖ threshold)`.
+Supplying `threshold = 1` against a 3-of-5 set resolves to a PDA nobody created —
+rejected (`5003`). There is no code path anywhere that reads a threshold from
+caller-supplied data. I considered storing the threshold in the account's data
+instead; folding it into the address is strictly stronger, because it makes the
+forgery unrepresentable rather than merely checked.
+
+**Approvals bind to the exact action.** This one took me longest to see. If
+approvals were scoped to a proposal id alone, a proposer could publish a harmless
+action, collect M approvals, then publish a second proposal under the same id
+carrying a malicious action — and the approvals already gathered would count for
+it. So `proposal_ref = H(multisig_id ‖ proposal_id ‖ action_hash)`, and both the
+nullifier and the marker seed derive from it. It closes the mirror-image
+griefing vector too: a junk action published under a real proposal id cannot burn
+that proposal's markers, because they land at different addresses.
+
+### Making M markers mean M distinct members
+
+Each approval occupies a PDA seeded by
+`H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
+`nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`. Two different
+addresses therefore imply two different secrets. `execute` checks the nullifiers
+are pairwise distinct (`5011`), that each account presented is the marker PDA for
+the nullifier it was paired with *on this proposal* (`5012`), and that the
+verifier program owns it (`5013`) — which it can only do if a membership proof
+was verified on chain.
+
+The distinctness check is quadratic in M deliberately: M is a multisig
+threshold, a small number, and a sort would cost more cycles than it saves. The
+measured cost confirms it — `execute` scales at ~48,600 user cycles per approval.
+
+### What did not work
+
+- **Storing the threshold in account data.** Workable, but it makes the forgery
+  *representable* and then rejected, rather than unrepresentable. Address
+  anchoring is the stronger construction and needs no data writes at all.
+- **Scoping approvals to `proposal_id`.** See the bait-and-switch above.
+- **Enabling risc0's `prove` feature** so the tests execute in-process rather
+  than through an `r0vm` subprocess. It drags in the GPU backends, and on macOS
+  that means Metal, which needs an Xcode component most machines lack. CI
+  installs `r0vm` instead.
+
+### Why the Logos stack
+
+The whole design rests on two properties nothing centralised provides. First,
+**trustless execution with real proof composition**: the threshold is enforced by
+a circuit the sequencer verifies, not by a server that could be asked to lie
+about who voted. Second, **shielded accounts as a first-class primitive**: a
+member's approval is bound to a secret that never appears on chain, so
+unlinkability holds against the other members and not just against outsiders. A
+centralised multisig service can hide the member list from the public; it cannot
+hide it from itself, and it cannot prove to a third party that it counted
+honestly.
+
+### Targeting the current testnet, and the SPEL patch that took
+
+The prize says it targets the *current* LEZ testnet. That testnet was reset onto
+a newer chain in August: everything deployed against **v0.2.0** stopped being
+accepted — not "went stale", but rejected outright, with submitted transactions
+returning a hash whose `getTransaction` is `null`. Everything here was rebuilt
+against **LEZ v0.2.4**, redeployed, and the whole lifecycle re-run. Every hash
+and address in this submission comes from that run.
+
+That upgrade is also why this repository vendors SPEL. Its latest release,
+**v0.6.0**, still pins LEZ v0.2.0 in about twenty places, and there is no
+released SPEL that builds against a current LEZ — so "use SPEL" and "transact on
+the current testnet" could not both be satisfied with anything published.
+`vendor/spel` is upstream v0.6.0 with the minimum changes to do both, and
+[`vendor/spel/PATCH.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/main/vendor/spel/PATCH.md)
+documents every one of them, how to reproduce the directory, and when it should
+be deleted. Three things broke: private-PDA derivation gained an ML-KEM 768
+viewing key, `WalletCore::from_env()` became async, and the wallet went
+multi-sequencer.
+
+Worth flagging because it is the kind of thing that wastes a reviewer's day:
+released SPEL *builds* cleanly against v0.2.4's testnet and then fails at run
+time on every instruction with `missing field 'sequencer_addr'`, because the
+wallet config format changed. The private-PDA API question is left to SPEL's
+maintainers rather than patched over here — this project uses only public PDAs,
+whose derivation is unchanged in v0.2.4.
+
+## Success Criteria Checklist
+
+### Functionality
+
+- [x] **Any M-of-N member holding a shielded LEZ account can submit an approval
+      without revealing their identity to on-chain observers or other members.**
+      The only trace is a marker PDA seeded by a secret-bound nullifier. See
+      [`docs/security.md`](docs/security.md), which states the threat model
+      against three adversaries including the insider.
+- [x] **The on-chain verifier confirms a threshold of M approvals was reached
+      without recording which members approved.** `execute`, checks 5–7.
+- [x] **A member cannot approve the same proposal twice.** The nullifier is
+      deterministic per `(proposal, member)`, so the second approval targets an
+      occupied PDA and `init` refuses.
+- [x] **A completed execution is unlinkable to any individual member's shielded
+      account.** `execute` consumes marker addresses and is signed by an executor
+      who need not be a member at all.
+- [x] **Proof generation runs client-side on a standard laptop.** Approvals are
+      built by `msig approve-args` and proved locally; **149 s and 154 s** for the
+      two approvals of a measured 2-of-3 run, timed by the script itself.
+- [x] **A reference integration on LEZ testnet.** A 2-of-3 multisig created, a
+      proposal published, two approvals gathered on the privacy-preserving path,
+      and executed against the fixed verifier. Seven transactions, all live; see
+      [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+
+      **What "threshold-gated action" means here**, since the criterion offers
+      *treasury transfer or parameter change* as examples and it is fair to ask
+      which one this is. The gated action is `transfer 100 LEZ to the grants
+      treasury`, bound into `proposal_ref` by its hash, and what the chain gates
+      is the **right to act on it**: the execution marker PDA comes into
+      existence only when M distinct secret-bound nullifiers resolve to markers
+      the verifier owns, and it can never be produced any other way. Performing
+      the transfer is one CPI away and deliberately out of scope — a multisig is
+      an authorisation primitive, and coupling it to one action type would make
+      it a treasury program instead. Any program can gate on that marker: it is
+      a PDA at a derivable address, owned by the verifier, whose existence *is*
+      the proof that the threshold was met. The submission demonstrates the
+      part the prize is about — reaching the threshold privately — rather than
+      re-implementing a transfer that LEZ already has.
+
+      One thing to flag before you click, because it would otherwise look like
+      dead links: **none of the seven transactions renders on the explorer right
+      now**, and all seven are on chain — `getTransaction` returns every one.
+      The explorer's indexer is behind: its own front page listed block 4351 as
+      the most recent while the chain was at 4496, and every transaction here was
+      included after that. It affects anything recently submitted, by anyone.
+
+      Worth stating plainly, since an earlier version of this document claimed
+      the opposite: the explorer is a WASM app that serves an identical page
+      shell for every hash and renders client-side, so comparing response sizes
+      — which is how the previous claim was reached — cannot distinguish an
+      indexed transaction from one that does not exist.
+      `./scripts/check-explorer.py` renders the pages in a headless browser
+      instead, with an impossible hash as the control, and prints what it finds.
+      Re-run it; the answer is a measurement with a date on it, not a claim.
+
+      `docs/DEPLOYMENT.md` gives a one-line `curl` per hash, and
+      `./scripts/verify-onchain.sh` does the stronger check — it reads the five
+      accounts the lifecycle created and confirms the verifier program owns
+      them, which no transaction lookup can fake.
+- [x] **At least 1 multisig instance on testnet with a proposal submitted,
+      approved by threshold, and executed.** Multisig
+      `4wqJXoEhqqqYknt1s7gHcgBL6pkfwNJDfhbVVeAqwtnX`, proposal
+      `E11Awng7j59dVft83VVrwftXp41roJPKY5QRMb45Zcoe`, execution marker
+      `CpiuicNDii6uCeMXtjd1W6hek6Vq35HJ7k3mz1Q82Fui` — all owned by the verifier.
+      Re-verify with `./scripts/verify-onchain.sh`.
+- [x] **Full documentation and a clean public repository.**
+
+### Usability
+
+- [x] **Module/SDK for building Logos modules.** `crates/multisig-sdk`,
+      transport-agnostic: it opens no socket and touches no filesystem.
+- [x] **Basecamp app GUI with local build instructions and loadable assets.**
+      `app/`, with both the `logos-module-builder` path and a standalone Qt path.
+      The packaged module is committed at `app/lp-0002-multisig.lgx` (2.4 MB),
+      built with the **real `lgx`** from `logos-co/logos-package` — the same tool
+      `nix-bundle-lgx` drives — and it passes `lgx verify`. It carries **two
+      variants**, `darwin-arm64` and `linux-amd64`, so it opens on the machine
+      the evaluator actually reviews on; the Linux half is built in Docker by
+      `scripts/build-linux-variant.sh` and the packaged Linux `msig` was run
+      inside a Linux container to confirm it works, not just that it exists.
+
+      **The Linux variant is load-tested against Basecamp's own Qt, not just
+      built.** Basecamp ships an `x86_64.AppImage` in the same 0.2.2 release;
+      extracted, it bundles the same Qt 6.9.2 as macOS. Running what Basecamp's
+      PluginLoader runs — `QPluginLoader::instance()` then
+      `qobject_cast<IComponent*>` — linked against *that* Qt gives
+      `SUCCESS: loaded + cast to IComponent`. The harness was shown able to
+      fail: a real Qt plugin with a different IID gives `CAST FAILED`. Basecamp
+      itself also boots on Linux with the package installed, reaching
+      `Logos Core started successfully!` and scanning the plugins directory.
+      What is *not* claimed is the click: a UI app's widget loads on click, and
+      headless there is nothing to click, so that half was exercised on macOS.
+      Method in [`app/README.md`](app/README.md).
+
+      **It was installed and driven in Logos Basecamp 0.2.2**, not merely
+      declared loadable: the committed package extracts into the user plugins
+      directory, the module loads (`Successfully loaded UI module`), and
+      pressing *Status* against `artifacts/testnet` returns the live
+      deployment's `2-of-3 · 2/2 READY TO EXECUTE` with both approval markers.
+      Doing that found three defects in the packaging, all fixed and all
+      described in `app/README.md`: the plugin was built against a Qt newer than
+      the one Basecamp runs, so Qt refused it outright; `Q_DECLARE_INTERFACE`
+      used a private IID instead of `com.logos.component.IComponent`, so the
+      host's `qobject_cast` returned null; and the `IComponent` declaration
+      carried an extra virtual, which shifted every later vtable slot.
+      `scripts/package-lgx.py` now refuses to package a binary with any of
+      those properties.
+- [x] **SPEL IDL.** `idl/multisig_verifier.idl.json`, generated from source by
+      `spel generate-idl`.
+
+### Reliability
+
+- [x] **Proof generation failures surface a clear error.** `approve-args`
+      verifies the witness locally before emitting anything, so a bad witness
+      fails in microseconds rather than after minutes of proving.
+- [x] **A partial set of approvals is preserved and resumable across client
+      restarts.** Every approval is recorded in `proposals/<id>.json` before the
+      command returns. This is not incidental: proving takes minutes, not an
+      approval, so a real threshold *is* gathered across sessions and days.
+- [x] **Deterministic, documented error codes.** Thirteen, `5001`–`5013`, in
+      [`docs/error-codes.md`](docs/error-codes.md), each mapped to the attack it
+      stops and the test that proves it.
+
+### Performance
+
+- [x] **CU cost of each on-chain operation documented.**
+      [`docs/cu-costs.md`](docs/cu-costs.md): `approve` 335,564 user cycles;
+      `execute` linear in M at ~48,600 per approval; all inside one segment at
+      1.56 % of the public budget. Measured by replaying through the sequencer's
+      own executor, reproducible with one command.
+
+### Supportability
+
+- [x] **Deployed and tested on LEZ devnet/testnet.** Both programs deployed;
+      full lifecycle run and independently re-verifiable over JSON-RPC.
+- [x] **E2E integration tests run against a LEZ sequencer (standalone mode), in
+      CI.** Two layers, because they answer different questions.
+      `multisig-verifier-tests` runs the built binary through the sequencer's own
+      **executor** on every push — same executor, same input order, same 32M
+      session limit — which is what makes 28 adversarial rejections cheap enough
+      to gate a commit. On top of that,
+      [`.github/workflows/e2e-local-sequencer.yml`](.github/workflows/e2e-local-sequencer.yml)
+      starts the actual `sequencer_service` binary in **standalone mode** and
+      drives the whole lifecycle against it over JSON-RPC. It is scheduled
+      rather than per-push because it builds the LEZ workspace and then
+      generates a real proof; both are CI, and only one of them can be fast.
+- [x] **CI green on the default branch.** Ubuntu and macOS both.
+- [x] **README documents end-to-end usage** — deployment steps, program
+      addresses, and step-by-step instructions for both the CLI and the Basecamp
+      app, the latter verified on LogosBasecamp 0.2.2.
+- [x] **Reproducible demo script working against a real local sequencer with
+      `RISC0_DEV_MODE=0`.** `scripts/e2e-local-sequencer.sh` starts a real
+      standalone sequencer, funds a throwaway wallet from its genesis vault,
+      deploys both programs onto that fresh chain, and runs create → propose →
+      *real Risc0 approvals* → execute, then reads the five resulting accounts
+      back off it. Nothing mocked, `RISC0_DEV_MODE=0` throughout, about eight
+      minutes for a 2-of-3. `scripts/demo.sh` remains the five-second tour for
+      readers who want the rejections and the cost table without a sequencer.
+- [x] **Recorded narrated video demo.** <https://youtu.be/cPVsWWBVEeE> — the
+      terminal is on screen throughout, `RISC0_DEV_MODE=0` is visible before any
+      proving starts, and the approval is a real proof generated in one
+      uninterrupted take, with its wall clock printed at the end.
+
+## FURPS Self-Assessment
+
+### Functionality
+
+Four instructions: `create_multisig`, `create_proposal`, `approve`, `execute`.
+Seven documented bindings, each with adversarial coverage. **Limitations, stated
+rather than buried:** the member set is fixed at creation (no rotation);
+proposals do not expire; the action payload is opaque to this protocol and a
+consuming program must validate it itself.
+
+### Usability
+
+Three surfaces over one library: the SDK, the `msig` CLI, and the Basecamp app.
+The app shells out to the CLI, so the GUI and the chain compute the same
+commitments from the same code — there is no second implementation to drift.
+Onboarding is `git clone && ./scripts/demo.sh`. The CLI's refusals are written to
+be read by a human and explain *why*, and the GUI passes them straight through.
+
+### Reliability
+
+Local pre-verification before proving; resumable partial approvals; thirteen
+documented error codes. Failure modes I know about and have not solved: a
+transaction whose proving outruns the wallet's polling window reports "NOT
+confirmed" while landing anyway — the scripts poll `getTransaction` rather than
+trust the CLI's verdict, and the docs say so.
+
+### Performance
+
+`approve` at 1.56 % of the public compute budget, with headroom to ~524k user
+cycles before a second segment. Wall-clock is dominated entirely by proving:
+**149 s and 154 s** for the two approvals of a 2-of-3 run against a local
+standalone sequencer, timed by `scripts/deploy-and-run.sh` itself rather than
+estimated, and written into `lifecycle.tsv` alongside the transaction hashes.
+Both numbers are in [`docs/cu-costs.md`](docs/cu-costs.md) with the machine they
+were taken on.
+
+That figure is a correction. This submission previously said "~10 minutes per
+approval" in six places, carried over from an early estimate that no one had
+gone back and measured. Measuring it was part of closing the "proof generation
+time benchmark" requirement, and it turned out the estimate was four times too
+pessimistic — which is worth stating plainly, because a benchmark nobody
+re-runs is just a claim.
+
+### Supportability
+
+61 tests across five suites, counted and itemised in the README. That number
+went from 40 after two audit passes found a threshold bypass and three untested
+error codes; the finding and its cost are written up in `docs/security.md`
+rather than quietly patched. The two guest
+crates are excluded from the host workspace because they target
+`riscv32im-risc0-zkvm-elf` — but the deployed program is still under test,
+because `multisig-verifier-tests` is a workspace member exercising the built
+binary. CI runs on Ubuntu and macOS, and a dedicated job fails if
+`MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary, since
+that constant is what stops a chained call from reaching an unaudited program.
+
+## Write-up, by the topics the brief names
+
+The Submission Requirements ask for a write-up covering six specific things, and
+the Scope section adds a seventh. Rather than leave them to be hunted for:
+
+| Required topic | Where |
+|---|---|
+| **Threshold proof scheme** | *Approach* above — membership against an anchored Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit via `env::verify` |
+| **Nullifier design** | *Making M markers mean M distinct members* above, and bindings 4–7 in [`docs/security.md`](docs/security.md) |
+| **LEZ account model compatibility** — specifically the **nonce** and **`program_owner`** constraints | [`docs/lez-account-model.md`](docs/lez-account-model.md), in full. Short version: the nonce constraint never binds on membership because a member is a Merkle leaf and not an account this program touches; it binds one level up, on the account that *submits*, which is unrelated to the member and may be a relayer. `program_owner` is load-bearing rather than an obstacle — it is how an uninitialised PDA is detectable, which is what makes a forged member set unrepresentable instead of merely refused |
+| **Trusted setup** | **None.** Risc0 is a STARK-based, transparent proving system: there is no structured reference string, no ceremony, and no toxic waste to trust or destroy. The only trusted parameters are the two program ImageIDs, and those are content-addressed — [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) shows a clean rebuild reproducing `5bb40082…` exactly, so an evaluator who rebuilds gets the same identity or knows something is wrong |
+| **Security assumptions** | [`docs/security.md`](docs/security.md) — three adversaries in increasing order of knowledge, ending at the insider, which is the interesting one |
+| **Known limitations** | [`docs/security.md`](docs/security.md), *What is not hidden* and *Residual risks and non-goals* — timing correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its other member |
+| **Integration instructions** | [`README.md`](README.md) — the CLI lifecycle, the Basecamp walkthrough, and [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for deployment |
+| **Proof generation time and gas cost benchmarks** | [`docs/cu-costs.md`](docs/cu-costs.md) — per-instruction CU, and per-approval wall clock measured by the lifecycle script itself |
+
+## Supporting Materials
+
+- [`docs/security.md`](docs/security.md) — threat model, what is hidden from
+  whom, what is deliberately public, residual risks
+- [`docs/lez-account-model.md`](docs/lez-account-model.md) — the nonce and
+  `program_owner` constraints, which are the incompatibility this prize exists
+  to solve
+- [`docs/error-codes.md`](docs/error-codes.md) — all 13 codes, the attack each
+  stops, and the test behind it
+- [`docs/cu-costs.md`](docs/cu-costs.md)
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)
+- Narrated demo video: ⚠️ pending — script at `VIDEO_SCRIPT.md`
+
+## What the testnet run taught, and what it cost
+
+Two things went wrong on the way, both worth stating because they are invisible
+until you hit them and neither is a program bug:
+
+1. **One approver account cannot serve several approvals.** A privacy
+   transaction consumes the approver's commitment, so a second approval from the
+   same account panics in the *client-side* circuit — `Invalid
+   account_identities length, left: 4, right: 3` — before anything is submitted.
+   One private account per approval fixes it, and that is how a real deployment
+   works anyway.
+2. **Variadic accounts take one comma-separated flag.** `spel-cli` resolves them
+   with `last_value()`, so a repeated `--approvals` silently keeps only the last.
+   The program then saw one account against two nullifiers and rejected with
+   `E_APPROVAL_COUNT_MISMATCH` (5009) — the check doing exactly its job, which is
+   how the cause was found.
+
+Both are now fixed in `scripts/deploy-and-run.sh` and documented in
+`docs/DEPLOYMENT.md`.
+
+## Outstanding
+
+**The narrated video has not been recorded.** `VIDEO_SCRIPT.md` has the full
+script. Nothing in this submission claims otherwise.
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the
+[Terms & Conditions](../TERMS.md).

--- a/solutions/LP-0002.md
+++ b/solutions/LP-0002.md
@@ -19,34 +19,23 @@ are anchored by PDA address, so neither can be invented or lowered.
 - **Repo:** <https://github.com/edenbd1/lp-0002-private-multisig>
 - **Reviewed commit:**
   [`e9e8fcd`](https://github.com/edenbd1/lp-0002-private-multisig/tree/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c).
-  Every path below is relative to it. Read them at that tree rather than at
-  `main`: `main` moves, and a path that has moved with it is no longer the file
-  this document describes.
+  Every path below is relative to it — read them at that tree, not at `main`, since
+  `main` moves and a moved path is no longer the file described here.
 - **CI on that commit:** the host suite and the deployed-binary audit — **131
-  tests**, 84 of which run the built verifier through the sequencer's own
-  executor, alongside gates that hold the documents to the code: every quoted path,
-  link and cited CI run must resolve, every explorer link must resolve against the
-  chain it names, nothing may name another submission, and every row of the
-  README's test inventory — with its total and its printed addition — must be what
-  the suites pass.
-  The full lifecycle against a standalone LEZ sequencer — `RISC0_DEV_MODE=0`,
-  building LEZ at a pinned revision and driving the whole lifecycle against it
-  with real proofs — runs on `1759015`: run
-  `33098969090`, green in 2 h 39, its log printing `RISC0_DEV_MODE=0` and closing
-  on `2 approval(s) recorded against a requirement of 2`. What separates the two
-  is five files — the deployment and CU-cost documents, the film's transcript and
-  its recording-evidence anchor, and the transcript-checker gate — with no program,
-  no script the demo runs and no artefact the chain sees among them, so
-  `git diff 1759015 e9e8fcd --stat` is the whole of it and that run exercised
-  exactly the code under review. Both program binaries also hash identically
-  across every commit in the range, so the thing being proved has not moved
-  underneath the proof.
-- **Video:** two narrated films play inline in the pull request — the whole
-  lifecycle against a standalone sequencer with two real proofs, and a 76-second
-  reading of this deployment. Both were shot for this submission and both show
-  their own commit on screen. Earlier recordings of an earlier deployment are not
-  linked: they carry superseded identifiers, and pointing a reviewer at a film
-  that contradicts the one above costs more than the extra commentary is worth.
+  tests**, 84 of which run the built verifier through the sequencer's own executor,
+  alongside gates that hold the documents to the code (every quoted path, link and
+  cited run must resolve, every explorer link against the chain it names). The full
+  lifecycle against a standalone LEZ sequencer — `RISC0_DEV_MODE=0`, LEZ built at a
+  pinned revision, driven with real proofs — runs on `1759015`: run `33098969090`,
+  green in 2 h 39, its log printing `RISC0_DEV_MODE=0` and closing on `2 approval(s)
+  recorded against a requirement of 2`. `git diff 1759015 e9e8fcd --stat` is five
+  docs/transcript files — no program, no script the demo runs, no chain artefact —
+  and both program binaries hash identically across the range, so that run
+  exercised exactly the code under review.
+- **Video:** two narrated films — the whole lifecycle against a standalone
+  sequencer with two real proofs, and a 76-second reading of this deployment. They
+  play inline in the pull request and are committed under `recordings/`. Both were
+  shot for this submission and show their own commit on screen.
 - **Where the detail lives:** `docs/security.md` (threat model),
   `docs/cu-costs.md`, `docs/error-codes.md`, `docs/lez-account-model.md`,
   `docs/account-layout.md`, `docs/DEPLOYMENT.md`, `vendor/spel/PATCH.md`.
@@ -62,72 +51,53 @@ transaction**: the client proves locally, LEZ's privacy circuit composes each
 chained call with a real `env::verify`
 (`lee/privacy_preserving_circuit/src/execution_state.rs:149-155`), and the
 sequencer verifies the receipt against the pinned circuit id. For that composition
-the callee must *be* a LEZ program emitting a `ProgramOutput` — a standalone Risc0
-guest commits a bespoke journal that cannot decode as one and is rejected with
-`ProgramExecutionFailed`. That is why `membership_lez` exists in the shape it
-does. It also has a privacy consequence I depend on: a privacy `Message` carries
-neither `program_id` nor `instruction_data`, so the witness can travel in the
-instruction. On the public path those bytes would be published verbatim — so the
-membership program must never be invoked there, and is not.
+the callee must *be* a LEZ program emitting a `ProgramOutput`, which is why
+`membership_lez` exists in the shape it does. A privacy `Message` also carries
+neither `program_id` nor `instruction_data`, so the witness travels in the
+instruction — on the public path those bytes would be published verbatim, so the
+membership program is never invoked there.
 
-**Anchoring, and the three attacks it closes.** A membership proof establishes
-membership against whatever root the statement names, which alone is worthless:
-anyone can build a one-leaf tree holding themselves. So the member set is anchored
-**by address** — the multisig is a PDA seeded by `[multisig_id, config_hash]`,
-only `create_multisig` initialises it, and an invented root gives an address
-nobody created (`5003`). The threshold and the spending tiers sit inside the same
-hash, `config_hash = H(member_root ‖ threshold ‖ tiers_hash)`, so a lowered
-threshold or a more generous tier table resolves to a PDA nobody created either.
-Folding them into the address makes the forgery *unrepresentable* rather than
-merely checked.
-
-The third attack took me longest to see. If approvals were scoped to a proposal id
-alone, a proposer could publish a harmless action, collect M approvals, then
-republish a malicious one under the same id — and the approvals already gathered
-would count for it. So
+**Anchoring, and the three attacks it closes.** A membership proof alone is
+worthless — anyone can build a one-leaf tree holding themselves — so the member set
+is anchored **by address**: the multisig is a PDA seeded by
+`[multisig_id, config_hash]`, `config_hash = H(member_root ‖ threshold ‖ tiers_hash)`,
+and only `create_multisig` initialises it. An invented root, a lowered threshold or
+a more generous tier table all resolve to a PDA nobody created (`5003`). Approvals
+bind to the exact action, not just a proposal id:
 `proposal_ref = H(PROPOSAL_REF_PREFIX ‖ multisig_id ‖ config_hash ‖ proposal_id ‖ action_hash)`,
-and both the nullifier and the marker seed derive from it. `config_hash` is in
-there deliberately: it is what makes a rotation cost nothing to police, since
-proposals raised under the old configuration land at addresses the new one never
-reads. That also closes the
-mirror image: a junk action under a real proposal id cannot burn that proposal's
-markers.
+and both the nullifier and the marker seed derive from it — so approvals gathered
+for a benign action cannot be replayed onto a malicious one republished under the
+same id, and a junk action cannot burn a real proposal's markers. `docs/security.md`
+carries the full argument and threat model.
 
-**Making M markers mean M distinct members.** Each approval occupies a PDA seeded
-by `H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
+**M markers mean M distinct members.** Each approval occupies a PDA seeded by
+`H(APPROVAL_MARKER_PREFIX ‖ proposal_ref ‖ nullifier)` where
 `nullifier = H(APPROVAL_NULLIFIER_PREFIX ‖ proposal_ref ‖ msk)`, so two addresses
-imply two secrets. `execute` checks the nullifiers are pairwise distinct (`5011`),
-that each account is the marker PDA for the nullifier it was paired with *on this
-proposal* (`5012`), and that the verifier owns it (`5013`) — which it can only do
-if a membership proof was verified on chain.
-
-**Rotation is replacement, not mutation.** `rotate_config` anchors a *second*
-configuration at its own PDA, with its own treasury, and writes that address into
-the first as `superseded_by`. Every guarantee the address gives the old one, the
-new one has by construction. No stale-proposal check exists and none is needed —
-`proposal_ref` derives through `config_hash`, so proposals raised under the old
-configuration live at addresses the new one never reads. It costs the *default*
-threshold, never a tier: pricing governance by tier would make the cheapest action
-available the one that rewrites who may act.
+imply two secrets. `execute` checks the nullifiers pairwise distinct (`5011`), each
+account the marker PDA for the nullifier it was paired with *on this proposal*
+(`5012`), and the verifier owns it (`5013`) — provable only if a membership proof
+was verified on chain. **Rotation is replacement, not mutation:** `rotate_config`
+anchors a *second* configuration at its own PDA with its own treasury and writes
+that address into the first as `superseded_by`; proposals raised under the old
+configuration live at addresses the new one never reads, so no stale-proposal check
+is needed. It costs the *default* threshold, never a tier — pricing governance by
+tier would make the cheapest action the one that rewrites who may act.
 
 **Targeting the current testnet.** The testnet was reset onto a newer chain in
-August, and everything deployed against **v0.2.0** stopped being accepted — not
-"went stale" but rejected outright, with submitted transactions returning a hash
-whose `getTransaction` is `null`. Everything here was rebuilt against **LEZ
-v0.2.4** and redeployed. That is also why this repository vendors SPEL: release
-**v0.6.0** still pins LEZ v0.2.0 in about twenty places, so "use SPEL" and
-"transact on the current testnet" could not both be satisfied with anything
-published. `vendor/spel` is upstream v0.6.0 with the minimum changes, documented
-one by one in `vendor/spel/PATCH.md`. Worth flagging because it wastes a
-reviewer's day: released SPEL *builds* against v0.2.4 and then fails at run time
-on every instruction with `missing field 'sequencer_addr'`.
+August; everything deployed against **v0.2.0** is now rejected outright, submitted
+transactions returning a hash whose `getTransaction` is `null`. Everything here was
+rebuilt against **LEZ v0.2.4** and redeployed. That is also why this repository
+vendors SPEL: release **v0.6.0** still pins LEZ v0.2.0 in about twenty places, so
+released SPEL *builds* against v0.2.4 and then fails at run time on every
+instruction with `missing field 'sequencer_addr'`. `vendor/spel` is upstream v0.6.0
+with the minimum changes, documented one by one in `vendor/spel/PATCH.md`.
 
 ## Live on the public testnet
 
 A **3-of-3** multisig with a spending tier, deployed 2026-08-25: created, funded,
 a transfer proposed, approved and executed — then the same member set voted to
-replace itself. **Thirteen transactions, twelve of them in blocks 23028–23554 and the
-`membership_lez` deploy earlier at 4459; five are on the proving path.**
+replace itself. **Thirteen transactions, twelve of them in blocks 23028–23554 and
+the `membership_lez` deploy earlier at 4459; five are on the proving path.**
 
 | Step | Transaction | Block |
 |---|---|---:|
@@ -145,55 +115,40 @@ replace itself. **Thirteen transactions, twelve of them in blocks 23028–23554 
 | `approve` C — **privacy tx** | `6fcc674a…9a314160` | 23553 |
 | `rotate_config` | `cb8a3f8b…ea942554` | 23554 |
 
-**Where the proof is, and why it is not in `execute`.** The five rows marked
-*privacy tx* each carry a ~265 kB STARK receipt the sequencer verified against the
-node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`; `execute` is a 1,413-byte public
-transaction with no proof in it, and that is deliberate. An approval is where
-membership is proven, so that is where the proof belongs. `execute` presents
-marker accounts that only a verified proof could have created — it re-derives each
-address and checks the verifier owns it, which is what makes them unforgeable —
-and it moves the value. Putting a proof in `execute` would prove nothing the
-approvals have not already proved, and would publish on the public path exactly
-what the approvals exist to keep off it. A reviewer who wants to see a proof on
-chain should open one of the five, not the sixth.
+**Where the proof is, and why not in `execute`.** The five rows marked *privacy tx*
+each carry a ~265 kB STARK receipt the sequencer verified against the node-pinned
+`PRIVACY_PRESERVING_CIRCUIT_ID`; `execute` is a 1,413-byte public transaction with
+no proof, deliberately — an approval is where membership is proven, so that is where
+the proof belongs, and putting a proof in `execute` would publish on the public path
+exactly what the approvals keep off it. A reviewer who wants a proof on chain opens
+one of the five, not the sixth.
 
 **Two approvals against a threshold of three** on the transfer, because the tier
-this multisig anchors covers the amount proposed — the tier doing something,
-counted in proofs not generated rather than claimed in prose. And it is anchored
-rather than merely applied: `config_hash` is `1628d88b…`, and the same members and
-threshold *without* the tier give `3dff16d7…` — a different PDA, an account nobody
-created. **Three approvals on the rotation**, because a rotation always costs the
-default threshold and `rotate_config` refuses to read the tier table for its own
-count.
-
-**The number only a real execution could produce is the treasury's:**
-`fund_treasury` put **2** in and `execute` moved **1** out, and the other side of
-that move is an account that is *not* the program's — the recipient
-`8kexXda8…` goes **1 → 2**, held by the native transfer program, which is what
-makes what it received spendable instead of stranded.
-
-Six accounts are owned by the verifier — multisig `C9CgRDNf…`, treasury
-`FyTtsh2h…`, proposal `5kM4uZdH…`, execution marker `J1N6WWpH…`, and the two
-approval markers. Their **Program Owner** is
-`CMNWomcJfauikXikhbN18jk4bRFeDScgKdSUwzqUjdMy`, base58-decoding to
-`a8a87f8b…61500750` — exactly the ImageID that
-`spel program-id artifacts/programs/multisig_verifier.bin` computes from the
-binary committed here. Nothing in that chain needs us.
+covers the amount proposed — the tier counted in proofs not generated. It is
+anchored rather than merely applied: `config_hash` is `1628d88b…`, and the same
+members and threshold *without* the tier give `3dff16d7…`, a different PDA nobody
+created. **Three approvals on the rotation**, which always costs the default
+threshold. **The number only a real execution could produce is the treasury's:**
+`fund_treasury` put **2** in and `execute` moved **1** out, and the recipient
+`8kexXda8…` goes **1 → 2**, held by the native transfer program, which is what makes
+what it received spendable. Six accounts are owned by the verifier — multisig,
+treasury, proposal, execution marker and the two approval markers — their
+**Program Owner** `CMNWomcJfauikXikhbN18jk4bRFeDScgKdSUwzqUjdMy` base58-decodes to
+`a8a87f8b…61500750`, exactly the ImageID
+`spel program-id artifacts/programs/multisig_verifier.bin` computes from the binary
+committed here.
 
 ```bash
 ./scripts/verify-onchain-lifecycle.sh    # no arguments, ~5 s from a clean clone
 ```
 
-It recomputes both deploy hashes from the committed bytecode, resolves all
-thirteen transactions, and asserts the variant each must carry — the five
-approvals `PrivacyPreserving` rather than `Public`. The explorer shows this too —
-each approval page reads `Type: Privacy-Preserving Transaction` with
-`Proof Size: 264907 bytes`, and `execute` reads `Public Transaction` and `0
-bytes` — so the script agrees with a third party rather than standing in for one. Its first step is an impossible hash that must return
-null, so a resolving hash afterwards means something. `./scripts/verify-onchain.sh artifacts/testnet "$(cat artifacts/testnet/proposal_id)"`
-reads the accounts back and decodes every record at the offsets
-`docs/account-layout.md` publishes, including `tiers_hash` and `superseded_by`.
-It takes those two arguments so it can be pointed at any run, not only this one.
+It recomputes both deploy hashes from the committed bytecode, resolves all thirteen
+transactions, and asserts the variant each must carry — the five approvals
+`PrivacyPreserving` rather than `Public`. The explorer agrees: each approval page
+reads `Type: Privacy-Preserving Transaction` with `Proof Size: 264907 bytes`, and
+`execute` reads `Public Transaction` and `0 bytes`. `docs/account-layout.md`
+publishes the byte offsets the companion `scripts/verify-onchain.sh` decodes,
+including `tiers_hash` and `superseded_by`.
 
 ## Success Criteria Checklist
 
@@ -212,7 +167,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `execute` consumes marker addresses and is signed by an executor who need not be a member at all.
 
 - [x] **Proof generation runs client-side on a standard laptop.**
-  Approvals are built by `msig approve-args` and proved locally: **484 s and 550 s** for the deployed run's two transfer approvals, timed by the script itself. Read per machine rather than as one number — `docs/cu-costs.md` tabulates measurements across two machines and two LEZ versions, 149 s to 4033 s.
+  Approvals are built by `msig approve-args` and proved locally: **484 s and 550 s** for the deployed run's two transfer approvals, timed by the script. `docs/cu-costs.md` tabulates measurements across two machines and two LEZ versions, 149 s to 4033 s.
 
 - [x] **A reference integration is delivered: a working demo of a threshold-gated action (e.g., treasury transfer or parameter change) on LEZ testnet using shielded member accounts.**
   The lifecycle below.
@@ -228,9 +183,9 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `crates/multisig-sdk`, transport-agnostic: it opens no socket and touches no filesystem.
 
 - [x] **Provide a Logos Basecamp app GUI with local build instructions, downloadable assets, and loadable in Logos app (Basecamp).**
-  `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.5 MB), built with the **real `lgx`** from `logos-co/logos-package` and passing `lgx verify`, carrying **two variants** — `darwin-arm64` and `linux-amd64` — so it opens on the machine the evaluator actually reviews on.
+  `app/`, with both the `logos-module-builder` path and a standalone Qt path. The packaged module is committed at `app/lp-0002-multisig.lgx` (2.5 MB), built with the **real `lgx`** from `logos-co/logos-package`, passing `lgx verify`, and carrying **two variants** — `darwin-arm64` and `linux-amd64`.
 
-  **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared loadable: the module loads, and pressing *Status* against a multisig folder returns that deployment's live state — the then-current one, with its approval markers. The tile renders whatever the CLI shipped inside the package prints rather than computing anything itself, and `app/README.md` says which session was driven and against what, rather than re-quoting it for a later deployment. Doing that found three packaging defects — a Qt newer than the one Basecamp runs, a private IID, and an extra virtual that shifted every later vtable slot — all fixed, described in `app/README.md`, and now refused by `scripts/package-lgx.py`. **The Linux variant is load-tested against Basecamp's own Qt**, extracted from the `x86_64.AppImage` in that release: `QPluginLoader::instance()` then `qobject_cast<IComponent*>` gives `SUCCESS`, and the harness was shown able to fail — a plugin with a different IID gives `CAST FAILED`. Not claimed: the click, since headless there is nothing to click. That half ran on macOS.
+  **It was installed and driven in Logos Basecamp 0.2.2**, not merely declared loadable: the module loads, and pressing *Status* against a multisig folder returns that deployment's live state — the tile renders whatever the packaged CLI prints rather than computing anything itself (`app/README.md` records which session was driven and against what). Doing that found and fixed three packaging defects, now refused by `scripts/package-lgx.py`. **The Linux variant is load-tested against Basecamp's own Qt** extracted from the release AppImage: `QPluginLoader::instance()` then `qobject_cast<IComponent*>` gives `SUCCESS`, and a different-IID plugin gives `CAST FAILED`, so the harness can fail. Not claimed: the click on Linux, since headless there is nothing to click — that half ran on macOS.
 
 - [x] **Provide an IDL for the LEZ program, using the [SPEL framework](https://github.com/logos-co/spel).**
   `idl/multisig_verifier.idl.json`, generated from source by `spel generate-idl`.
@@ -241,7 +196,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   `approve-args` verifies the witness locally before emitting anything, so a bad witness fails in microseconds rather than after minutes of proving.
 
 - [x] **A partial set of approvals (fewer than M) is preserved and resumable across client restarts.**
-  Every approval is recorded in `proposals/<id>.json` before the command returns — not incidental, since proving takes minutes and a real threshold *is* gathered across sessions and days.
+  Every approval is recorded in `proposals/<id>.json` before the command returns — a real threshold is gathered across sessions and days.
 
 - [x] **The verifier program returns deterministic, documented error codes for all invalid-proof and double-vote scenarios.**
   Twenty-seven, `5001`–`5027`, in `docs/error-codes.md`, each mapped to the attack it stops and the test that proves it.
@@ -257,7 +212,7 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   Both programs deployed; the full lifecycle and the rotation run, and independently re-verifiable over JSON-RPC.
 
 - [x] **End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  Two layers. `multisig-verifier-tests` runs the built binary through the sequencer's own **executor** on every push — same executor, same input order, same 32M session limit. On top of that, `.github/workflows/e2e-local-sequencer.yml` starts the actual `sequencer_service` binary in **standalone mode** and drives the whole lifecycle against it over JSON-RPC with a real proof.
+  Two layers. `multisig-verifier-tests` runs the built binary through the sequencer's own **executor** on every push. On top of that, `.github/workflows/e2e-local-sequencer.yml` starts the actual `sequencer_service` binary in **standalone mode** and drives the whole lifecycle against it over JSON-RPC with a real proof.
 
 - [x] **CI must be green on the default branch.**
   Ubuntu and macOS both.
@@ -266,26 +221,10 @@ It takes those two arguments so it can be pointed at any run, not only this one.
   — deployment steps, program addresses, and instructions for both the CLI and the Basecamp app.
 
 - [x] **A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back off it. Nothing mocked: **1333 s** on an Apple-silicon laptop, and **2 h 12 to 2 h 49** across the green runs on a GitHub runner, 2 h 39 for the one cited above. `scripts/demo.sh` is the twenty-second tour without a sequencer — it reads the live chain, and shows the tier and a rotation as well.
+  `scripts/e2e-local-sequencer.sh` starts a real standalone sequencer, funds a throwaway wallet from its genesis vault, deploys both programs onto that fresh chain, and runs create → propose → *real Risc0 approvals* → execute, then reads the accounts back. Nothing mocked: **1333 s** on an Apple-silicon laptop, **2 h 12 to 2 h 49** across the green GitHub runs. `scripts/demo.sh` is the twenty-second tour without a sequencer — it reads the live chain and shows the tier and a rotation.
 
 - [x] **A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  Two films play inline in the pull request. This one is a single take of
-  `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose hash
-  is on screen; the reviewed commit `e9e8fcd` is two commits later — run
-  `git diff c72ff1c e9e8fcd --stat`: `docs/recording-evidence.md` alone, the
-  reconciliation of this film's own evidence — no program, no script, no chain artefact, and the verifier binary is
-  byte-identical across the range. It starts a real LEZ sequencer in standalone mode,
-  deploys both programs onto that fresh chain, creates the multisig, proposes a
-  transfer, gathers **two real Risc0 approvals**, executes, and reads the accounts
-  back off the same chain, closing on
-  `e2e against a real local sequencer: PASS (http://localhost:3141, 2-of-3, RISC0_DEV_MODE=0)`.
-  `RISC0_DEV_MODE=0` is on screen before any proving starts and again in that
-  line. No funded account, no public testnet, nothing mocked. Only the stretch
-  where the prover works and the screen does not change is sped up, its factor
-  written across the picture while it plays. The factor is 63, written across
-  the picture for the whole of the sped-up stretch, so a compressed shot is
-  announced rather than slipped past. The other film is the 76-second reading of
-  the public-testnet deployment.
+  Two films (committed under `recordings/`, and inline in the PR). This one is a single take of `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose hash is on screen (the reviewed commit `e9e8fcd` is two commits later; `git diff c72ff1c e9e8fcd --stat` is `docs/recording-evidence.md` alone, the verifier binary byte-identical across the range). It starts a real standalone LEZ sequencer, deploys both programs, gathers **two real Risc0 approvals**, executes, and reads the accounts back, closing on `PASS (…, 2-of-3, RISC0_DEV_MODE=0)`. `RISC0_DEV_MODE=0` shows before any proving starts and again in that line. Only the stretch where the prover works and the screen is static is sped up, factor **63** on screen while it plays. The other film is the 76-second reading of the public-testnet deployment.
 
 ## FURPS Self-Assessment
 
@@ -301,9 +240,9 @@ configuration replaced which, only not who voted for it.
 
 Three surfaces over one library: the SDK, the `msig` CLI, and the Basecamp app.
 The app shells out to the CLI, so the GUI and the chain compute the same
-commitments from the same code — there is no second implementation to drift.
-Onboarding is `git clone && ./scripts/demo.sh`. The CLI's refusals explain *why*,
-and the GUI passes them straight through.
+commitments from the same code — no second implementation to drift. Onboarding is
+`git clone && ./scripts/demo.sh`. The CLI's refusals explain *why*, and the GUI
+passes them straight through.
 
 ### Reliability
 
@@ -315,69 +254,53 @@ trust the CLI's verdict.
 
 ### Performance
 
-`approve` at **541,207 user cycles**, 3.12 % of the public budget. Wall clock is
-dominated entirely by proving: **484 s and 550 s** for this deployment's two
-transfer approvals.
-
-Three things cut against this submission and all three are in `docs/cu-costs.md`
-with the machine and LEZ version attached. **The version got slower**: the same
-lifecycle measured 149–154 s under v0.2.0, and v0.2.4 is about three times more
-expensive — CI went 1264 s to 4033 s. **Spending tiers made every instruction
-dearer** by 45,000–52,000 cycles, and pushed `execute` at M=5 from one segment to
-two, which is the one figure that changes what an operator must plan for. The tier
-itself is nearly free; what is paid everywhere is the anchoring, including by
-multisigs that have none. **And proving times vary with contention**: an idle
-laptop measures 437 s where a shared runner took sixty-seven minutes, so the
-honest summary is a range, not a number.
+`approve` at **541,207 user cycles**, 3.12 % of the public budget; wall clock is
+dominated by proving (**484 s and 550 s** for this deployment's two transfer
+approvals). Three things cut against this submission, all in `docs/cu-costs.md`
+with machine and LEZ version attached: **v0.2.4 is ~3× slower** than v0.2.0 on the
+same lifecycle; **spending tiers made every instruction dearer** (the anchoring,
+not the tier itself, and it pushes `execute` at M=5 from one segment to two); and
+**proving times vary with contention**, an idle laptop measuring 437 s where a
+shared runner took sixty-seven minutes — so the honest summary is a range.
 
 ### Supportability
 
-**131 tests** across nine suites, itemised in the README, eighty-four of them
-running the **built verifier binary** through the sequencer's own executor rather
-than the host crate — and every one of the twenty-seven error codes is exercised
-against that binary. Thirteen mutations were run against the guards the tier and
-rotation work added, each rebuilt through the reproducible Docker build with the
-binary's hash required to move first; thirteen were caught, recorded in the
-message of commit `d9f368c`. That run was by hand with no harness committed, so
-unlike everything else here it is a claim from the history rather than something
-a clone re-derives. The two guest crates
-target `riscv32im-risc0-zkvm-elf` and so sit outside the host workspace, but the
-deployed program is still under test, because `multisig-verifier-tests` is a
-workspace member exercising it. CI runs on Ubuntu and macOS, and a dedicated job
-fails if `MEMBERSHIP_LEZ_PROGRAM_ID` drifts from the committed membership binary —
-the constant that stops a chained call reaching an unaudited program.
+**131 tests** across nine suites, itemised in the README, eighty-four running the
+**built verifier binary** through the sequencer's own executor, and every one of
+the twenty-seven error codes exercised against that binary. Thirteen mutations were
+run against the tier and rotation guards, each rebuilt through the reproducible
+Docker build with the binary's hash required to move first; all thirteen were
+caught (recorded in commit `d9f368c`) — that run was by hand with no harness
+committed, so it is a claim from history rather than something a clone re-derives.
+CI runs on Ubuntu and macOS, and a dedicated job fails if `MEMBERSHIP_LEZ_PROGRAM_ID`
+drifts from the committed membership binary.
 
 ## Write-up, by the topics the brief names
 
 - **Threshold proof scheme** — *Approach* above: membership against an anchored
-  Merkle root, proved in a Risc0 guest, composed on chain by LEZ's privacy circuit
-  via `env::verify`.
-- **Nullifier design** — *Making M markers mean M distinct members* above, and
-  bindings 4–7 in `docs/security.md`.
+  Merkle root, proved in a Risc0 guest, composed on chain via `env::verify`.
+- **Nullifier design** — *M markers mean M distinct members* above, and bindings
+  4–7 in `docs/security.md`.
 - **LEZ account model compatibility (nonce, `program_owner`)** —
-  `docs/lez-account-model.md`, in full. The nonce constraint never binds on
-  membership: a member is a Merkle leaf, not an account this program touches, and
-  it binds one level up on the account that *submits*, which may be a relayer.
-  `program_owner` is load-bearing rather than an obstacle — it is how an
-  uninitialised PDA is detectable, which is what makes a forged configuration
+  `docs/lez-account-model.md`. The nonce constraint never binds on membership (a
+  member is a Merkle leaf, not an account this program touches); `program_owner` is
+  how an uninitialised PDA is detectable, which makes a forged configuration
   unrepresentable.
 - **Trusted setup** — **none**. Risc0 is STARK-based and transparent: no reference
   string, no ceremony, no toxic waste. The only trusted parameters are the two
-  ImageIDs, and those are content-addressed; `docs/DEPLOYMENT.md` shows a clean
-  rebuild reproducing `a8a87f8b…`.
+  content-addressed ImageIDs; `docs/DEPLOYMENT.md` shows a clean rebuild reproducing
+  `a8a87f8b…`.
 - **Security assumptions** and **known limitations** — `docs/security.md`: three
-  adversaries in increasing order of knowledge, ending at the insider; then timing
-  correlation, small anonymity sets, and a 1-of-2 multisig hiding nothing from its
-  other member.
-- **Integration instructions** — `README.md`, and `docs/DEPLOYMENT.md` for
-  deployment.
-- **Benchmarks** — `docs/cu-costs.md`: per-instruction CU, per-approval wall
+  adversaries in increasing order of knowledge; then timing correlation, small
+  anonymity sets, and a 1-of-2 multisig hiding nothing from its other member.
+- **Integration instructions** — `README.md`, and `docs/DEPLOYMENT.md`.
+- **Benchmarks** — `docs/cu-costs.md`: per-instruction CU and per-approval wall
   clock, each with the machine and LEZ version it was measured on.
 
-Also worth opening: `docs/error-codes.md` (all 27 codes, the attack each stops,
-the test behind it) and `docs/recording-evidence.md`. Two LEZ behaviours that each
-cost a day — an approver account cannot serve two approvals, and variadic accounts
-take one comma-separated flag — are written up in `docs/DEPLOYMENT.md`.
+Also worth opening: `docs/error-codes.md` (all 27 codes) and
+`docs/recording-evidence.md`. Two LEZ behaviours that each cost a day — an approver
+account cannot serve two approvals, and variadic accounts take one comma-separated
+flag — are written up in `docs/DEPLOYMENT.md`.
 
 ## Terms & Conditions
 


### PR DESCRIPTION
A threshold multisig for LEZ where an approval is unlinkable to the member who
gave it — including to the other members — and the chain records only that the
threshold was met.

## The exact version under review

Everything below is pinned to one commit. Nothing in this submission points at a
branch, so nothing under review can move after it is opened.

| | |
|---|---|
| **Repository** | https://github.com/edenbd1/lp-0002-private-multisig |
| **Reviewed commit** | [`e9e8fcd`](https://github.com/edenbd1/lp-0002-private-multisig/commit/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c) |
| **Basecamp module** | [`app/lp-0002-multisig.lgx`](https://github.com/edenbd1/lp-0002-private-multisig/blob/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c/app/lp-0002-multisig.lgx) — 2.5 MB, `darwin-arm64` and `linux-amd64`, verified loading in Basecamp 0.2.2 |
| **CI — host tests + deployed-binary audit** | [run 33221831189](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/33221831189) ✅ — six jobs, all green, on the reviewed commit `e9e8fcd`: 131 tests, 84 of them through the sequencer's own executor, plus the gates that hold these documents to the code; and the full standalone-sequencer lifecycle ran on the reviewed commit itself — [run 33249480393](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/33249480393) ✅, `RISC0_DEV_MODE=0`, no skip path |
| **CI — full lifecycle vs a standalone LEZ sequencer** | [run 33098969090](https://github.com/edenbd1/lp-0002-private-multisig/actions/runs/33098969090) ✅ — 2 h 39 at `RISC0_DEV_MODE=0`, on `1759015`, an ancestor of the reviewed commit; `git diff 1759015 e9e8fcd --stat` is five files — the deployment and CU-cost notes, the film's transcript and its recording-evidence anchor, and the transcript-checker gate — with no program, no demo script and no chain artefact among them, so the run exercised the code under review: it builds LEZ at a pinned revision, starts a standalone sequencer, and drives deploy → create → propose → real Risc0 approvals → execute against it |
| **Solution file** | [`solutions/LP-0002.md`](https://github.com/logos-co/lambda-prize/pull/125/files) |

> **Redeployed on 2026-08-25, and the gate now prices what it releases.** The
> multisig anchors a **spending tier**: at or below a cap, fewer approvals than
> the default threshold. This deployment is 3-of-3 and the transfer cleared with
> **two** approvals, which is the tier doing something — counted in proofs not
> generated rather than asserted in prose.
>
> The tier is anchored, not merely applied. `config_hash` here is `1628d88b…`;
> the same members and threshold *without* the tier give `3dff16d7…` — a different
> PDA, an account nobody created. So a caller who invents a more generous table
> must present a `config_hash` committing to it, and that hash is the address they
> then have to read the multisig from. The gate still moves value: treasury
> **2 → 1**, recipient **1 → 2**, both sides in the `execute` transaction.
> Everything below is that deployment, in blocks 23028-23554.
>
> Only the verifier was redeployed. `membership_lez` is byte-for-byte the binary
> it has been since block 4459, so `MEMBERSHIP_LEZ_PROGRAM_ID` — the pin that
> stops a chained call reaching anything but the audited membership program —
> never moved. Keeping it there took work: with `lto = "fat"`, unreachable code
> in a linked crate shifts the ELF, and the first build of this revision moved
> the membership ImageID purely because `multisig-core` had gained an
> account-layout module the membership guest never calls. Gating that behind a
> feature the membership guest does not enable brings the ImageID back exactly.

**Two minutes eight, the whole lifecycle, two real proofs, narrated.** One take
of `scripts/e2e-local-sequencer.sh` — the script CI runs — at `c72ff1c`, whose
hash is on screen in the opening seconds; the reviewed commit is later because a
film's transcript and the measurement of it can only be written once the film
exists. It starts a real LEZ sequencer in
standalone mode, deploys both programs onto that fresh chain, creates the
multisig, proposes a transfer, gathers **two real Risc0 approvals**, executes,
and reads the accounts back off the same chain. It closes on
`e2e against a real local sequencer: PASS (http://localhost:3141, 2-of-3, RISC0_DEV_MODE=0)`, and
`RISC0_DEV_MODE=0` is also on screen before any proving starts. No funded
account, no public testnet, nothing mocked. The session ran 31 min 40; only the
stretch where the prover works and the screen does not change is sped up — 1,259
seconds compressed to 20, a factor of 63 written across the picture for the whole
of it, so a sped-up shot is announced rather than slipped past.

https://github.com/user-attachments/assets/7553f021-77b8-4ba6-bf84-200900f04c83

**Seventy-six seconds, two scripts.** One terminal session running
`verify-onchain-lifecycle.sh` and then
`verify-onchain.sh`: the thirteen transactions and the variant each carries —
five of them `PrivacyPreserving` — then the six accounts decoded field by field,
down to the recipient's balance of two. Nothing is sped up; the two scripts
answer in about eleven seconds between them. It is narrated, and the narration was
re-recorded for this deployment rather than carried over — it says thirteen
transactions and a recipient holding two, which is what the screen shows. The same
words are burned in as captions and committed as
`recordings/lp-0002-threshold-moves-value.srt`, so the film can be read as well as
watched. The hash on screen is `c72ff1c`. The reason it is
not the reviewed commit is structural: a film's transcript can only be committed
after the film exists, so the commit that carries the transcript is necessarily
later than the take. What came after this take is exactly that — the transcript
and the anchor that holds it to the picture. The e2e film above was shot at
`c72ff1c`, a different take at the same commit, also earlier than the reviewed
commit for the same reason; run `git diff` from either against the reviewed commit to see that only
documents, the transcript and the anchor lie between.

[`docs/recording-evidence.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c/docs/recording-evidence.md)
carries the `git diff` that says so, the measured transcript check, and what it
does **not** establish.

https://github.com/user-attachments/assets/c5eb01f3-fadf-4f37-9dac-130c7128c79a


## What is verified on chain

Each `approve` declares a `ChainedCall` to a LEZ-native membership program, so
the privacy circuit composes it with a real `env::verify` and the sequencer
checks the receipt against the node-pinned `PRIVACY_PRESERVING_CIRCUIT_ID`. The
member set and the threshold are folded into the PDA address, so neither can be
invented nor lowered — a forged configuration resolves to an address nobody ever
created.

## Transactions — the lifecycle and the rotation, on the current public testnet

| Step | Transaction | Block |
|---|---|---|
| deploy `membership_lez` | [`fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98`](https://explorer.testnet.lez.logos.co/transaction/fb8eb10f7f394286c109cb6502a1c95294180523f30d06f707fc087a589bea98) | 4459 |
| deploy `multisig_verifier` | [`268834b601f78b59090e90f8f10fd8ce3b526528e1224983edba95224be31aa3`](https://explorer.testnet.lez.logos.co/transaction/268834b601f78b59090e90f8f10fd8ce3b526528e1224983edba95224be31aa3) | 23028 |
| `create_multisig` | [`dce8fd4dc4b53216d7271466ba66290b3bbfb2cf125701cd7c97a68cb69d1db0`](https://explorer.testnet.lez.logos.co/transaction/dce8fd4dc4b53216d7271466ba66290b3bbfb2cf125701cd7c97a68cb69d1db0) | 23029 |
| `fund_treasury` | [`993d1f7c2b27fcab1abf759513f7bf7c64449a547b608e692deae67ec94f640b`](https://explorer.testnet.lez.logos.co/transaction/993d1f7c2b27fcab1abf759513f7bf7c64449a547b608e692deae67ec94f640b) | 23030 |
| `create_proposal` | [`54a300eb8c0bec27adb40b3ab36ff653b6234dc4deab2a47ac89a0a665c4fdd3`](https://explorer.testnet.lez.logos.co/transaction/54a300eb8c0bec27adb40b3ab36ff653b6234dc4deab2a47ac89a0a665c4fdd3) | 23031 |
| `approve` (member A, **privacy tx**) | [`1a5e529d8b9c87ec781b6e8cc2d4bc71c149e7f45f9ce66711108a22dbf6fcd5`](https://explorer.testnet.lez.logos.co/transaction/1a5e529d8b9c87ec781b6e8cc2d4bc71c149e7f45f9ce66711108a22dbf6fcd5) | 23039 |
| `approve` (member B, **privacy tx**) | [`28a07e8df970322b643d7d5d6c74640f49e6d0260964255909181fdc815e8397`](https://explorer.testnet.lez.logos.co/transaction/28a07e8df970322b643d7d5d6c74640f49e6d0260964255909181fdc815e8397) | 23065 |
| `execute` | [`d0bab2943f09d3a27a10610c49c2a6cce1a2c94b93ded6f341ce29005ba8ca7c`](https://explorer.testnet.lez.logos.co/transaction/d0bab2943f09d3a27a10610c49c2a6cce1a2c94b93ded6f341ce29005ba8ca7c) | 23066 |
| `create_proposal` (rotation) | [`7a9331a9db536f710689b31861e7a3c94462fa1e090140e9fc3af66bc9eee773`](https://explorer.testnet.lez.logos.co/transaction/7a9331a9db536f710689b31861e7a3c94462fa1e090140e9fc3af66bc9eee773) | 23527 |
| `approve` (member A, **privacy tx**) | [`664fa866c041d39733dadadf84e266b1ec9a36e033a2cc271d2032c87dc2b563`](https://explorer.testnet.lez.logos.co/transaction/664fa866c041d39733dadadf84e266b1ec9a36e033a2cc271d2032c87dc2b563) | 23536 |
| `approve` (member B, **privacy tx**) | [`87aeffe96c98d4ed58601bbb5707f5c6516ca602e4a7aff1e274ba2188bb58a0`](https://explorer.testnet.lez.logos.co/transaction/87aeffe96c98d4ed58601bbb5707f5c6516ca602e4a7aff1e274ba2188bb58a0) | 23544 |
| `approve` (member C, **privacy tx**) | [`6fcc674ae1c198651181afc74b47e005dc90aee4729301e79fb709019a314160`](https://explorer.testnet.lez.logos.co/transaction/6fcc674ae1c198651181afc74b47e005dc90aee4729301e79fb709019a314160) | 23553 |
| `rotate_config` | [`cb8a3f8b07db5039b48aefc32e3770e9919b2ce7af0792ef31fb8b47ea942554`](https://explorer.testnet.lez.logos.co/transaction/cb8a3f8b07db5039b48aefc32e3770e9919b2ce7af0792ef31fb8b47ea942554) | 23554 |

Check any of them:

```bash
curl -s -X POST https://testnet.lez.logos.co -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<hash>"]}'
```

**Three approvals on the rotation, two on the transfer.** The anchored tier
prices transfers; it never prices governance, and `rotate_config` does not read
the tier table for its own count.

The two deployment hashes are `SHA256(borsh(bytecode))` of the binaries committed
under `artifacts/programs/`, so they can be recomputed from the repository
without trusting this table.

## The accounts, which are the stronger evidence

All six are owned by the verifier program. `./scripts/verify-onchain.sh` reads
them back and decodes every record against the offsets published in
[`docs/account-layout.md`](https://github.com/edenbd1/lp-0002-private-multisig/blob/e9e8fcd89aca6ee26ae1e75bfa7acae2c720198c/docs/account-layout.md).

| Account | Address | Balance |
|---|---|---|
| multisig | `C9CgRDNfrCUJMzYG1YbskwViRTpDypty74YC2KThcxL3` | 0 |
| treasury | `FyTtsh2h5fC85vrei19ThtM4yRThHEH4MGtXH1azrdhM` | **2 → 1** |
| proposal | `5kM4uZdHgwjanoX82PtmeRUptkekm4EfjCzvmz6r7MHz` | 0 |
| approval marker A | `5YajQiNzWfsy5VnDQxEKh7UPN6mXcqFsY3XTWp9GhWZg` | 0 |
| approval marker B | `3fWFBfi8VWy9NadC6vE5KXtmjj9MzYkC9p2XWHX6ANit` | 0 |
| execution marker | `J1N6WWpHVPh6pBpXmKAe522JBEWaaRT3jymaWcczg5AG` | 0 |

A seventh account is not the program's, and it is the point of the exercise: the
**recipient**, `8kexXda8j5hPegPeHXzUM9PhvjYNFLpN8wN8PvG5iDhn`, went **1 → 2**. It
is held by the native transfer program rather than by the verifier, which is what
makes what it received spendable instead of stranded.

The treasury's balance is the one number nothing except a real execution could
produce: `fund_treasury` put 2 in and `execute` moved 1 out, and the two sides of
that move are visible in two accounts owned by two different programs. Each
approval marker exists only because a membership proof was verified on chain, and
nothing in the pair names a member — read them and you learn the threshold was
met, and nothing about who met it.

## On the block explorer, measured rather than asserted

**All thirteen render**, and each carries the type it should: two
`Deployment`, five `Privacy-Preserving Transaction` — the transfer's two
approvals and the rotation's three — and six `Public Transaction`. Checked
at 22:24 UTC on 2026-08-25, against an impossible hash as the control, which still answers
`Transaction not found`.

The index trails the sequencer — on this chain, roughly an hour and three
quarters — so a transaction submitted recently answers "Transaction not found"
there while `getTransaction` already resolves it. That is an indexing delay, not
a gap, and it affects anything recent by anyone. These thirteen were written in
blocks 23028-23554 and each was behind the index for about three hours.

**And a `curl` size comparison under-reports public transactions**, which is
worth stating because this description used to recommend one. Three sizes,
measured on these very hashes:

| what | over `curl` | why |
|---|---|---|
| a hash that cannot exist | **2,416 bytes** | the page stops at the loading shell |
| a **public** transaction | **4.9-7.0 kB** | *complete* — hash, `Type: Public Transaction`, `Program ID`, instruction-data size, signature count, and every account with its nonce |
| a deployment or a privacy-preserving transaction | **372-694 kB** | the same page, plus the proof bytes, which are almost all of it |

A public transaction's page is small because a public transaction carries no
proof, not because anything is missing from it. So the size tells you which kind
of transaction you fetched, and it does **not** tell you whether it is there —
`Type:` does. `scripts/check-explorer.py` classifies on that marker rather than
on a length, with an impossible hash as the control, and aborts if the control
ever classifies as found.

```bash
# where the explorer's index is, and where the sequencer is
curl -s https://explorer.testnet.lez.logos.co/ | grep -o 'block_id[^,]*' | head -1

# the control: a hash that cannot exist
curl -s "https://explorer.testnet.lez.logos.co/transaction/$(python3 -c 'print("ff"*32)')" | wc -c
```

**Correction.** An earlier version of this description said the explorer was a
WASM application returning an identical shell for every `/transaction/<hash>`
URL, so an indexed transaction and one that cannot exist were byte-identical over
`curl`. That was true when `check-explorer.py` was written — it is why the script
drives a browser at all. It stopped being true on **2026-08-15**, when the
explorer began rendering server-side; and as the table above shows, it stopped
being true only *partly*, which is the sort of half-change that turns a shortcut
into a wrong answer.

## Note on versions

The testnet was reset onto a newer chain in August, so everything here was
rebuilt against **LEZ v0.2.4** and redeployed. That is also why the repository
vendors SPEL: no published SPEL release builds against a current LEZ, and
`vendor/spel/PATCH.md` documents every change, how to reproduce the directory,
and when it should be deleted.

## Against the criteria

**131 tests**, CI green on Linux and macOS, including a workflow that runs the
whole lifecycle against a real standalone LEZ sequencer with `RISC0_DEV_MODE=0`.
Eighty-four of the 131 run the **built verifier binary** through the sequencer's
own executor rather than the host crate: 30 rejections and honest controls, 22 on
the state it writes and the value it moves, 23 on the spending tiers and the
rotation, 6 on the IDL and the docs, 3 pinning the committed membership binary and
every ImageID the documentation quotes.

**Thirteen mutations, thirteen caught.** Every guard the tier and rotation work
added was watched fail when removed — each rebuilt through the reproducible Docker
build with the binary's hash required to move first, because a mutation that
leaves the artefact untouched proves nothing. CU costs are measured rather than
estimated, per instruction and per machine, and this revision made them worse:
every instruction is 45,000-52,000 user cycles dearer and `execute` at M=5 crossed
from one segment to two. That is in `docs/cu-costs.md` with the numbers, not
rounded in the submission's favour. The Basecamp module ships as a `.lgx` with
darwin-arm64 and linux-amd64 variants and was verified loading in Basecamp 0.2.2,
not merely built.

**And the documents are gated against the code**, because on this repository they
have drifted from it. Every quoted path, link and cited CI run must resolve;
every explorer link must resolve against the chain it names; nothing in the tree
may name another submission; and every row of the README's test inventory, with
its total and the addition printed under it, must be what the suites actually
pass. That last gate was rewritten after it checked four rows of nine and
reported "every stated count is what its suite passes" — it now reads the table,
and a row it cannot map is a failure rather than a skip.

Happy to address anything in review.










