### PR TITLE
Solution: LP-0008 — Autonomous AI Module with Wallet, Storage, and Messaging

### DIFF
--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -27,15 +27,15 @@ skill category, each with its own shielded account and spending envelope:
 
 | category | agent id | policy account | per-tx | per-period | `create_policy` |
 |---|---|---|---|---|---|
-| storage | `9Xpkkvos…jfv1FaE` | `6FscNXjN…Nj3ipSe` | 50 | 500 | `6857ba23…631fe7d4` |
-| messaging | `GpRdooEW…MZpe5FS` | `7HH46tXh…K1dA7bp` | 25 | 250 | `ce557a0a…278e1918` |
-| blockchain | `A7UBoMbS…c39JtMu` | `2RK4dPwz…W3Wusvc9` | 200 | 1,000 | `2f6b481c…ecec5eda` |
+| storage | `9Xpkkvos…jfv1FaE` | `6FscNXjN…Nj3ipSe` | 50 | 500 | [`6857ba23…631fe7d4`](https://explorer.testnet.lez.logos.co/transaction/6857ba2378a84ba51618582e852e3827a872e3ea85f17de76bdb45b1631fe7d4) |
+| messaging | `GpRdooEW…MZpe5FS` | `7HH46tXh…K1dA7bp` | 25 | 250 | [`ce557a0a…278e1918`](https://explorer.testnet.lez.logos.co/transaction/ce557a0a8adc517b60496c35514e269fff92a4393b90bef41ce10916278e1918) |
+| blockchain | `A7UBoMbS…c39JtMu` | `2RK4dPwz…W3Wusvc9` | 200 | 1,000 | [`2f6b481c…ecec5eda`](https://explorer.testnet.lez.logos.co/transaction/2f6b481cffde2adaeed9442c19599c939d97da0c930b70b45d97ac34ecec5eda) |
 
 They have **paid each other for priced skills, unattended**, the per-period total
 accumulating on chain: sixteen settlements, of which **thirteen are under the
 program this repository ships**. One was made **by a module a host loaded**, in
 the same call that discovered the payee's signed Agent Card and opened the A2A
-task: `ed8c3514…374b8cb3`, block 9477. Every hash, block and balance below is
+task: [`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3), block 9477. Every hash, block and balance below is
 generated from the chain rather than typed.
 
 **What is not delivered is stated plainly.** All twenty-three success criteria are
@@ -60,22 +60,38 @@ Expanded in `docs/limitations.md`:
 - no model has run against the inference port. The prize puts the choice of model
   **out of scope** and asks only that inference be pluggable, which it is — a
   local and an HTTP backend behind one port — but neither has served a real
-  request.
+  request;
+- **`messaging.join` subscribes to the discovery topic, not the group's own.**
+  `module/src/messaging_skills.cpp:176` passes `discoveryTopic(group)` where
+  `module/src/delivery_runtime.cpp:695` opens `groupTopic(channelId)`, so the skill
+  returns `{"ok":true}` and joins the wrong topic. The prize defines it as "joins a
+  Logos Messaging group topic", so that criterion is met in shape and not in
+  substance. The fix is two lines and it is not applied here: changing the source
+  without rebuilding the `.lgx` makes `check-package-fresh.py` red, and the
+  toolchain that rebuilds it is not on this machine. Disclosed rather than hidden,
+  in full, in `docs/limitations.md`.
 
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
-- **Reviewed commit:** `20678b7`. Every path below is relative to it, and the
-  links are pinned to it rather than to `main`, so the version under review cannot
-  move after submission.
-- **CI on that exact commit, all green:** the host suite (9 min), the full
-  lifecycle against a standalone LEZ sequencer (3 h 29, `RISC0_DEV_MODE=0`, no
-  skip path), and the run that loads this module in one Logos Core runtime
-  alongside the wallet, storage and messaging modules. Beside them run gates that
+- **Reviewed commit:**
+  [`1956340`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/1956340334023e40b71970d561ec13d15fddd0ed).
+  Every path below is relative to it. Read them at that tree rather than at
+  `main`: `main` moves, and a path that has moved with it is no longer the file
+  this document describes.
+- **CI, all green — and this says which run sat where.** The host suite
+  (`33084399499`, 12 min) and the explorer-link gate (`33084399822`) ran on the
+  reviewed commit itself. So did the full lifecycle against a standalone
+  LEZ sequencer: `33093872580`, 3 h 16, `RISC0_DEV_MODE=0`, no skip path, ending
+  on a payment inside the envelope moving a balance `0 → 50` and one above the
+  ceiling refused with `Program error 6005`. Of the four workflows, only the run
+  that loads this module in one Logos Core runtime alongside the wallet, storage
+  and messaging modules sits elsewhere — `33087503041`, on `4d684c2`, which
+  differs from the reviewed commit by one line of one document. Beside them run gates that
   hold the documents to the code: every quoted path and link must resolve, every
   cited CI run must be on a commit this branch has, every explorer link must
   resolve against the chain it names, the README's stated test count must be what
-  the suite passes, and nothing in the tree may name another submission.
+  the suite passes, and no file may name a different prize entry.
 - **Where the detail lives:** `docs/criteria-evidence.md` (the long form of every
   criterion), `docs/architecture.md`, `docs/skills.md`, `docs/security-model.md`,
   `docs/a2a-binding.md`, `docs/limitations.md`, `docs/DEPLOYMENT.md`,
@@ -118,7 +134,7 @@ this repository rather than as a hundred and fifty kilobytes of working text at
 the top of a public tree, so the command above generates instead. CI runs both on
 every push, and requires a drifted copy to be rejected.
 
-The deployed program is `697746f5…cb5370bf`. A LEZ deploy hash is
+The deployed program is [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf). A LEZ deploy hash is
 `SHA256(u32_le(len) ‖ bytecode)`, so `artifacts/programs/agent_verifier.bin` **is**
 its own deploy transaction — recompute it and compare, which `./scripts/demo.sh`
 does in front of you. The sixteen settlements are recorded in
@@ -126,7 +142,7 @@ does in front of you. The sixteen settlements are recorded in
 re-decoded from the chain's own copy of the transaction rather than from the
 manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
 redeploy orphaned instead of counting them. The one the video ends on is
-`54f85182…e2f47115`, block 10102 — the recipient goes 107 → 108 LEZ, and no owner
+[`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115), block 10102 — the recipient goes 107 → 108 LEZ, and no owner
 signs anything.
 
 ## Approach
@@ -188,14 +204,17 @@ written down there first, with the retractions of claims that did not survive it
 ## Success Criteria Checklist
 
 Twenty-three criteria, mirrored from the prize in its own order and its own
-words. **Tally: 23 MET, 0 UNMET.** Each entry gives the verdict and the one
-thing that re-derives it; the long form of every one — the controls, the
-transcripts, what was watched failing — is in `docs/criteria-evidence.md`.
+words. **Tally: 23 MET, 0 UNMET.** Most entries give the verdict and the one thing that
+re-derives it. Six do not, because the criterion is about behaviour rather than
+an artefact — a retry that times out, an owner driving the agent from a separate
+app — and for those the long form carries the transcript instead. The long form
+of every entry, including the controls and what was watched failing, is in
+`docs/criteria-evidence.md`.
 
 ### Functionality
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime; transcript in `artifacts/e2e/exercise-nodes.txt`.
+  All three companions are built from their published sources and all four modules load in one runtime; the workflow is `.github/workflows/alongside-companion-modules.yml` and the run that shows it is `32805342163`.
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
   *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: the payee's balance moves on chain, 107 → 108 LEZ on the settlement the video ends on.
@@ -207,19 +226,19 @@ transcripts, what was watched failing — is in `docs/criteria-evidence.md`.
   Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging.
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
-  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain (blocks 10776, 10786).
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain: [`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8) at block 10776 and [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597) at block 10786, the payee going 4 → 6.
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable.
+  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. **With one qualification, stated here rather than left for a reviewer to find:** `messaging.join` is registered, documented and reachable, and it subscribes to the discovery topic instead of the group's own, so it does not do what the prize's wording asks. `docs/limitations.md` gives the two lines and why they are not applied.
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
   Cards follow the A2A schema, tasks follow the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
-  `./scripts/delivery-in-plugin.sh settle` does discovery, task and settlement in one invocation — `ed8c3514…374b8cb3`, block 9477, from a module a host loaded.
+  `./scripts/delivery-in-plugin.sh settle` does discovery, task and settlement in one invocation — [`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3), block 9477, from a module a host loaded.
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold.
+  Four run end to end — file vault, marketplace, notary, event alerter — and **three of those four are in the recorded demo**: the marketplace, the notary and the event alerter. The file vault runs in `alongside-companion-modules.yml` rather than on camera, because as the prize words it that case has no chain step. The spending threshold is filmed as well, and is deliberately not counted: it is a criterion of its own, not one of the nine.
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
   Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; addresses and `create_policy` hashes in the table above.
@@ -249,18 +268,18 @@ transcripts, what was watched failing — is in `docs/criteria-evidence.md`.
 ### Performance
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  `docs/benchmarks/cu-budget.md`, candid about its premise: LEZ v0.2.4 does not meter compute units, and the document shows the search establishing that rather than inventing a number. What is measured instead is what actually costs — a `claim_agent` proof at ~54 min on a four-core runner, `create_policy` at about one block.
+  `docs/benchmarks/cu-budget.md`, candid about its premise: LEZ v0.2.4 does not meter compute units, and the document shows the search establishing that rather than inventing a number. What is measured instead is what actually costs — a `claim_agent` proof at 58 min on a four-core runner, `create_policy` at about one block.
 
 ### Supportability
 
 - [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
-  Deployed at `697746f5…cb5370bf`; `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
+  Deployed at [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf); `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `32814477623` on the reviewed commit, 3 h 29, of which 58 minutes are real `claim_agent` proving.
+  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on the reviewed commit, 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically, run `32769238263`.
+  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `1956340`.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.
@@ -301,7 +320,7 @@ named, and does not take the module or a concurrent skill with it.
 
 LEZ v0.2.4 does not meter compute units, and `docs/benchmarks/cu-budget.md` says
 so with the search that establishes it, rather than inventing a number. What is
-measured instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
+measured instead is what actually costs: a `claim_agent` proof at 58 minutes on a
 four-core runner, `create_policy` at about one block.
 
 ### Supportability
@@ -319,8 +338,8 @@ anything that does not work is written down before anything that does.
 
 ## Supporting Materials
 
-- **Video demo:** <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, four illustrative
-  use cases, against the public testnet and never a localnet, `RISC0_DEV_MODE=0`
+- **Video demo:** <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, three of the
+  prize's illustrative use cases plus the spending threshold, against the public testnet and never a localnet, `RISC0_DEV_MODE=0`
   legible throughout the proving output. The same file is a release asset
   (`lp8-demo.mp4`), so the evidence does not depend on a third party keeping it up.
 - **The demo as text, checked against the film:** `recordings/lp8-demo.srt` is the

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -10,7 +10,7 @@
 > | three agents live on the public testnet, and one paying another | [Summary](#summary) and [Repository](#repository) — explorer links, not hashes to paste |
 > | that it runs from a clean clone | [The four commands](#the-four-commands-that-check-the-rest) — four lines, all exit 0 |
 > | the recorded demo, and the e2e green in CI | [Supporting Materials](#supporting-materials) and the Supportability entries in the [checklist](#success-criteria-checklist) |
-> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md) |
+> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md) |
 
 ## Summary
 
@@ -60,7 +60,7 @@ block 9477. Every hash, block and balance is in
 success criteria are now met, the last of them — the recorded video demo — by
 one narrated walkthrough published with this submission. That is not a claim
 that nothing is missing. Disclosed at the same volume as everything else, and
-expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md):
+expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md):
 
 - the **three agents published here** can never have an above-threshold spend
   approved: their owners anchored while their accounts were still unclaimed, and
@@ -88,6 +88,13 @@ expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomou
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module>
+- **Reviewed commit:** [`708b2ce`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/708b2cea8401ef3a2a179baf4d2aabeddefac59f).
+  Every repository link below names that commit rather than `main`, so the
+  version under review cannot move after this is opened.
+- **CI on that exact commit:**
+  [the host suite](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505542)
+  and [the full lifecycle against a standalone LEZ sequencer](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555),
+  both green.
 - **License:** dual MIT / Apache-2.0 (both full texts committed)
 - **Default branch:** `main`
 
@@ -96,7 +103,7 @@ claim depends on trusting the author.
 
 ### The four commands that check the rest
 
-Run from a clean clone against the tip of `main`. These exit codes were observed
+Run from a clean clone at the reviewed commit. These exit codes were observed
 on a fresh clone of the public repository, not intended.
 
 ```console
@@ -153,13 +160,13 @@ The three agents, their limits and the `create_policy` that anchored each are in
 the table under [Summary](#summary), every hash a link to the block explorer.
 Their claim transactions, policy-account addresses, owner ids and the byte-level
 record layout are in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
 and re-read from the chain by `./scripts/verify-deployment.sh`.
 
 #### The settlements
 
-Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/a2a-task.tsv)
-and [`artifacts/shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/shielded-settlement.tsv);
+Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/a2a-task.tsv)
+and [`artifacts/shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/shielded-settlement.tsv);
 thirteen are under the shipped program, where the criterion asks for two. Each is
 re-decoded from the chain's own copy of the transaction rather than from the
 manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
@@ -170,7 +177,7 @@ The one the video ends on:
 block 10102 — the recipient goes 107 → 108 LEZ, and no owner signs anything.
 Every row, with its before/after balances and the program that owned the ledger
 it charged, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#the-settlements-in-full).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#the-settlements-in-full).
 
 ## Approach
 
@@ -187,7 +194,7 @@ one detected. Only the program may write that account's data (LEZ rule 6), and
 `spend` derives the address from the *paying* account out of the pre-state, so
 there is no argument to lie about. The full argument, with the refusal codes and
 the four deployments it took to get there, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
 
 ### What was tried and did not work, and why Logos
 
@@ -196,7 +203,7 @@ walked around by an attacker who was not lying — they really were the owner of
 the policy they anchored; they had simply never been asked whether the agent
 agreed. The full account, including the attack transaction that the superseded
 program accepted and the one today's program refuses, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
 `./scripts/demo.sh` section 5 replays it against both programs in front of you.
 
 ## Design Write-up
@@ -205,7 +212,7 @@ The prize names seven topics. Each has a document in the repository that carries
 it at full length; what follows is the decision each one turns on, so this
 section reads in five minutes and the document is opened only where it matters.
 
-**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/architecture.md).
+**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/architecture.md).
 A Logos Core plugin exposing three skill categories, each a thin binding onto a
 real Logos node or onto LEZ. `invoke()` is the single dispatcher every capability
 sits behind, which is what lets a second Logos app drive the owner's end without
@@ -214,23 +221,23 @@ of `std::function`s — `DeliveryPort`, `StoragePort`, `WalletPort`, `ProgramPor
 — so every skill has a test against a fake port and there is one place where a
 real node is wired.
 
-**Skill interface design** — [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md).
+**Skill interface design** — [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md).
 A skill is a class with `name()`, `parameterSchema()` and `invoke(json)`, added
 through `registerSkill` without touching the core module. Schemas are declared
 once and the Agent Card is generated from the registry rather than written by
 hand, so a card cannot advertise a skill the module does not have.
 
 **Spending threshold mechanism** — [Approach](#approach) above has the argument;
-[`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/security-model.md) has the mechanism, the
+[`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/security-model.md) has the mechanism, the
 refusal codes, and what a holder of the agent's key can and cannot do.
 
-**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/a2a-binding.md).
+**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/a2a-binding.md).
 Agent Cards follow the A2A schema, tasks follow the A2A lifecycle, and Logos
 Messaging is the transport A2A leaves open. Payment is the part A2A omits: the
 client pays the price the card advertises, signed by the agent's own shielded
 account, with no owner in the loop.
 
-**Security model** — [`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/security-model.md).
+**Security model** — [`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/security-model.md).
 Anchoring takes two signatures: the agent signs `claim_agent` to name the account
 that may bind it, and only that account is accepted by `create_policy`, which is
 `#[account(init, …)]` — so the first anchor is the only one possible, not merely
@@ -238,12 +245,12 @@ the only one detected. What is *not* closed is enumerated there too: the balance
 is held by the transfer program, so the agent's key can move it by calling that
 program directly. This program bounds what the agent moves *through it*.
 
-**Known limitations** — [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md), where
+**Known limitations** — [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md), where
 anything that does not work is written down first, with the retractions of claims
 that did not survive checking.
 
-**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/DEPLOYMENT.md) for
-the chain side, [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/basecamp.md) for loading the module
+**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/DEPLOYMENT.md) for
+the chain side, [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/basecamp.md) for loading the module
 into Logos Basecamp, including what a `.lgx` must satisfy to load at all.
 
 ## Success Criteria Checklist
@@ -254,91 +261,91 @@ Reliability 3 of 3, Performance 1 of 1, Supportability 6 of 6.
 
 Each entry gives the verdict and the one thing that re-derives it. The long form
 of every one — the controls, the transcripts, what was watched failing — is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md), copied there
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md), copied there
 unchanged.
 
 **Functionality**
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32582715045`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32582715045), which ran on this branch's head commit `4f4ede8`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32582715045`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32582715045), which ran on commit `4f4ede8`, an earlier revision of this branch. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
-  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The owner can deploy the agent and configure it with a single CLI command on any machine using Logos Core headless.**
-  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
-  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
-  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Every skill the prize lists is registered and documented in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
-  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/a2a-binding.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/a2a-binding.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
-  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
-  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
-  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 
 **Usability**
 
 - [x] **MET — Provide a documented skill interface (module/SDK) that can be used to add new skills without modifying the core agent module.**
-  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md); a new skill needs no change to the core module. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#usability).
+  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md); a new skill needs no change to the core module. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#usability).
 
 - [x] **MET — The owner-facing interface is accessible from the Logos app (Basecamp) via the owner channel — local build instructions and loadable assets are provided.**
-  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/basecamp.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#usability).
+  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/basecamp.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#usability).
 
 
 **Reliability**
 
 - [x] **MET — The agent module recovers from transient failures (network interruptions, node restarts) without losing pending task state.**
-  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
+  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
 
 - [x] **MET — Above-threshold transactions that fail to reach the owner for approval are not executed — the agent retries notification before timing out and reports the failure.**
-  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
+  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
 
 - [x] **MET — Skill failures are isolated: a failing skill does not crash the module or affect other concurrently running skills.**
-  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
+  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
 
 
 **Performance**
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  [`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#performance).
+  [`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#performance).
 
 
 **Supportability**
 
 - [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
-  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  [Run `32024953786`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32024953786) — **success, 3 h 03**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  [Run `32669505555`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555) — **success, 3 h 06, on the reviewed commit**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main`; the badge is not the check, `gh run list` is. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  Green on `main`, and on the reviewed commit specifically: [run `32669505542`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505542). The badge is not the check, a run id is. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
-  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
+  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
 
 ## FURPS Self-Assessment
 
@@ -371,7 +378,7 @@ with it.
 ### Performance
 
 LEZ v0.2.4 does not meter compute units, and
-[`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/benchmarks/cu-budget.md) says so with the
+[`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/benchmarks/cu-budget.md) says so with the
 search that establishes it, rather than inventing a number. What is measured
 instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
 four-core runner, `create_policy` at about one block.
@@ -393,7 +400,7 @@ implies is written up in full. An inbound A2A request is not dispatched to the
 skill it names. The storage skills
 have never driven a live node from inside the module. No model has run against
 the inference port. Each is expanded in
-[`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md).
+[`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md).
 
 ## Supporting Materials
 
@@ -413,13 +420,13 @@ the inference port. Each is expanded in
 - **On-chain evidence:** every hash, block and explorer link is in
   [Repository](#repository), generated rather than transcribed, and deliberately
   not repeated here. Manifests, read **by column name**:
-  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/agents.tsv) ·
-  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/anchored.tsv) ·
-  [`a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/a2a-task.tsv) ·
-  [`shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/shielded-settlement.tsv)
+  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/agents.tsv) ·
+  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/anchored.tsv) ·
+  [`a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/a2a-task.tsv) ·
+  [`shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/shielded-settlement.tsv)
 - **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/main/docs) — architecture, skills,
   security model, A2A binding, deployment, Basecamp loading, CU budget, and
-  [`limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md), which is where anything
+  [`limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md), which is where anything
   that does not work is written down first.
 
 ## Terms & Conditions

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -65,11 +65,17 @@ Expanded in `docs/limitations.md`:
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
-- **Reviewed commit:** `e1c57ba`. Every path below is relative to it, and the
+- **Reviewed commit:** `20678b7`. Every path below is relative to it, and the
   links are pinned to it rather than to `main`, so the version under review cannot
   move after submission.
-- **CI on that exact commit, both green:** the host suite, and the full lifecycle
-  against a standalone LEZ sequencer.
+- **CI on that exact commit, all green:** the host suite (9 min), the full
+  lifecycle against a standalone LEZ sequencer (3 h 29, `RISC0_DEV_MODE=0`, no
+  skip path), and the run that loads this module in one Logos Core runtime
+  alongside the wallet, storage and messaging modules. Beside them run gates that
+  hold the documents to the code: every quoted path and link must resolve, every
+  cited CI run must be on a commit this branch has, every explorer link must
+  resolve against the chain it names, the README's stated test count must be what
+  the suite passes, and nothing in the tree may name another submission.
 - **Where the detail lives:** `docs/criteria-evidence.md` (the long form of every
   criterion), `docs/architecture.md`, `docs/skills.md`, `docs/security-model.md`,
   `docs/a2a-binding.md`, `docs/limitations.md`, `docs/DEPLOYMENT.md`,

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -10,7 +10,7 @@
 > | three agents live on the public testnet, and one paying another | [Summary](#summary) and [Repository](#repository) — explorer links, not hashes to paste |
 > | that it runs from a clean clone | [The four commands](#the-four-commands-that-check-the-rest) — four lines, all exit 0 |
 > | the recorded demo, and the e2e green in CI | [Supporting Materials](#supporting-materials) and the Supportability entries in the [checklist](#success-criteria-checklist) |
-> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](../docs/limitations.md) |
+> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md) |
 
 ## Summary
 
@@ -60,7 +60,7 @@ block 9477. Every hash, block and balance is in
 success criteria are now met, the last of them — the recorded video demo — by
 one narrated walkthrough published with this submission. That is not a claim
 that nothing is missing. Disclosed at the same volume as everything else, and
-expanded in [`docs/limitations.md`](../docs/limitations.md):
+expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md):
 
 - the **three agents published here** can never have an above-threshold spend
   approved: their owners anchored while their accounts were still unclaimed, and
@@ -153,13 +153,13 @@ The three agents, their limits and the `create_policy` that anchored each are in
 the table under [Summary](#summary), every hash a link to the block explorer.
 Their claim transactions, policy-account addresses, owner ids and the byte-level
 record layout are in
-[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
 and re-read from the chain by `./scripts/verify-deployment.sh`.
 
 #### The settlements
 
-Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](../artifacts/a2a-task.tsv)
-and [`artifacts/shielded-settlement.tsv`](../artifacts/shielded-settlement.tsv);
+Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/a2a-task.tsv)
+and [`artifacts/shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/shielded-settlement.tsv);
 thirteen are under the shipped program, where the criterion asks for two. Each is
 re-decoded from the chain's own copy of the transaction rather than from the
 manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
@@ -170,7 +170,7 @@ The one the video ends on:
 block 10102 — the recipient goes 107 → 108 LEZ, and no owner signs anything.
 Every row, with its before/after balances and the program that owned the ledger
 it charged, is in
-[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#the-settlements-in-full).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#the-settlements-in-full).
 
 ## Approach
 
@@ -187,7 +187,7 @@ one detected. Only the program may write that account's data (LEZ rule 6), and
 `spend` derives the address from the *paying* account out of the pre-state, so
 there is no argument to lie about. The full argument, with the refusal codes and
 the four deployments it took to get there, is in
-[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#approach-the-spending-limit-at-length).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
 
 ### What was tried and did not work, and why Logos
 
@@ -196,7 +196,7 @@ walked around by an attacker who was not lying — they really were the owner of
 the policy they anchored; they had simply never been asked whether the agent
 agreed. The full account, including the attack transaction that the superseded
 program accepted and the one today's program refuses, is in
-[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
 `./scripts/demo.sh` section 5 replays it against both programs in front of you.
 
 ## Design Write-up
@@ -205,7 +205,7 @@ The prize names seven topics. Each has a document in the repository that carries
 it at full length; what follows is the decision each one turns on, so this
 section reads in five minutes and the document is opened only where it matters.
 
-**Module architecture** — [`docs/architecture.md`](../docs/architecture.md).
+**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/architecture.md).
 A Logos Core plugin exposing three skill categories, each a thin binding onto a
 real Logos node or onto LEZ. `invoke()` is the single dispatcher every capability
 sits behind, which is what lets a second Logos app drive the owner's end without
@@ -214,23 +214,23 @@ of `std::function`s — `DeliveryPort`, `StoragePort`, `WalletPort`, `ProgramPor
 — so every skill has a test against a fake port and there is one place where a
 real node is wired.
 
-**Skill interface design** — [`docs/skills.md`](../docs/skills.md).
+**Skill interface design** — [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md).
 A skill is a class with `name()`, `parameterSchema()` and `invoke(json)`, added
 through `registerSkill` without touching the core module. Schemas are declared
 once and the Agent Card is generated from the registry rather than written by
 hand, so a card cannot advertise a skill the module does not have.
 
 **Spending threshold mechanism** — [Approach](#approach) above has the argument;
-[`docs/security-model.md`](../docs/security-model.md) has the mechanism, the
+[`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/security-model.md) has the mechanism, the
 refusal codes, and what a holder of the agent's key can and cannot do.
 
-**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](../docs/a2a-binding.md).
+**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/a2a-binding.md).
 Agent Cards follow the A2A schema, tasks follow the A2A lifecycle, and Logos
 Messaging is the transport A2A leaves open. Payment is the part A2A omits: the
 client pays the price the card advertises, signed by the agent's own shielded
 account, with no owner in the loop.
 
-**Security model** — [`docs/security-model.md`](../docs/security-model.md).
+**Security model** — [`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/security-model.md).
 Anchoring takes two signatures: the agent signs `claim_agent` to name the account
 that may bind it, and only that account is accepted by `create_policy`, which is
 `#[account(init, …)]` — so the first anchor is the only one possible, not merely
@@ -238,12 +238,12 @@ the only one detected. What is *not* closed is enumerated there too: the balance
 is held by the transfer program, so the agent's key can move it by calling that
 program directly. This program bounds what the agent moves *through it*.
 
-**Known limitations** — [`docs/limitations.md`](../docs/limitations.md), where
+**Known limitations** — [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md), where
 anything that does not work is written down first, with the retractions of claims
 that did not survive checking.
 
-**Integration instructions** — [`docs/DEPLOYMENT.md`](../docs/DEPLOYMENT.md) for
-the chain side, [`docs/basecamp.md`](../docs/basecamp.md) for loading the module
+**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/DEPLOYMENT.md) for
+the chain side, [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/basecamp.md) for loading the module
 into Logos Basecamp, including what a `.lgx` must satisfy to load at all.
 
 ## Success Criteria Checklist
@@ -254,91 +254,91 @@ Reliability 3 of 3, Performance 1 of 1, Supportability 6 of 6.
 
 Each entry gives the verdict and the one thing that re-derives it. The long form
 of every one — the controls, the transcripts, what was watched failing — is in
-[`docs/criteria-evidence.md`](../docs/criteria-evidence.md), copied there
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md), copied there
 unchanged.
 
 **Functionality**
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32040423074`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32040423074). [Evidence](../docs/criteria-evidence.md#functionality).
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32040423074`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32040423074). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
-  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](../docs/criteria-evidence.md#functionality).
+  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The owner can deploy the agent and configure it with a single CLI command on any machine using Logos Core headless.**
-  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](../docs/criteria-evidence.md#functionality).
+  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
-  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](../docs/criteria-evidence.md#functionality).
+  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
-  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](../docs/criteria-evidence.md#functionality).
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in [`docs/skills.md`](../docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](../docs/criteria-evidence.md#functionality).
+  Every skill the prize lists is registered and documented in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
-  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](../docs/a2a-binding.md). [Evidence](../docs/criteria-evidence.md#functionality).
+  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/a2a-binding.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
-  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](../docs/criteria-evidence.md#functionality).
+  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](../docs/criteria-evidence.md#functionality).
+  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
-  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](../docs/criteria-evidence.md#functionality).
+  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
-  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](../docs/criteria-evidence.md#functionality).
+  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 
 **Usability**
 
 - [x] **MET — Provide a documented skill interface (module/SDK) that can be used to add new skills without modifying the core agent module.**
-  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](../docs/skills.md); a new skill needs no change to the core module. [Evidence](../docs/criteria-evidence.md#usability).
+  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/skills.md); a new skill needs no change to the core module. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#usability).
 
 - [x] **MET — The owner-facing interface is accessible from the Logos app (Basecamp) via the owner channel — local build instructions and loadable assets are provided.**
-  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](../docs/basecamp.md). [Evidence](../docs/criteria-evidence.md#usability).
+  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/basecamp.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#usability).
 
 
 **Reliability**
 
 - [x] **MET — The agent module recovers from transient failures (network interruptions, node restarts) without losing pending task state.**
-  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](../docs/criteria-evidence.md#reliability).
+  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
 
 - [x] **MET — Above-threshold transactions that fail to reach the owner for approval are not executed — the agent retries notification before timing out and reports the failure.**
-  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](../docs/criteria-evidence.md#reliability).
+  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
 
 - [x] **MET — Skill failures are isolated: a failing skill does not crash the module or affect other concurrently running skills.**
-  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](../docs/criteria-evidence.md#reliability).
+  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#reliability).
 
 
 **Performance**
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  [`docs/benchmarks/cu-budget.md`](../docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](../docs/criteria-evidence.md#performance).
+  [`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#performance).
 
 
 **Supportability**
 
 - [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
-  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](../docs/criteria-evidence.md#supportability).
+  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  [Run `32024953786`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32024953786) — **success, 3 h 03**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](../docs/criteria-evidence.md#supportability).
+  [Run `32024953786`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32024953786) — **success, 3 h 03**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main`; the badge is not the check, `gh run list` is. [Evidence](../docs/criteria-evidence.md#supportability).
+  Green on `main`; the badge is not the check, `gh run list` is. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
-  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](../docs/criteria-evidence.md#supportability).
+  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](../docs/criteria-evidence.md#supportability).
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 - [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](../docs/criteria-evidence.md#supportability).
+  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#supportability).
 
 ## FURPS Self-Assessment
 
@@ -371,7 +371,7 @@ with it.
 ### Performance
 
 LEZ v0.2.4 does not meter compute units, and
-[`docs/benchmarks/cu-budget.md`](../docs/benchmarks/cu-budget.md) says so with the
+[`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/benchmarks/cu-budget.md) says so with the
 search that establishes it, rather than inventing a number. What is measured
 instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
 four-core runner, `create_policy` at about one block.
@@ -393,7 +393,7 @@ implies is written up in full. An inbound A2A request is not dispatched to the
 skill it names. The storage skills
 have never driven a live node from inside the module. No model has run against
 the inference port. Each is expanded in
-[`docs/limitations.md`](../docs/limitations.md).
+[`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md).
 
 ## Supporting Materials
 

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -210,7 +210,7 @@ of every entry, including the controls and what was watched failing, is in
 ### Functionality
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime; the workflow is `.github/workflows/alongside-companion-modules.yml` and the run that shows it is `32805342163`.
+  All three companions are built from their published sources and all four modules load in one runtime; the workflow is `.github/workflows/alongside-companion-modules.yml` and the run that shows it is `33087503041`, on `4d684c2`, an ancestor of the reviewed commit.
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
   *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: the payee's balance moves on chain, 107 → 108 LEZ on the settlement the video ends on.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -260,7 +260,7 @@ unchanged.
 **Functionality**
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32040423074`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32040423074). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32582715045`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32582715045), which ran on this branch's head commit `4f4ede8`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
   *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/criteria-evidence.md#functionality).

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -10,7 +10,7 @@
 > | three agents live on the public testnet, and one paying another | [Summary](#summary) and [Repository](#repository) — explorer links, not hashes to paste |
 > | that it runs from a clean clone | [The four commands](#the-four-commands-that-check-the-rest) — four lines, all exit 0 |
 > | the recorded demo, and the e2e green in CI | [Supporting Materials](#supporting-materials) and the Supportability entries in the [checklist](#success-criteria-checklist) |
-> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md) |
+> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`][limitations-md] |
 
 ## Summary
 
@@ -60,7 +60,7 @@ block 9477. Every hash, block and balance is in
 success criteria are now met, the last of them — the recorded video demo — by
 one narrated walkthrough published with this submission. That is not a claim
 that nothing is missing. Disclosed at the same volume as everything else, and
-expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md):
+expanded in [`docs/limitations.md`][limitations-md]:
 
 - the **three agents published here** can never have an above-threshold spend
   approved: their owners anchored while their accounts were still unclaimed, and
@@ -88,12 +88,12 @@ expanded in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomou
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module>
-- **Reviewed commit:** [`708b2ce`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/708b2cea8401ef3a2a179baf4d2aabeddefac59f).
+- **Reviewed commit:** [`e1c57ba`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/e1c57bab5c12f783429debd735579002e2d3fcb1).
   Every repository link below names that commit rather than `main`, so the
   version under review cannot move after this is opened.
 - **CI on that exact commit:**
-  [the host suite](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505542)
-  and [the full lifecycle against a standalone LEZ sequencer](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555),
+  [the host suite](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726730085)
+  and [the full lifecycle against a standalone LEZ sequencer](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726759802),
   both green.
 - **License:** dual MIT / Apache-2.0 (both full texts committed)
 - **Default branch:** `main`
@@ -160,13 +160,13 @@ The three agents, their limits and the `create_policy` that anchored each are in
 the table under [Summary](#summary), every hash a link to the block explorer.
 Their claim transactions, policy-account addresses, owner ids and the byte-level
 record layout are in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
 and re-read from the chain by `./scripts/verify-deployment.sh`.
 
 #### The settlements
 
-Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/a2a-task.tsv)
-and [`artifacts/shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/shielded-settlement.tsv);
+Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`][a2a-task-tsv]
+and [`artifacts/shielded-settlement.tsv`][shielded-settlement-tsv];
 thirteen are under the shipped program, where the criterion asks for two. Each is
 re-decoded from the chain's own copy of the transaction rather than from the
 manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
@@ -177,7 +177,7 @@ The one the video ends on:
 block 10102 — the recipient goes 107 → 108 LEZ, and no owner signs anything.
 Every row, with its before/after balances and the program that owned the ledger
 it charged, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#the-settlements-in-full).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#the-settlements-in-full).
 
 ## Approach
 
@@ -194,7 +194,7 @@ one detected. Only the program may write that account's data (LEZ rule 6), and
 `spend` derives the address from the *paying* account out of the pre-state, so
 there is no argument to lie about. The full argument, with the refusal codes and
 the four deployments it took to get there, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
 
 ### What was tried and did not work, and why Logos
 
@@ -203,7 +203,7 @@ walked around by an attacker who was not lying — they really were the owner of
 the policy they anchored; they had simply never been asked whether the agent
 agreed. The full account, including the attack transaction that the superseded
 program accepted and the one today's program refuses, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
 `./scripts/demo.sh` section 5 replays it against both programs in front of you.
 
 ## Design Write-up
@@ -212,7 +212,7 @@ The prize names seven topics. Each has a document in the repository that carries
 it at full length; what follows is the decision each one turns on, so this
 section reads in five minutes and the document is opened only where it matters.
 
-**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/architecture.md).
+**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/architecture.md).
 A Logos Core plugin exposing three skill categories, each a thin binding onto a
 real Logos node or onto LEZ. `invoke()` is the single dispatcher every capability
 sits behind, which is what lets a second Logos app drive the owner's end without
@@ -221,23 +221,23 @@ of `std::function`s — `DeliveryPort`, `StoragePort`, `WalletPort`, `ProgramPor
 — so every skill has a test against a fake port and there is one place where a
 real node is wired.
 
-**Skill interface design** — [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md).
+**Skill interface design** — [`docs/skills.md`][skills-md].
 A skill is a class with `name()`, `parameterSchema()` and `invoke(json)`, added
 through `registerSkill` without touching the core module. Schemas are declared
 once and the Agent Card is generated from the registry rather than written by
 hand, so a card cannot advertise a skill the module does not have.
 
 **Spending threshold mechanism** — [Approach](#approach) above has the argument;
-[`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/security-model.md) has the mechanism, the
+[`docs/security-model.md`][security-model-md] has the mechanism, the
 refusal codes, and what a holder of the agent's key can and cannot do.
 
-**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/a2a-binding.md).
+**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`][a2a-binding-md].
 Agent Cards follow the A2A schema, tasks follow the A2A lifecycle, and Logos
 Messaging is the transport A2A leaves open. Payment is the part A2A omits: the
 client pays the price the card advertises, signed by the agent's own shielded
 account, with no owner in the loop.
 
-**Security model** — [`docs/security-model.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/security-model.md).
+**Security model** — [`docs/security-model.md`][security-model-md].
 Anchoring takes two signatures: the agent signs `claim_agent` to name the account
 that may bind it, and only that account is accepted by `create_policy`, which is
 `#[account(init, …)]` — so the first anchor is the only one possible, not merely
@@ -245,12 +245,12 @@ the only one detected. What is *not* closed is enumerated there too: the balance
 is held by the transfer program, so the agent's key can move it by calling that
 program directly. This program bounds what the agent moves *through it*.
 
-**Known limitations** — [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md), where
+**Known limitations** — [`docs/limitations.md`][limitations-md], where
 anything that does not work is written down first, with the retractions of claims
 that did not survive checking.
 
-**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/DEPLOYMENT.md) for
-the chain side, [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/basecamp.md) for loading the module
+**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/DEPLOYMENT.md) for
+the chain side, [`docs/basecamp.md`][basecamp-md] for loading the module
 into Logos Basecamp, including what a `.lgx` must satisfy to load at all.
 
 ## Success Criteria Checklist
@@ -261,91 +261,91 @@ Reliability 3 of 3, Performance 1 of 1, Supportability 6 of 6.
 
 Each entry gives the verdict and the one thing that re-derives it. The long form
 of every one — the controls, the transcripts, what was watched failing — is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md), copied there
+[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md), copied there
 unchanged.
 
 **Functionality**
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32679505073`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32679505073), which ran on the reviewed commit. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32726762720`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726762720), which ran on the reviewed commit. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
-  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — The owner can deploy the agent and configure it with a single CLI command on any machine using Logos Core headless.**
-  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
-  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
-  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Every skill the prize lists is registered and documented in [`docs/skills.md`][skills-md], and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
-  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/a2a-binding.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`][a2a-binding-md]. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
-  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
-  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence][criteria-evidence-md-functionality].
 
 - [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
-  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence][criteria-evidence-md-functionality].
 
 
 **Usability**
 
 - [x] **MET — Provide a documented skill interface (module/SDK) that can be used to add new skills without modifying the core agent module.**
-  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/skills.md); a new skill needs no change to the core module. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#usability).
+  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`][skills-md]; a new skill needs no change to the core module. [Evidence][criteria-evidence-md-usability].
 
 - [x] **MET — The owner-facing interface is accessible from the Logos app (Basecamp) via the owner channel — local build instructions and loadable assets are provided.**
-  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/basecamp.md). [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#usability).
+  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`][basecamp-md]. [Evidence][criteria-evidence-md-usability].
 
 
 **Reliability**
 
 - [x] **MET — The agent module recovers from transient failures (network interruptions, node restarts) without losing pending task state.**
-  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
+  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence][criteria-evidence-md-reliability].
 
 - [x] **MET — Above-threshold transactions that fail to reach the owner for approval are not executed — the agent retries notification before timing out and reports the failure.**
-  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
+  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence][criteria-evidence-md-reliability].
 
 - [x] **MET — Skill failures are isolated: a failing skill does not crash the module or affect other concurrently running skills.**
-  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#reliability).
+  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence][criteria-evidence-md-reliability].
 
 
 **Performance**
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  [`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#performance).
+  [`docs/benchmarks/cu-budget.md`][cu-budget-md], which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#performance).
 
 
 **Supportability**
 
 - [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
-  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence][criteria-evidence-md-supportability].
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  [Run `32669505555`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555) — **success, 3 h 06, on the reviewed commit**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  [Run `32726759802`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726759802) — **success, 3 h 18, on the reviewed commit**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. The same lifecycle also ran green in 3 h 06 as [run `32669505555`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555) on [`708b2ce`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/708b2cea8401ef3a2a179baf4d2aabeddefac59f): `git diff 708b2ce..e1c57ba` touches only `docs/recording-evidence.md`, `recordings/lp8-demo.srt` and `scripts/check-transcript.py`, so both runs drove an identical script against identical binaries. Two independent measurements, not one. [Evidence][criteria-evidence-md-supportability].
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main`, and on the reviewed commit specifically: [run `32669505542`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505542). The badge is not the check, a run id is. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  Green on `main`, and on the reviewed commit specifically: [run `32726730085`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726730085). The badge is not the check, a run id is. [Evidence][criteria-evidence-md-supportability].
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
-  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence][criteria-evidence-md-supportability].
 
 - [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence][criteria-evidence-md-supportability].
 
 - [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#supportability).
+  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence][criteria-evidence-md-supportability].
 
 ## FURPS Self-Assessment
 
@@ -378,7 +378,7 @@ with it.
 ### Performance
 
 LEZ v0.2.4 does not meter compute units, and
-[`docs/benchmarks/cu-budget.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/benchmarks/cu-budget.md) says so with the
+[`docs/benchmarks/cu-budget.md`][cu-budget-md] says so with the
 search that establishes it, rather than inventing a number. What is measured
 instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
 four-core runner, `create_policy` at about one block.
@@ -400,7 +400,7 @@ implies is written up in full. An inbound A2A request is not dispatched to the
 skill it names. The storage skills
 have never driven a live node from inside the module. No model has run against
 the inference port. Each is expanded in
-[`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md).
+[`docs/limitations.md`][limitations-md].
 
 ## Supporting Materials
 
@@ -412,6 +412,24 @@ the inference port. Each is expanded in
   evidence does not depend on a third party keeping it up.
   `./scripts/check-video.py` reads the terminal text off the pixels and asserts
   all of that rather than describing it.
+- **The demo as text, and a check that it is this film's:**
+  [`recordings/lp8-demo.srt`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/recordings/lp8-demo.srt) — 298 cues, 2,784
+  words, the narration as spoken, so twenty-two minutes can be read and grepped
+  instead of watched. `./scripts/check-transcript.py` ties it to the film: cues
+  ordered and non-overlapping, the last landing inside the film rather than 577 s
+  short of it, and four anchors requiring the picture to show what the narration
+  is talking about at the second it says it — where the line is "that percentage
+  is r0vm", the frame there must show the prover's output. The narration is
+  spoken and never on screen, so those anchors are the part a plausible file
+  written from memory could not satisfy. It refuses to pass on structure alone:
+  a transcript with no anchors defined is rejected, and fewer than two tested
+  anchors is a failure — a rule that exists because the first version of this
+  check reported "anchor not testable" four times and then printed "transcript
+  matches the film". Mutation-tested three ways, all caught.
+  [`docs/recording-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/recording-evidence.md) carries both
+  checks' measured output and ends with what they do **not** establish: not every
+  frame, not the wording against the audio, and one OCR behaviour routed around
+  rather than diagnosed.
 - **Reproduce from a clean clone, no keys and no funds:** `./scripts/demo.sh` ·
   `./scripts/verify-deployment.sh` · `./scripts/check-docs.py`
 - **Reproduce the deployment and the settlements** (needs a funded testnet
@@ -420,16 +438,29 @@ the inference port. Each is expanded in
 - **On-chain evidence:** every hash, block and explorer link is in
   [Repository](#repository), generated rather than transcribed, and deliberately
   not repeated here. Manifests, read **by column name**:
-  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/agents.tsv) ·
-  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/anchored.tsv) ·
-  [`a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/a2a-task.tsv) ·
-  [`shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/shielded-settlement.tsv)
-- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs) — architecture, skills,
+  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/agents.tsv) ·
+  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/anchored.tsv) ·
+  [`a2a-task.tsv`][a2a-task-tsv] ·
+  [`shielded-settlement.tsv`][shielded-settlement-tsv]
+- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/e1c57bab5c12f783429debd735579002e2d3fcb1/docs) — architecture, skills,
   security model, A2A binding, deployment, Basecamp loading, CU budget, and
-  [`limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md), which is where anything
+  [`limitations.md`][limitations-md], which is where anything
   that does not work is written down first.
 
 ## Terms & Conditions
 
 By submitting this solution, I confirm that I have read and agree to the
 [Terms & Conditions](../TERMS.md).
+
+[a2a-binding-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/a2a-binding.md
+[a2a-task-tsv]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/a2a-task.tsv
+[basecamp-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/basecamp.md
+[criteria-evidence-md-functionality]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#functionality
+[criteria-evidence-md-reliability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#reliability
+[criteria-evidence-md-supportability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#supportability
+[criteria-evidence-md-usability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#usability
+[cu-budget-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/benchmarks/cu-budget.md
+[limitations-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/limitations.md
+[security-model-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/security-model.md
+[shielded-settlement-tsv]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/shielded-settlement.tsv
+[skills-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/skills.md

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -93,7 +93,7 @@ a fresh clone of the public repository, not intended.
 $ ./scripts/demo.sh                                            # exit 0
 $ ./scripts/verify-deployment.sh                               # exit 0
 $ ./scripts/check-docs.py                                      # exit 0
-$ ./scripts/submission-evidence.py --check SUBMISSION-DRAFT.md # exit 0
+$ ./scripts/submission-evidence.py                             # exit 0
 ```
 
 **`./scripts/demo.sh` needs no key, no funded account and no local sequencer** —
@@ -111,9 +111,12 @@ Every figure here is fetched by `./scripts/submission-evidence.py` from the
 committed binary and from `https://testnet.lez.logos.co`. It derives the deploy
 transaction from the committed bytes rather than quoting it, reads the manifests by
 column name, confirms every transaction it cites is inside the block it names and
-absent from **both** neighbours, and exits non-zero otherwise. `--check` re-runs
-the comparison without writing, so a stale copy cannot be produced. CI runs it on
-every push.
+absent from **both** neighbours, and exits non-zero otherwise. `--check FILE` re-runs
+the comparison against a document without writing, so a stale copy cannot be
+produced — its target is the submission draft, which is deliberately kept outside
+this repository rather than as a hundred and fifty kilobytes of working text at
+the top of a public tree, so the command above generates instead. CI runs both on
+every push, and requires a drifted copy to be rejected.
 
 The deployed program is `697746f5…cb5370bf`. A LEZ deploy hash is
 `SHA256(u32_le(len) ‖ bytecode)`, so `artifacts/programs/agent_verifier.bin` **is**

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -257,10 +257,10 @@ transcripts, what was watched failing — is in `docs/criteria-evidence.md`.
   Deployed at `697746f5…cb5370bf`; `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path, run `32726759802`.
+  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `32814477623` on the reviewed commit, 3 h 29, of which 58 minutes are real `claim_agent` proving.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically, run `32726730085`.
+  Green on `main` and on the reviewed commit specifically, run `32769238263`.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -1,0 +1,428 @@
+# Solution: LP-0008 — Autonomous AI Module with Wallet, Storage, and Messaging
+
+**Submitted by:** edenbd1
+
+> **Where to find what.** Every claim below carries the command that re-derives
+> it; the long form of each is in the repository, linked.
+>
+> | To check | Go to |
+> |---|---|
+> | three agents live on the public testnet, and one paying another | [Summary](#summary) and [Repository](#repository) — explorer links, not hashes to paste |
+> | that it runs from a clean clone | [The four commands](#the-four-commands-that-check-the-rest) — four lines, all exit 0 |
+> | the recorded demo, and the e2e green in CI | [Supporting Materials](#supporting-materials) and the Supportability entries in the [checklist](#success-criteria-checklist) |
+> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`](../docs/limitations.md) |
+
+## Summary
+
+An agent that participates in the Logos stack directly rather than through an API
+key: it holds its own shielded LEZ account, and the ceiling on what it may spend
+is not a check inside the agent process but **state on chain that the agent's own
+program is the only thing permitted to write**.
+
+The core idea is one design decision. An agent runs unattended on a remote node
+and holds its own signing key, so any spending rule the agent evaluates can be
+evaluated differently by whoever holds the process. So the rule is not evaluated
+by the agent at all. Each agent has exactly one policy account, at
+`PDA(program, "agent-policy/v1", agent_id)` — the program and the agent, and
+nothing else — and the owner, both limits, the period and the running total live
+in that account's data, which LEZ rule 6 (`UnauthorizedDataModification`) lets
+only this program write. Anchoring one takes two signatures: the agent signs
+`claim_agent` to name the account that may bind it, and only that account's
+signature is accepted by `create_policy`. `create_policy` is
+`#[account(init, …)]`, so the first anchor for an agent is the only anchor for
+that agent — a second is not *detected*, it is impossible. `spend` derives the
+same address from the *paying* account's id out of the pre-state, so there is no
+argument to lie about, and it reads the limits off the account rather than from
+the call.
+
+**Three agents are anchored and live on the public LEZ testnet**, one per default
+skill category, each with its own shielded account and its own spending envelope:
+
+| category | agent id | policy account | per-tx | per-period | `create_policy` on chain |
+|---|---|---|---|---|---|
+| storage | `9XpkkvosC14TKTNZAoUdKXJwCheJ3dF8u3Xoojfv1FaE` | `6FscNXjNhamSCTbzLe67gU3noFHkQKDjRmD4tNj3ipSe` | 50 | 500 | [`6857ba23…631fe7d4`](https://explorer.testnet.lez.logos.co/transaction/6857ba2378a84ba51618582e852e3827a872e3ea85f17de76bdb45b1631fe7d4), block 8868 |
+| messaging | `GpRdooEWJjX4JmRyT2n5KzMnDKtCM2HrvZ8iwMZpe5FS` | `7HH46tXhgfrMSSzWwpNrjkqujCB9EGA5cEvnYK1dA7bp` | 25 | 250 | [`ce557a0a…278e1918`](https://explorer.testnet.lez.logos.co/transaction/ce557a0a8adc517b60496c35514e269fff92a4393b90bef41ce10916278e1918), block 8876 |
+| blockchain | `A7UBoMbSoQXNaDTiSjbr28KjedNrvBvroiamrc39JtMu` | `2RK4dPwzDTAdgjUGpGsCkok962StYpPV14QpW3Wusvc9` | 200 | 1,000 | [`2f6b481c…ecec5eda`](https://explorer.testnet.lez.logos.co/transaction/2f6b481cffde2adaeed9442c19599c939d97da0c930b70b45d97ac34ecec5eda), block 8884 |
+
+They have **paid each other for priced skills, unattended**, with the per-period
+total accumulating on chain: sixteen settlements in all, of which **thirteen are
+under the program this repository ships** — the messaging agent paying the
+storage agent seven times, the storage agent paying the blockchain agent four
+times, the blockchain agent paying the storage agent once, and one paid to a
+shielded payee. One of those payments was made **by a module a host loaded**, in the same
+call that discovered the payee's signed Agent Card and opened the A2A task:
+settlement
+[`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3),
+block 9477. Every hash, block and balance is in
+[Repository](#repository) below, generated from the chain rather than typed.
+
+**What is not delivered is stated plainly.** All twenty-three of the prize's
+success criteria are now met, the last of them — the recorded video demo — by
+one narrated walkthrough published with this submission. That is not a claim
+that nothing is missing. Disclosed at the same volume as everything else, and
+expanded in [`docs/limitations.md`](../docs/limitations.md):
+
+- the **three agents published here** can never have an above-threshold spend
+  approved: their owners anchored while their accounts were still unclaimed, and
+  such an account is filtered out of every later post-state. That is
+  irreversible for those three. It is not a property of the chain — an owner
+  claimed before it anchors signs indefinitely, and the whole path ran on the
+  public testnet ([`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8)
+  block 10776, [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597)
+  block 10786, payee 4 → 6) against a fourth agent provisioned for it;
+- the storage skills **have** driven a live node from inside the module — the
+  module `dlopen`s `libstorage` and opens its own node on
+  `meta.configure("storage","on")`, and `./scripts/skills-live.sh` calls all four
+  through `invoke()` from an empty `SkillPorts`. What is missing is the evidence
+  discipline the other node runs have: no transcript is committed for it and no
+  CI job runs it, unlike `artifacts/e2e/exercise-nodes.txt`;
+- an inbound A2A task request is not automatically dispatched to the skill it
+  names. That is about inbound auto-serving, not about skill dispatch, which the
+  module has and the prize puts in scope: `invoke()` is the single dispatcher
+  every capability sits behind;
+- no model has run against the inference port. The prize puts the choice of model
+  **out of scope** and asks only that inference be pluggable, which it is — a
+  local and an HTTP backend behind one port — but neither has served a real
+  request here.
+
+## Repository
+
+- **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module>
+- **License:** dual MIT / Apache-2.0 (both full texts committed)
+- **Default branch:** `main`
+
+Everything here is verifiable from a clean clone plus the public sequencer. No
+claim depends on trusting the author.
+
+### The four commands that check the rest
+
+Run from a clean clone against the tip of `main`. These exit codes were observed
+on a fresh clone of the public repository, not intended.
+
+```console
+$ ./scripts/demo.sh                                            # exit 0
+$ ./scripts/verify-deployment.sh                               # exit 0
+$ ./scripts/check-docs.py                                      # exit 0
+$ ./scripts/submission-evidence.py --check SUBMISSION-DRAFT.md # exit 0
+```
+
+**`./scripts/demo.sh` needs no key, no funded account and no local sequencer** —
+only a Rust toolchain, `python3` and `curl`, and it names any of them that are
+missing before it runs anything. It runs the policy tests, recomputes the
+deployed program's hash from the committed binary, asks the public sequencer
+whether that transaction exists, asks the same sequencer about a hash that
+*cannot* exist, and replays the adversarial attack against both the superseded
+program and the shipped one. Without the null control the first question would
+prove nothing: an RPC that answered non-null to everything would pass it just as
+happily. Thirteen checks print `OK`, none prints `FAIL`, and it closes on
+
+```
+OK   the committed program refuses each attack, with the documented code
+
+demo complete — every claim above was computed or fetched here, not asserted.
+```
+
+### Evidence on the public testnet, generated rather than typed
+
+**The three tables below are reproduced from the output of
+`./scripts/submission-evidence.py`.** That script fetches every figure from the
+committed binary and from `https://testnet.lez.logos.co`, derives the deploy
+transaction from the committed bytes rather than quoting it, reads the manifests
+by column name, confirms every transaction it cites is inside the block it names
+and absent from **both** neighbours, and exits non-zero if any of that fails.
+`--check` re-runs the comparison against a document without writing, so a stale
+copy cannot be produced. It runs in CI on every push. Regenerate them yourself:
+
+```console
+$ ./scripts/submission-evidence.py
+```
+
+Nothing in these tables was transcribed by hand. Where a fact moves — CI state,
+a period's running total — this document gives the command to ask rather than a
+number.
+
+#### The program, and the three agents
+
+The deployed program is
+[`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf).
+A LEZ deploy hash is `SHA256(u32_le(len) || bytecode)`, so
+`artifacts/programs/agent_verifier.bin` **is** its own deploy transaction —
+recompute it and compare, which `./scripts/demo.sh` does in front of you.
+
+The three agents, their limits and the `create_policy` that anchored each are in
+the table under [Summary](#summary), every hash a link to the block explorer.
+Their claim transactions, policy-account addresses, owner ids and the byte-level
+record layout are in
+[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
+and re-read from the chain by `./scripts/verify-deployment.sh`.
+
+#### The settlements
+
+Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`](../artifacts/a2a-task.tsv)
+and [`artifacts/shielded-settlement.tsv`](../artifacts/shielded-settlement.tsv);
+thirteen are under the shipped program, where the criterion asks for two. Each is
+re-decoded from the chain's own copy of the transaction rather than from the
+manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
+redeploy orphaned instead of counting them.
+
+The one the video ends on:
+[`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115),
+block 10102 — the recipient goes 107 → 108 LEZ, and no owner signs anything.
+Every row, with its before/after balances and the program that owned the ledger
+it charged, is in
+[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#the-settlements-in-full).
+
+## Approach
+
+### The spending limit is an account, not an `if`
+
+A limit enforced inside the agent is enforced by whoever controls the agent's
+process — which, for an agent on a remote node holding its own key, is not
+necessarily the owner. So it is moved out of the process entirely.
+
+`create_policy` initialises exactly one account per agent, at
+`PDA(program, "agent-policy/v1", agent_id)`, and it is `#[account(init, …)]`:
+the first anchor for an agent is the only anchor possible, not merely the only
+one detected. Only the program may write that account's data (LEZ rule 6), and
+`spend` derives the address from the *paying* account out of the pre-state, so
+there is no argument to lie about. The full argument, with the refusal codes and
+the four deployments it took to get there, is in
+[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#approach-the-spending-limit-at-length).
+
+### What was tried and did not work, and why Logos
+
+Four deployments were needed to get the anchoring right, and each earlier one was
+walked around by an attacker who was not lying — they really were the owner of
+the policy they anchored; they had simply never been asked whether the agent
+agreed. The full account, including the attack transaction that the superseded
+program accepted and the one today's program refuses, is in
+[`docs/criteria-evidence.md`](../docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
+`./scripts/demo.sh` section 5 replays it against both programs in front of you.
+
+## Design Write-up
+
+The prize names seven topics. Each has a document in the repository that carries
+it at full length; what follows is the decision each one turns on, so this
+section reads in five minutes and the document is opened only where it matters.
+
+**Module architecture** — [`docs/architecture.md`](../docs/architecture.md).
+A Logos Core plugin exposing three skill categories, each a thin binding onto a
+real Logos node or onto LEZ. `invoke()` is the single dispatcher every capability
+sits behind, which is what lets a second Logos app drive the owner's end without
+the module exporting anything else. No skill links a library: each takes a struct
+of `std::function`s — `DeliveryPort`, `StoragePort`, `WalletPort`, `ProgramPort`
+— so every skill has a test against a fake port and there is one place where a
+real node is wired.
+
+**Skill interface design** — [`docs/skills.md`](../docs/skills.md).
+A skill is a class with `name()`, `parameterSchema()` and `invoke(json)`, added
+through `registerSkill` without touching the core module. Schemas are declared
+once and the Agent Card is generated from the registry rather than written by
+hand, so a card cannot advertise a skill the module does not have.
+
+**Spending threshold mechanism** — [Approach](#approach) above has the argument;
+[`docs/security-model.md`](../docs/security-model.md) has the mechanism, the
+refusal codes, and what a holder of the agent's key can and cannot do.
+
+**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`](../docs/a2a-binding.md).
+Agent Cards follow the A2A schema, tasks follow the A2A lifecycle, and Logos
+Messaging is the transport A2A leaves open. Payment is the part A2A omits: the
+client pays the price the card advertises, signed by the agent's own shielded
+account, with no owner in the loop.
+
+**Security model** — [`docs/security-model.md`](../docs/security-model.md).
+Anchoring takes two signatures: the agent signs `claim_agent` to name the account
+that may bind it, and only that account is accepted by `create_policy`, which is
+`#[account(init, …)]` — so the first anchor is the only one possible, not merely
+the only one detected. What is *not* closed is enumerated there too: the balance
+is held by the transfer program, so the agent's key can move it by calling that
+program directly. This program bounds what the agent moves *through it*.
+
+**Known limitations** — [`docs/limitations.md`](../docs/limitations.md), where
+anything that does not work is written down first, with the retractions of claims
+that did not survive checking.
+
+**Integration instructions** — [`docs/DEPLOYMENT.md`](../docs/DEPLOYMENT.md) for
+the chain side, [`docs/basecamp.md`](../docs/basecamp.md) for loading the module
+into Logos Basecamp, including what a `.lgx` must satisfy to load at all.
+
+## Success Criteria Checklist
+
+Twenty-three criteria, mirrored from the prize in its own order and its own
+words. **Tally: 23 MET, 0 UNMET** — Functionality 11 of 11, Usability 2 of 2,
+Reliability 3 of 3, Performance 1 of 1, Supportability 6 of 6.
+
+Each entry gives the verdict and the one thing that re-derives it. The long form
+of every one — the controls, the transcripts, what was watched failing — is in
+[`docs/criteria-evidence.md`](../docs/criteria-evidence.md), copied there
+unchanged.
+
+**Functionality**
+
+- [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32040423074`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32040423074). [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
+  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — The owner can deploy the agent and configure it with a single CLI command on any machine using Logos Core headless.**
+  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
+  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — All default skills listed above are implemented and documented.**
+  Every skill the prize lists is registered and documented in [`docs/skills.md`](../docs/skills.md), and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
+  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`](../docs/a2a-binding.md). [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
+  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
+  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
+  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence](../docs/criteria-evidence.md#functionality).
+
+- [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
+  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence](../docs/criteria-evidence.md#functionality).
+
+
+**Usability**
+
+- [x] **MET — Provide a documented skill interface (module/SDK) that can be used to add new skills without modifying the core agent module.**
+  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`](../docs/skills.md); a new skill needs no change to the core module. [Evidence](../docs/criteria-evidence.md#usability).
+
+- [x] **MET — The owner-facing interface is accessible from the Logos app (Basecamp) via the owner channel — local build instructions and loadable assets are provided.**
+  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`](../docs/basecamp.md). [Evidence](../docs/criteria-evidence.md#usability).
+
+
+**Reliability**
+
+- [x] **MET — The agent module recovers from transient failures (network interruptions, node restarts) without losing pending task state.**
+  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence](../docs/criteria-evidence.md#reliability).
+
+- [x] **MET — Above-threshold transactions that fail to reach the owner for approval are not executed — the agent retries notification before timing out and reports the failure.**
+  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence](../docs/criteria-evidence.md#reliability).
+
+- [x] **MET — Skill failures are isolated: a failing skill does not crash the module or affect other concurrently running skills.**
+  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence](../docs/criteria-evidence.md#reliability).
+
+
+**Performance**
+
+- [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
+  [`docs/benchmarks/cu-budget.md`](../docs/benchmarks/cu-budget.md), which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](../docs/criteria-evidence.md#performance).
+
+
+**Supportability**
+
+- [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
+  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence](../docs/criteria-evidence.md#supportability).
+
+- [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
+  [Run `32024953786`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32024953786) — **success, 3 h 03**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. [Evidence](../docs/criteria-evidence.md#supportability).
+
+- [x] **MET — CI must be green on the default branch.**
+  Green on `main`; the badge is not the check, `gh run list` is. [Evidence](../docs/criteria-evidence.md#supportability).
+
+- [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
+  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence](../docs/criteria-evidence.md#supportability).
+
+- [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence](../docs/criteria-evidence.md#supportability).
+
+- [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
+  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence](../docs/criteria-evidence.md#supportability).
+
+## FURPS Self-Assessment
+
+### Functionality
+
+The agent holds a shielded LEZ account, signs its own
+transactions, and spends under a ceiling the chain keeps in state only its own
+program may write. It can also be *paid* at that account, by the keys its signed
+card publishes rather than by an id, so a settlement can hide both ends. Every
+default skill is implemented and registered, and the registry is asserted against
+the loaded binary rather than the source, because this repository has shipped
+skills that were implemented, documented and unreachable. A2A discovery, the task
+lifecycle and settlement are one call rather than three.
+
+### Usability
+
+A new skill is a class with three methods and a `registerSkill`
+call; the core module is not touched. The owner's end is three registered skills
+behind `invoke()`, which is why a second Logos app can drive it with nothing else
+exported. One command deploys and configures.
+
+### Reliability
+
+Pending task state survives the module being destroyed and
+rebuilt over the same directory. An above-threshold payment whose approval never
+reaches the owner is not executed — it retries, times out and reports. A skill
+that throws is caught, named, and does not take the module or a concurrent skill
+with it.
+
+### Performance
+
+LEZ v0.2.4 does not meter compute units, and
+[`docs/benchmarks/cu-budget.md`](../docs/benchmarks/cu-budget.md) says so with the
+search that establishes it, rather than inventing a number. What is measured
+instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
+four-core runner, `create_policy` at about one block.
+
+### Supportability
+
+Ten jobs on every push, an end-to-end run against a real
+standalone sequencer with `RISC0_DEV_MODE=0` and no skip path, and gates that
+hold the documents to the code — `check-docs.py` resolves every path and citation
+across fifteen documents, `check-package-fresh.py` refuses a package whose binary
+has lost a source literal, `write-program-record.py` refuses a source that has
+moved under the deployed program.
+
+**What is weakest, stated here rather than found later.** The three agents
+published here can never have an above-threshold spend approved — their owners
+anchored while unclaimed, which is irreversible for them; the path itself works
+and has run on chain against a fourth agent, and the ordering requirement it
+implies is written up in full. An inbound A2A request is not dispatched to the
+skill it names. The storage skills
+have never driven a live node from inside the module. No model has run against
+the inference port. Each is expanded in
+[`docs/limitations.md`](../docs/limitations.md).
+
+## Supporting Materials
+
+- **Video demo:** **<https://youtu.be/5HF0xv6GX64>** — one narrated walkthrough, 21 m 57 s,
+  four illustrative use cases, against the public testnet at
+  `https://testnet.lez.logos.co` and never a localnet, with `RISC0_DEV_MODE=0`
+  legible throughout the proving output. The same file is a release asset of this
+  repository, [`lp8-demo.mp4`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/releases/download/demo-v1/lp8-demo.mp4), so the
+  evidence does not depend on a third party keeping it up.
+  `./scripts/check-video.py` reads the terminal text off the pixels and asserts
+  all of that rather than describing it.
+- **Reproduce from a clean clone, no keys and no funds:** `./scripts/demo.sh` ·
+  `./scripts/verify-deployment.sh` · `./scripts/check-docs.py`
+- **Reproduce the deployment and the settlements** (needs a funded testnet
+  signer): `./scripts/deploy-agents.sh` · `./scripts/a2a-task.sh` ·
+  `./scripts/e2e-local-sequencer.sh` · `./scripts/delivery-in-plugin.sh settle`
+- **On-chain evidence:** every hash, block and explorer link is in
+  [Repository](#repository), generated rather than transcribed, and deliberately
+  not repeated here. Manifests, read **by column name**:
+  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/agents.tsv) ·
+  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/anchored.tsv) ·
+  [`a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/a2a-task.tsv) ·
+  [`shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/artifacts/shielded-settlement.tsv)
+- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/main/docs) — architecture, skills,
+  security model, A2A binding, deployment, Basecamp loading, CU budget, and
+  [`limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/main/docs/limitations.md), which is where anything
+  that does not work is written down first.
+
+## Terms & Conditions
+
+By submitting this solution, I confirm that I have read and agree to the
+[Terms & Conditions](../TERMS.md).

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -49,7 +49,11 @@ Expanded in `docs/limitations.md`:
   for those three. It is not a property of the chain — an owner claimed before it
   anchors signs indefinitely, and the whole path ran on the public testnet
   (`approve_spend` block 10776, `spend_approved` block 10786, payee 4 → 6) against
-  a fourth agent provisioned for it;
+  a fourth agent provisioned for it. **The same freeze takes `update_policy` with
+  them**: a limit on those three cannot be lowered, raised or zeroed, so the brake
+  `docs/security-model.md` describes is a property of the program that these three
+  deployments cannot reach. All three read `nonce: 1` with the default program
+  owner today — check them yourself with `getAccount`;
 - the storage skills **have** driven a live node from inside the module — it
   `dlopen`s `libstorage` and opens its own node on `meta.configure("storage","on")`
   — but without the evidence discipline the other node runs have: no committed
@@ -61,24 +65,12 @@ Expanded in `docs/limitations.md`:
   **out of scope** and asks only that inference be pluggable, which it is — a
   local and an HTTP backend behind one port — but neither has served a real
   request;
-- **`messaging.join` subscribes to the discovery topic, not the group's own.**
-  `module/src/messaging_skills.cpp:176` passes `discoveryTopic(group)` where
-  `module/src/delivery_runtime.cpp:695` opens `groupTopic(channelId)`, so the skill
-  returns `{"ok":true}` and joins the wrong topic. The prize defines it as "joins a
-  Logos Messaging group topic", so that criterion is met in shape and not in
-  substance. The source fix is one line and it is written; it is not
-  shipped, because `module/agent.lgx` carries compiled plugins for three
-  architectures — `darwin-arm64`, `linux-amd64` and `linux-arm64` — and
-  `check-package-fresh.py` correctly refuses a package whose source has moved under
-  it. Shipping the source change without rebuilding all three would make the tree
-  claim a behaviour the shipped module does not have, which is worse than the bug.
-  `docs/limitations.md` carries the whole of it, including the line numbers.
 
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
 - **Reviewed commit:**
-  [`9faf9b7`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/9faf9b76fa9d8c20daa9a3b118dc4948da7b63af).
+  [`d157b47`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/d157b4748f10f3148667ec39b04091af1e7c3cf5).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -89,11 +81,9 @@ Expanded in `docs/limitations.md`:
   a balance `0 → 50` and one above the ceiling refused with `Program error 6005`)
   all ran on `1956340`. The run that loads this module in one Logos Core runtime
   alongside the wallet, storage and messaging modules ran on `4d684c2`
-  (`33087503041`). Both are ancestors of the reviewed commit, and everything
-  between them and it is documentation — run
-  `git diff 4d684c2 <reviewed commit> --stat` for the list rather than taking that
-  from here. No program, no workflow, no script and no artefact the chain sees is
-  in it. Beside them run gates that
+  (`33087503041`). Both are ancestors of the reviewed commit; run
+  `git diff 4d684c2 <reviewed commit> --stat` for what lies between rather than
+  taking a distance from here. Beside them run gates that
   hold the documents to the code: every quoted path and link must resolve, every
   cited CI run must be on a commit this branch has, every explorer link must
   resolve against the chain it names, the README's stated test count must be what
@@ -235,7 +225,7 @@ of every entry, including the controls and what was watched failing, is in
   Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain: [`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8) at block 10776 and [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597) at block 10786, the payee going 4 → 6.
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. **With one qualification, stated here rather than left for a reviewer to find:** `messaging.join` is registered, documented and reachable, and it subscribes to the discovery topic instead of the group's own, so it does not do what the prize's wording asks. `docs/limitations.md` gives the two lines and why they are not applied.
+  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. `messaging.join` subscribes the topic `messaging.create_group` opens, and a unit test asserts the two meet — it did not until recently, and `docs/limitations.md` keeps the whole record of that, including the assumption that kept it open longer than its cause: rebuilding the three-architecture package was believed impossible here and was not.
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
   Cards follow the A2A schema, tasks follow the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
@@ -285,7 +275,7 @@ of every entry, including the controls and what was watched failing, is in
   `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on the reviewed commit, 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `9faf9b7`.
+  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `1956340`.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -9,18 +9,14 @@ key: it holds its own shielded LEZ account, and the ceiling on what it may spend
 is not a check inside the agent process but **state on chain that the agent's own
 program is the only thing permitted to write**.
 
-An agent runs unattended on a remote node and holds its own signing key, so any
-rule the agent evaluates can be evaluated differently by whoever holds the
-process. So the rule is not evaluated by the agent at all. Each agent has exactly
-one policy account, at `PDA(program, "agent-policy/v1", agent_id)`, and the owner,
-both limits, the period and the running total live in its data, which LEZ rule 6
-(`UnauthorizedDataModification`) lets only this program write. Anchoring takes two
-signatures: the agent signs `claim_agent` to name the account that may bind it,
-and only that account is accepted by `create_policy` — which is
-`#[account(init, …)]`, so the first anchor is the only anchor possible, not merely
-the only one detected. `spend` derives the same address from the *paying* account
-out of the pre-state, so there is no argument to lie about, and reads the limits
-off the account rather than from the call.
+An agent runs unattended on a remote node and holds its own signing key, so any rule
+it evaluates can be evaluated differently by whoever holds the process — so the rule is
+not the agent's to evaluate. Each agent has one policy account at
+`PDA(program, "agent-policy/v1", agent_id)` holding the owner, both limits, the period
+and the running total, which LEZ rule 6 (`UnauthorizedDataModification`) lets only this
+program write. Anchoring takes two signatures so the first anchor is the only one
+possible, and `spend` derives the address from the *paying* account out of the
+pre-state — the mechanism, and the attacks it closes, is in Approach below.
 
 **Three agents are anchored and live on the public LEZ testnet**, one per default
 skill category, each with its own shielded account and spending envelope:
@@ -32,74 +28,55 @@ skill category, each with its own shielded account and spending envelope:
 | blockchain | `A7UBoMbS…c39JtMu` | `2RK4dPwz…W3Wusvc9` | 200 | 1,000 | [`2f6b481c…ecec5eda`](https://explorer.testnet.lez.logos.co/transaction/2f6b481cffde2adaeed9442c19599c939d97da0c930b70b45d97ac34ecec5eda) |
 
 They have **paid each other for priced skills, unattended**, the per-period total
-accumulating on chain: sixteen settlements, of which **thirteen are under the
-program this repository ships**. One was made **by a module a host loaded**, in
-the same call that discovered the payee's signed Agent Card and opened the A2A
-task: [`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3), block 9477. Every hash, block and balance below is
-generated from the chain rather than typed.
+accumulating on chain: sixteen settlements, **thirteen under the program this
+repository ships**. One was made **by a module a host loaded**, in the same call
+that discovered the payee's signed Agent Card and opened the A2A task:
+[`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3), block 9477. Every hash, block and balance below is generated from
+the chain rather than typed.
 
-**What is not delivered is stated plainly.** All twenty-three success criteria are
-met, the last of them — the recorded video demo — by one narrated walkthrough
-published with this submission. That is not a claim that nothing is missing.
-Expanded in `docs/limitations.md`:
+**What is not delivered is stated plainly.** All twenty-three criteria are met — the
+last, the recorded video demo, by one narrated walkthrough — which is not a claim that
+nothing is missing. `docs/limitations.md` has the full list; the load-bearing ones:
 
-- the **three agents published here** can never have an above-threshold spend
-  approved: their owners anchored while their accounts were still unclaimed, and
-  such an account is filtered out of every later post-state. That is irreversible
-  for those three. It is not a property of the chain — an owner claimed before it
-  anchors signs indefinitely, and the whole path ran on the public testnet
-  (`approve_spend` block 10776, `spend_approved` block 10786, payee 4 → 6) against
-  a fourth agent provisioned for it. **The same freeze takes `update_policy` with
-  them**: a limit on those three cannot be lowered, raised or zeroed, so the brake
-  `docs/security-model.md` describes is a property of the program that these three
-  deployments cannot reach. All three read `nonce: 1` with the default program
-  owner today — check them yourself with `getAccount`;
-- the storage skills **have** driven a live node from inside the module — it
-  `dlopen`s `libstorage` and opens its own node on `meta.configure("storage","on")`
-  — but without the evidence discipline the other node runs have: no committed
-  transcript, no CI job;
-- an inbound A2A task request is not automatically dispatched to the skill it
-  names. That is inbound auto-serving, not skill dispatch, which the module has:
-  `invoke()` is the single dispatcher every capability sits behind;
-- no model has run against the inference port. The prize puts the choice of model
-  **out of scope** and asks only that inference be pluggable, which it is — a
-  local and an HTTP backend behind one port — but neither has served a real
-  request;
+- the **three agents published here** can never have an above-threshold spend approved:
+  their owners anchored while the accounts were still unclaimed, which every later
+  post-state filters out — irreversible for those three, and it freezes `update_policy`
+  on them too. Not a property of the chain (an owner who claims before anchoring signs
+  indefinitely): the whole path ran on the public testnet against a fourth agent —
+  `approve_spend` block 10776, `spend_approved` block 10786, payee 4 → 6;
+- the storage skills **have** driven a live node from inside the module (`dlopen`ing
+  `libstorage` on `meta.configure("storage","on")`) but with no committed transcript or
+  CI job;
+- an inbound A2A task request is not auto-dispatched to the skill it names — that is
+  inbound auto-serving, not the skill dispatch the module has behind `invoke()`;
+- no model has run against the inference port — the prize puts model choice **out of
+  scope** and asks only that inference be pluggable, which it is (a local and an HTTP
+  backend behind one port), though neither has served a real request.
 
 ## Repository
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
 - **Reviewed commit:**
   [`42b922f`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83).
-  Every path below is relative to it. Read them at that tree rather than at
-  `main`: `main` moves, and a path that has moved with it is no longer the file
-  this document describes.
-- **CI, all green — and this names the commit each run sat on.** The host suite
-  (`33084399499`, 12 min), the explorer-link gate (`33084399822`) and the full
-  lifecycle against a standalone LEZ sequencer (`33093872580`, 3 h 16,
-  `RISC0_DEV_MODE=0`, no skip path, ending on a payment inside the envelope moving
-  a balance `0 → 50` and one above the ceiling refused with `Program error 6005`)
-  all ran on `1956340`. The run that loads this module in one Logos Core runtime
-  alongside the wallet, storage and messaging modules ran on `4d684c2`
-  (`33087503041`). Both are ancestors of the reviewed commit; run
-  `git diff 4d684c2 <reviewed commit> --stat` for what lies between rather than
-  taking a distance from here. Beside them run gates that
-  hold the documents to the code: every quoted path and link must resolve, every
-  cited CI run must be on a commit this branch has, every explorer link must
-  resolve against the chain it names, the README's stated test count must be what
-  the suite passes, and no file may name a different prize entry.
+  Every path below is relative to it — read them at that tree, not at `main`, since
+  `main` moves and a moved path is no longer the file described here.
+- **CI, all green — each run names the commit it sat on.** The host suite
+  (`33084399499`, 12 min), the explorer-link gate (`33084399822`) and the full lifecycle
+  against a standalone LEZ sequencer (`33093872580`, 3 h 16, `RISC0_DEV_MODE=0`, no skip
+  path, ending on a payment moving a balance `0 → 50` and one above the ceiling refused
+  with `Program error 6005`) all ran on `1956340`; the run loading this module alongside
+  the wallet, storage and messaging modules in one Logos Core runtime ran on `4d684c2`
+  (`33087503041`). Both are ancestors of the reviewed commit. Beside them run gates that
+  hold the documents to the code — every path, link and cited run must resolve, every
+  explorer link against its chain, and no file may name a different prize entry.
 - **Where the detail lives:** `docs/criteria-evidence.md` (the long form of every
   criterion), `docs/architecture.md`, `docs/skills.md`, `docs/security-model.md`,
   `docs/a2a-binding.md`, `docs/limitations.md`, `docs/DEPLOYMENT.md`,
   `docs/basecamp.md`, `docs/benchmarks/cu-budget.md`.
 
-Everything here is verifiable from a clean clone plus the public sequencer. No
-claim depends on trusting the author.
-
-### The four commands that check the rest
-
-Run from a clean clone at the reviewed commit. These exit codes were observed on
-a fresh clone of the public repository, not intended.
+Everything here is verifiable from a clean clone plus the public sequencer; no claim
+depends on trusting the author. Four commands check the rest, from a clean clone at
+the reviewed commit — the exit codes were observed on a fresh clone, not intended:
 
 ```console
 $ ./scripts/demo.sh                                            # exit 0
@@ -108,109 +85,78 @@ $ ./scripts/check-docs.py                                      # exit 0
 $ ./scripts/submission-evidence.py                             # exit 0
 ```
 
-**`./scripts/demo.sh` needs no key, no funded account and no local sequencer** —
-only a Rust toolchain, `python3` and `curl`, and it names any that are missing
-before running anything. It runs the policy tests, recomputes the deployed
-program's hash from the committed binary, asks the public sequencer whether that
-transaction exists, asks it about a hash that *cannot* exist, and replays the
-adversarial attack against both the superseded program and the shipped one.
-Without the null control the first question would prove nothing: an RPC answering
-non-null to everything would pass it just as happily. Thirteen checks print `OK`.
-
-### Evidence generated rather than typed
-
-Every figure here is fetched by `./scripts/submission-evidence.py` from the
-committed binary and from `https://testnet.lez.logos.co`. It derives the deploy
-transaction from the committed bytes rather than quoting it, reads the manifests by
-column name, confirms every transaction it cites is inside the block it names and
-absent from **both** neighbours, and exits non-zero otherwise. `--check FILE` re-runs
-the comparison against a document without writing, so a stale copy cannot be
-produced — its target is the submission draft, which is deliberately kept outside
-this repository rather than as a hundred and fifty kilobytes of working text at
-the top of a public tree, so the command above generates instead. CI runs both on
-every push, and requires a drifted copy to be rejected.
+**`./scripts/demo.sh` needs no key, no funded account and no local sequencer** — only
+a Rust toolchain, `python3` and `curl`, naming any that are missing first. It runs the
+policy tests, recomputes the deployed program's hash from the committed binary, asks
+the public sequencer whether that transaction exists and whether a hash that *cannot*
+exist does (the null control, without which the first question proves nothing), and
+replays the adversarial attack against the superseded and the shipped program. Thirteen
+checks print `OK`. Every figure here is fetched from the committed binary and
+`https://testnet.lez.logos.co` by `./scripts/submission-evidence.py` (`--check FILE`
+re-runs the comparison, so a stale copy cannot be produced and CI rejects a drifted one).
 
 The deployed program is [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf). A LEZ deploy hash is
 `SHA256(u32_le(len) ‖ bytecode)`, so `artifacts/programs/agent_verifier.bin` **is**
-its own deploy transaction — recompute it and compare, which `./scripts/demo.sh`
-does in front of you. The sixteen settlements are recorded in
-`artifacts/a2a-task.tsv` and `artifacts/shielded-settlement.tsv`; each is
-re-decoded from the chain's own copy of the transaction rather than from the
-manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
-redeploy orphaned instead of counting them. The one the video ends on is
-[`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115), block 10102 — the recipient goes 107 → 108 LEZ, and no owner
-signs anything.
+its own deploy transaction — `./scripts/demo.sh` recomputes and compares it in front
+of you. The sixteen settlements are in `artifacts/a2a-task.tsv` and
+`artifacts/shielded-settlement.tsv`, each re-decoded from the chain by
+`./scripts/verify-deployment.sh` (which also labels the rows a redeploy orphaned
+rather than counting them). The one the video ends on is
+[`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115), block 10102 — the recipient goes 107 → 108 LEZ, no owner signs.
 
 ## Approach
 
-**The spending limit is an account, not an `if`.** A limit enforced inside the
-agent is enforced by whoever controls the agent's process — which, for an agent on
-a remote node holding its own key, is not necessarily the owner. So it is moved
-out of the process entirely. `create_policy` initialises exactly one account per
-agent and is `#[account(init, …)]`: the first anchor is the only anchor possible,
-not merely the only one detected. Only the program may write that account's data
-(LEZ rule 6), and `spend` derives the address from the *paying* account out of the
-pre-state, so there is no argument to lie about.
+**The spending limit is an account, not an `if`.** A limit enforced inside the agent
+is enforced by whoever controls the agent's process — which, for an agent on a remote
+node holding its own key, is not necessarily the owner. So it is moved out of the
+process: `create_policy` initialises exactly one account per agent and is
+`#[account(init, …)]` (the first anchor is the only anchor possible), only the program
+may write that account's data (LEZ rule 6), and `spend` derives the address from the
+*paying* account out of the pre-state, so there is no argument to lie about.
 
-**What was tried and did not work.** Four deployments were needed to get the
-anchoring right, and each earlier one was walked around by an attacker who was not
-lying — they really were the owner of the policy they anchored; they had simply
-never been asked whether the agent agreed. `docs/criteria-evidence.md` carries the
-full account, including the attack transaction the superseded program accepted and
-the one today's program refuses, and `./scripts/demo.sh` section 5 replays it
-against both programs in front of you.
+**What was tried and did not work.** Four deployments were needed to get anchoring
+right; each earlier one was walked around by an attacker who was not lying — they really
+owned the policy they anchored, they had simply never been asked whether the agent
+agreed. `docs/criteria-evidence.md` carries the full account, and `./scripts/demo.sh`
+section 5 replays the attack the superseded program accepted and today's refuses.
 
 ## Design Write-up
 
-The prize names seven topics. Each has a document carrying it at full length; what
-follows is the decision each one turns on.
+The prize names seven topics; each has a full-length document, and here is the
+decision each turns on.
 
-**Module architecture** (`docs/architecture.md`) — a Logos Core plugin exposing
-three skill categories, each a thin binding onto a real Logos node or onto LEZ.
-`invoke()` is the single dispatcher every capability sits behind, which lets a
-second Logos app drive the owner's end without the module exporting anything else.
-No skill links a library: each takes a struct of `std::function` ports, so every
-skill has a test against a fake and there is one place where a real node is wired.
-
-**Skill interface design** (`docs/skills.md`) — a skill is a class with `name()`,
-`parameterSchema()` and `invoke(json)`, added through `registerSkill` without
-touching the core module. Schemas are declared once and the Agent Card is
-generated from the registry rather than written by hand, so a card cannot
-advertise a skill the module does not have.
-
-**Spending threshold mechanism** — Approach above has the argument;
-`docs/security-model.md` has the refusal codes and what a holder of the agent's
-key can and cannot do.
-
-**Agent-to-agent coordination** (`docs/a2a-binding.md`) — Agent Cards follow the
-A2A schema, tasks follow the A2A lifecycle, and Logos Messaging is the transport
-A2A leaves open. Payment is the part A2A omits: the client pays the price the card
-advertises, signed by the agent's own shielded account, with no owner in the loop.
-
-**Security model** — what is *not* closed is enumerated alongside it: the balance
-is held by the transfer program, so the agent's key can move it by calling that
-program directly. This program bounds what the agent moves *through it*.
-
-**Known limitations** (`docs/limitations.md`) — anything that does not work is
-written down there first, with the retractions of claims that did not survive it.
-
-**Integration instructions** — `docs/DEPLOYMENT.md` for the chain side,
-`docs/basecamp.md` for loading into Logos Basecamp.
+- **Module architecture** (`docs/architecture.md`) — a Logos Core plugin of three
+  skill categories, each a thin binding onto a real Logos node or onto LEZ. `invoke()`
+  is the single dispatcher behind every capability. No skill links a library: each
+  takes a struct of `std::function` ports, so each has a test against a fake and a real
+  node is wired in one place.
+- **Skill interface design** (`docs/skills.md`) — a skill is a class with `name()`,
+  `parameterSchema()` and `invoke(json)`, added via `registerSkill` without touching the
+  core. The Agent Card is generated from the registry, so it cannot advertise a skill
+  the module lacks.
+- **Spending threshold mechanism** — Approach above; `docs/security-model.md` has the
+  refusal codes and what a holder of the agent's key can and cannot do.
+- **Agent-to-agent coordination** (`docs/a2a-binding.md`) — Agent Cards follow the A2A
+  schema, tasks the A2A lifecycle, Logos Messaging the transport A2A leaves open.
+  Payment is the part A2A omits: the client pays the advertised price, signed by the
+  agent's own shielded account, with no owner in the loop.
+- **Security model** — enumerated alongside what it does not close: the balance is held
+  by the transfer program, so the agent's key can move it directly; this program bounds
+  what the agent moves *through it*.
+- **Known limitations** (`docs/limitations.md`) and **integration instructions**
+  (`docs/DEPLOYMENT.md` for the chain, `docs/basecamp.md` for Basecamp).
 
 ## Success Criteria Checklist
 
-Twenty-three criteria, mirrored from the prize in its own order and its own
-words. **Tally: 23 MET, 0 UNMET.** Most entries give the verdict and the one thing that
-re-derives it. Six do not, because the criterion is about behaviour rather than
-an artefact — a retry that times out, an owner driving the agent from a separate
-app — and for those the long form carries the transcript instead. The long form
-of every entry, including the controls and what was watched failing, is in
+Twenty-three criteria, mirrored from the prize in its own order and words. **Tally:
+23 MET, 0 UNMET.** Most entries give the verdict and the one thing that re-derives it;
+the long form of every entry, with the controls and what was watched failing, is in
 `docs/criteria-evidence.md`.
 
 ### Functionality
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime; the workflow is `.github/workflows/alongside-companion-modules.yml` and the run that shows it is `33087503041`, on `4d684c2`, an ancestor of the reviewed commit.
+  All three companions are built from their published sources and all four modules load in one runtime; workflow `.github/workflows/alongside-companion-modules.yml`, run `33087503041` on `4d684c2`, an ancestor of the reviewed commit.
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
   *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: the payee's balance moves on chain, 107 → 108 LEZ on the settlement the video ends on.
@@ -219,25 +165,25 @@ of every entry, including the controls and what was watched failing, is in
   `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no prior state.
 
 - [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
-  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging.
+  Two LogosBasecamp processes, each with its own user dir and loaded copy, exchanging over Logos Messaging.
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
   Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain: [`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8) at block 10776 and [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597) at block 10786, the payee going 4 → 6.
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. Two were brought to match the prize's wording rather than merely disclosed against it: `storage.upload` now **encrypts** the file before the node sees it and `storage.download` **decrypts** on the way back — SHA256-CTR with an HMAC-SHA256 tag in `module/src/vault_crypto.cpp`, its primitives carrying RFC known-answer tests and the round trip asserted in `skills_test.cpp`, so the content address names ciphertext and Logos Storage never holds the file; and `storage.list` returns the labels the agent recorded, which Storage keys-by-content has nowhere to keep. `messaging.join` subscribes the topic `messaging.create_group` opens, a unit test asserting the two meet. All three moved compiled code, so the three-architecture package was rebuilt and its digests re-recorded — `check-package-fresh.py`, green in CI.
+  Every skill the prize lists is registered and documented in `docs/skills.md`, the registry asserted against the *loaded binary* (this repository has shipped skills that were implemented, documented and unreachable). Two were brought to the prize's exact wording: `storage.upload`/`storage.download` now **encrypt/decrypt** (SHA256-CTR + HMAC-SHA256 in `module/src/vault_crypto.cpp`, RFC known-answer tests, round trip in `skills_test.cpp`), so Storage only ever holds ciphertext; and `messaging.join` subscribes the topic `messaging.create_group` opens, with a unit test. All three moved compiled code, so the three-architecture package was rebuilt and its digests re-recorded — `check-package-fresh.py`, green in CI.
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
-  Cards follow the A2A schema, tasks follow the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
+  Cards follow the A2A schema, tasks the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
   `./scripts/delivery-in-plugin.sh settle` does discovery, task and settlement in one invocation — [`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3), block 9477, from a module a host loaded.
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end — file vault, marketplace, notary, event alerter — and **three of those four are in the recorded demo**: the marketplace, the notary and the event alerter. The file vault runs in `alongside-companion-modules.yml` rather than on camera, because as the prize words it that case has no chain step. The spending threshold is filmed as well, and is deliberately not counted: it is a criterion of its own, not one of the nine.
+  Four run end to end — file vault, marketplace, notary, event alerter — and **three are in the recorded demo** (marketplace, notary, event alerter); the file vault runs in `alongside-companion-modules.yml` rather than on camera, as the prize words it having no chain step. The spending threshold is filmed too but not counted — it is a criterion of its own.
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
-  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; addresses and `create_policy` hashes in the table above.
+  Storage, messaging and blockchain, each with its own shielded account and anchored envelope; addresses and `create_policy` hashes in the table above.
 
 - [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
   `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents, and runs in CI.
@@ -264,7 +210,7 @@ of every entry, including the controls and what was watched failing, is in
 ### Performance
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  `docs/benchmarks/cu-budget.md`, candid about its premise: LEZ v0.2.4 does not meter compute units, and the document shows the search establishing that rather than inventing a number. What is measured instead is what actually costs — a `claim_agent` proof at 58 min on a four-core runner, `create_policy` at about one block.
+  `docs/benchmarks/cu-budget.md`, candid about its premise: LEZ v0.2.4 does not meter compute units, and the document shows the search that establishes that rather than inventing a number. What is measured instead is what actually costs — a `claim_agent` proof at 58 min on a four-core runner, `create_policy` at about one block.
 
 ### Supportability
 
@@ -272,88 +218,75 @@ of every entry, including the controls and what was watched failing, is in
   Deployed at [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf); `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on `1956340`, an ancestor of the reviewed commit — the delta to the reviewed commit is documentation, the `messaging.join` fix, the storage encryption and the rebuilt packages, none of which touch the spending lifecycle this run proves. 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
+  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on `1956340`, an ancestor of the reviewed commit — the delta to the reviewed commit is documentation, the `messaging.join` fix, the storage encryption and the rebuilt packages, none touching the spending lifecycle this run proves. 3 h 16, of which 58 min are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically: run `33199329323`, the full CI suite — every skill compiled and exercised against fake ports including the encrypted storage round trip, the package freshness gate, and the SDK third-party-skill example — is green on the reviewed commit itself. Its head_sha is the reviewed commit.
+  Green on `main` and on the reviewed commit specifically: run `33199329323`, the full CI suite — every skill compiled and exercised against fake ports including the encrypted storage round trip, the package-freshness gate and the SDK third-party-skill example — is green, its head_sha the reviewed commit.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.
 
 - [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes.
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above (`33093872580`) executes.
 
 - [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
   <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout the proving output; `./scripts/check-video.py` reads that off the pixels rather than describing it. See Supporting Materials.
+
 ## FURPS Self-Assessment
 
 ### Functionality
 
-The agent holds a shielded LEZ account, signs its own transactions, and spends
-under a ceiling the chain keeps in state only its own program may write. It can
-also be *paid* at that account, by the keys its signed card publishes rather than
-by an id, so a settlement can hide both ends. Every default skill is implemented
-and registered, and the registry is asserted against the loaded binary rather than
-the source, because this repository has shipped skills that were implemented,
-documented and unreachable. A2A discovery, the task lifecycle and settlement are
-one call rather than three.
+The agent holds a shielded LEZ account, signs its own transactions, and spends under a
+ceiling only its own program may write to chain state. It is *paid* at that account by
+the keys its signed card publishes, so a settlement can hide both ends. Every default
+skill is registered and asserted against the loaded binary; A2A discovery, the task
+lifecycle and settlement are one call.
 
 ### Usability
 
-A new skill is a class with three methods and a `registerSkill` call; the core
-module is not touched. The owner's end is three registered skills behind
-`invoke()`, which is why a second Logos app can drive it with nothing else
-exported. One command deploys and configures.
+A new skill is a class with three methods and a `registerSkill` call, no core file
+touched. The owner's end is three registered skills behind `invoke()`, so a second
+Logos app drives it with nothing else exported. One command deploys and configures.
 
 ### Reliability
 
 Pending task state survives the module being destroyed and rebuilt over the same
-directory. An above-threshold payment whose approval never reaches the owner is
-not executed — it retries, times out and reports. A skill that throws is caught,
-named, and does not take the module or a concurrent skill with it.
+directory. An above-threshold payment whose approval never reaches the owner retries,
+times out and reports rather than executing. A skill that throws is caught and named,
+taking neither the module nor a concurrent skill with it.
 
 ### Performance
 
-LEZ v0.2.4 does not meter compute units, and `docs/benchmarks/cu-budget.md` says
-so with the search that establishes it, rather than inventing a number. What is
-measured instead is what actually costs: a `claim_agent` proof at 58 minutes on a
-four-core runner, `create_policy` at about one block.
+LEZ v0.2.4 does not meter compute units, and `docs/benchmarks/cu-budget.md` shows the
+search that establishes that rather than inventing a number. What actually costs is
+measured: a `claim_agent` proof at 58 min on a four-core runner, `create_policy` about
+one block.
 
 ### Supportability
 
-Ten jobs on every push, an end-to-end run against a real standalone sequencer with
-`RISC0_DEV_MODE=0` and no skip path, and gates that hold the documents to the code
-— `check-docs.py` resolves every path and citation across fifteen documents,
-`check-package-fresh.py` refuses a package whose binary has lost a source literal,
-`write-program-record.py` refuses a source that has moved under the deployed
-program.
-
-**What is weakest** is the list at the end of [Summary](#summary), stated there
-rather than left to be found — and expanded in `docs/limitations.md`, where
-anything that does not work is written down before anything that does.
+Ten jobs on every push, an end-to-end run against a real standalone sequencer
+(`RISC0_DEV_MODE=0`, no skip path), and gates holding the documents to the code
+(`check-docs.py`, `check-package-fresh.py`, `write-program-record.py`). **What is
+weakest** is the list at the end of [Summary](#summary), stated there and expanded in
+`docs/limitations.md`.
 
 ## Supporting Materials
 
-- **Video demo:** <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, three of the
-  prize's illustrative use cases plus the spending threshold, against the public testnet and never a localnet, `RISC0_DEV_MODE=0`
-  legible throughout the proving output. The same file is a release asset
-  (`lp8-demo.mp4`), so the evidence does not depend on a third party keeping it up.
+- **Video demo:** <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, three of the prize's
+  illustrative use cases plus the spending threshold, against the public testnet and
+  never a localnet, `RISC0_DEV_MODE=0` legible throughout the proving output. The same
+  file is a release asset (`lp8-demo.mp4`), so the evidence does not depend on a third
+  party keeping it up.
 - **The demo as text, checked against the film:** `recordings/lp8-demo.srt` is the
-  narration as spoken, so twenty-two minutes can be read and grepped instead of
-  watched. `./scripts/check-transcript.py` ties it to the picture: four anchors
-  require the frame to show what the narration names at the second it says it —
-  where the line is "that percentage is r0vm", the frame there must show the
-  prover's output. The narration is spoken and never on screen, so those anchors
-  are the part a plausible file written from memory could not satisfy. It refuses
-  to pass on structure alone, because its first version reported "anchor not
-  testable" four times and then printed "transcript matches the film".
-  Mutation-tested three ways, all caught; `docs/recording-evidence.md` carries the
-  measured output and what it does **not** establish.
-- **Reproduce the deployment and the settlements** (needs a funded testnet
-  signer): `./scripts/deploy-agents.sh` · `./scripts/a2a-task.sh` ·
-  `./scripts/e2e-local-sequencer.sh` · `./scripts/delivery-in-plugin.sh settle`.
-  The four commands that need no key are in [Repository](#repository); the
-  manifests they read by column name are `artifacts/{agents,anchored,a2a-task,shielded-settlement}.tsv`.
+  narration as spoken, readable and greppable instead of watched.
+  `./scripts/check-transcript.py` ties it to the picture — four anchors require the frame
+  to show what the narration names at the second it says it — and refuses to pass on
+  structure alone; `docs/recording-evidence.md` carries the output and its limits.
+- **Reproduce the deployment and the settlements** (needs a funded testnet signer):
+  `./scripts/deploy-agents.sh` · `./scripts/a2a-task.sh` ·
+  `./scripts/e2e-local-sequencer.sh` · `./scripts/delivery-in-plugin.sh settle`. The
+  four commands that need no key are in [Repository](#repository); the manifests they
+  read by column name are `artifacts/{agents,anchored,a2a-task,shielded-settlement}.tsv`.
 
 ## Terms & Conditions
 

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -272,7 +272,7 @@ of every entry, including the controls and what was watched failing, is in
   Deployed at [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf); `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on the reviewed commit, 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
+  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on `1956340`, an ancestor of the reviewed commit — the delta to the reviewed commit is documentation, the `messaging.join` fix, the storage encryption and the rebuilt packages, none of which touch the spending lifecycle this run proves. 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
   Green on `main` and on the reviewed commit specifically: run `33199329323`, the full CI suite — every skill compiled and exercised against fake ports including the encrypted storage round trip, the package freshness gate, and the SDK third-party-skill example — is green on the reviewed commit itself. Its head_sha is the reviewed commit.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -66,10 +66,13 @@ Expanded in `docs/limitations.md`:
   `module/src/delivery_runtime.cpp:695` opens `groupTopic(channelId)`, so the skill
   returns `{"ok":true}` and joins the wrong topic. The prize defines it as "joins a
   Logos Messaging group topic", so that criterion is met in shape and not in
-  substance. The fix is two lines and it is not applied here: changing the source
-  without rebuilding the `.lgx` makes `check-package-fresh.py` red, and the
-  toolchain that rebuilds it is not on this machine. Disclosed rather than hidden,
-  in full, in `docs/limitations.md`.
+  substance. The source fix is one line and it is written; it is not
+  shipped, because `module/agent.lgx` carries compiled plugins for three
+  architectures — `darwin-arm64`, `linux-amd64` and `linux-arm64` — and
+  `check-package-fresh.py` correctly refuses a package whose source has moved under
+  it. Shipping the source change without rebuilding all three would make the tree
+  claim a behaviour the shipped module does not have, which is worse than the bug.
+  `docs/limitations.md` carries the whole of it, including the line numbers.
 
 ## Repository
 

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -267,7 +267,7 @@ unchanged.
 **Functionality**
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32582715045`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32582715045), which ran on commit `4f4ede8`, an earlier revision of this branch. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
+  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32679505073`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32679505073), which ran on the reviewed commit. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
   *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/criteria-evidence.md#functionality).

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -424,7 +424,7 @@ the inference port. Each is expanded in
   [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/anchored.tsv) ·
   [`a2a-task.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/a2a-task.tsv) ·
   [`shielded-settlement.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/artifacts/shielded-settlement.tsv)
-- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/main/docs) — architecture, skills,
+- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs) — architecture, skills,
   security model, A2A binding, deployment, Basecamp loading, CU budget, and
   [`limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/708b2cea8401ef3a2a179baf4d2aabeddefac59f/docs/limitations.md), which is where anything
   that does not work is written down first.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -78,19 +78,22 @@ Expanded in `docs/limitations.md`:
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
 - **Reviewed commit:**
-  [`1956340`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/1956340334023e40b71970d561ec13d15fddd0ed).
+  [`9faf9b7`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/9faf9b76fa9d8c20daa9a3b118dc4948da7b63af).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
-- **CI, all green — and this says which run sat where.** The host suite
-  (`33084399499`, 12 min) and the explorer-link gate (`33084399822`) ran on the
-  reviewed commit itself. So did the full lifecycle against a standalone
-  LEZ sequencer: `33093872580`, 3 h 16, `RISC0_DEV_MODE=0`, no skip path, ending
-  on a payment inside the envelope moving a balance `0 → 50` and one above the
-  ceiling refused with `Program error 6005`. Of the four workflows, only the run
-  that loads this module in one Logos Core runtime alongside the wallet, storage
-  and messaging modules sits elsewhere — `33087503041`, on `4d684c2`, which
-  differs from the reviewed commit by one line of one document. Beside them run gates that
+- **CI, all green — and this names the commit each run sat on.** The host suite
+  (`33084399499`, 12 min), the explorer-link gate (`33084399822`) and the full
+  lifecycle against a standalone LEZ sequencer (`33093872580`, 3 h 16,
+  `RISC0_DEV_MODE=0`, no skip path, ending on a payment inside the envelope moving
+  a balance `0 → 50` and one above the ceiling refused with `Program error 6005`)
+  all ran on `1956340`. The run that loads this module in one Logos Core runtime
+  alongside the wallet, storage and messaging modules ran on `4d684c2`
+  (`33087503041`). Both are ancestors of the reviewed commit, and everything
+  between them and it is documentation — run
+  `git diff 4d684c2 <reviewed commit> --stat` for the list rather than taking that
+  from here. No program, no workflow, no script and no artefact the chain sees is
+  in it. Beside them run gates that
   hold the documents to the code: every quoted path and link must resolve, every
   cited CI run must be on a commit this branch has, every explorer link must
   resolve against the chain it names, the README's stated test count must be what
@@ -282,7 +285,7 @@ of every entry, including the controls and what was watched failing, is in
   `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on the reviewed commit, 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `1956340`.
+  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `9faf9b7`.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -2,16 +2,6 @@
 
 **Submitted by:** edenbd1
 
-> **Where to find what.** Every claim below carries the command that re-derives
-> it; the long form of each is in the repository, linked.
->
-> | To check | Go to |
-> |---|---|
-> | three agents live on the public testnet, and one paying another | [Summary](#summary) and [Repository](#repository) — explorer links, not hashes to paste |
-> | that it runs from a clean clone | [The four commands](#the-four-commands-that-check-the-rest) — four lines, all exit 0 |
-> | the recorded demo, and the e2e green in CI | [Supporting Materials](#supporting-materials) and the Supportability entries in the [checklist](#success-criteria-checklist) |
-> | **what does not work** | the list at the end of [Summary](#summary), and [`docs/limitations.md`][limitations-md] |
-
 ## Summary
 
 An agent that participates in the Logos stack directly rather than through an API
@@ -19,92 +9,79 @@ key: it holds its own shielded LEZ account, and the ceiling on what it may spend
 is not a check inside the agent process but **state on chain that the agent's own
 program is the only thing permitted to write**.
 
-The core idea is one design decision. An agent runs unattended on a remote node
-and holds its own signing key, so any spending rule the agent evaluates can be
-evaluated differently by whoever holds the process. So the rule is not evaluated
-by the agent at all. Each agent has exactly one policy account, at
-`PDA(program, "agent-policy/v1", agent_id)` — the program and the agent, and
-nothing else — and the owner, both limits, the period and the running total live
-in that account's data, which LEZ rule 6 (`UnauthorizedDataModification`) lets
-only this program write. Anchoring one takes two signatures: the agent signs
-`claim_agent` to name the account that may bind it, and only that account's
-signature is accepted by `create_policy`. `create_policy` is
-`#[account(init, …)]`, so the first anchor for an agent is the only anchor for
-that agent — a second is not *detected*, it is impossible. `spend` derives the
-same address from the *paying* account's id out of the pre-state, so there is no
-argument to lie about, and it reads the limits off the account rather than from
-the call.
+An agent runs unattended on a remote node and holds its own signing key, so any
+rule the agent evaluates can be evaluated differently by whoever holds the
+process. So the rule is not evaluated by the agent at all. Each agent has exactly
+one policy account, at `PDA(program, "agent-policy/v1", agent_id)`, and the owner,
+both limits, the period and the running total live in its data, which LEZ rule 6
+(`UnauthorizedDataModification`) lets only this program write. Anchoring takes two
+signatures: the agent signs `claim_agent` to name the account that may bind it,
+and only that account is accepted by `create_policy` — which is
+`#[account(init, …)]`, so the first anchor is the only anchor possible, not merely
+the only one detected. `spend` derives the same address from the *paying* account
+out of the pre-state, so there is no argument to lie about, and reads the limits
+off the account rather than from the call.
 
 **Three agents are anchored and live on the public LEZ testnet**, one per default
-skill category, each with its own shielded account and its own spending envelope:
+skill category, each with its own shielded account and spending envelope:
 
-| category | agent id | policy account | per-tx | per-period | `create_policy` on chain |
+| category | agent id | policy account | per-tx | per-period | `create_policy` |
 |---|---|---|---|---|---|
-| storage | `9XpkkvosC14TKTNZAoUdKXJwCheJ3dF8u3Xoojfv1FaE` | `6FscNXjNhamSCTbzLe67gU3noFHkQKDjRmD4tNj3ipSe` | 50 | 500 | [`6857ba23…631fe7d4`](https://explorer.testnet.lez.logos.co/transaction/6857ba2378a84ba51618582e852e3827a872e3ea85f17de76bdb45b1631fe7d4), block 8868 |
-| messaging | `GpRdooEWJjX4JmRyT2n5KzMnDKtCM2HrvZ8iwMZpe5FS` | `7HH46tXhgfrMSSzWwpNrjkqujCB9EGA5cEvnYK1dA7bp` | 25 | 250 | [`ce557a0a…278e1918`](https://explorer.testnet.lez.logos.co/transaction/ce557a0a8adc517b60496c35514e269fff92a4393b90bef41ce10916278e1918), block 8876 |
-| blockchain | `A7UBoMbSoQXNaDTiSjbr28KjedNrvBvroiamrc39JtMu` | `2RK4dPwzDTAdgjUGpGsCkok962StYpPV14QpW3Wusvc9` | 200 | 1,000 | [`2f6b481c…ecec5eda`](https://explorer.testnet.lez.logos.co/transaction/2f6b481cffde2adaeed9442c19599c939d97da0c930b70b45d97ac34ecec5eda), block 8884 |
+| storage | `9Xpkkvos…jfv1FaE` | `6FscNXjN…Nj3ipSe` | 50 | 500 | `6857ba23…631fe7d4` |
+| messaging | `GpRdooEW…MZpe5FS` | `7HH46tXh…K1dA7bp` | 25 | 250 | `ce557a0a…278e1918` |
+| blockchain | `A7UBoMbS…c39JtMu` | `2RK4dPwz…W3Wusvc9` | 200 | 1,000 | `2f6b481c…ecec5eda` |
 
-They have **paid each other for priced skills, unattended**, with the per-period
-total accumulating on chain: sixteen settlements in all, of which **thirteen are
-under the program this repository ships** — the messaging agent paying the
-storage agent seven times, the storage agent paying the blockchain agent four
-times, the blockchain agent paying the storage agent once, and one paid to a
-shielded payee. One of those payments was made **by a module a host loaded**, in the same
-call that discovered the payee's signed Agent Card and opened the A2A task:
-settlement
-[`ed8c3514…374b8cb3`](https://explorer.testnet.lez.logos.co/transaction/ed8c351412409c81723ea7b90e2d9cdcb0841a33234894bfff8269af374b8cb3),
-block 9477. Every hash, block and balance is in
-[Repository](#repository) below, generated from the chain rather than typed.
+They have **paid each other for priced skills, unattended**, the per-period total
+accumulating on chain: sixteen settlements, of which **thirteen are under the
+program this repository ships**. One was made **by a module a host loaded**, in
+the same call that discovered the payee's signed Agent Card and opened the A2A
+task: `ed8c3514…374b8cb3`, block 9477. Every hash, block and balance below is
+generated from the chain rather than typed.
 
-**What is not delivered is stated plainly.** All twenty-three of the prize's
-success criteria are now met, the last of them — the recorded video demo — by
-one narrated walkthrough published with this submission. That is not a claim
-that nothing is missing. Disclosed at the same volume as everything else, and
-expanded in [`docs/limitations.md`][limitations-md]:
+**What is not delivered is stated plainly.** All twenty-three success criteria are
+met, the last of them — the recorded video demo — by one narrated walkthrough
+published with this submission. That is not a claim that nothing is missing.
+Expanded in `docs/limitations.md`:
 
 - the **three agents published here** can never have an above-threshold spend
   approved: their owners anchored while their accounts were still unclaimed, and
-  such an account is filtered out of every later post-state. That is
-  irreversible for those three. It is not a property of the chain — an owner
-  claimed before it anchors signs indefinitely, and the whole path ran on the
-  public testnet ([`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8)
-  block 10776, [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597)
-  block 10786, payee 4 → 6) against a fourth agent provisioned for it;
-- the storage skills **have** driven a live node from inside the module — the
-  module `dlopen`s `libstorage` and opens its own node on
-  `meta.configure("storage","on")`, and `./scripts/skills-live.sh` calls all four
-  through `invoke()` from an empty `SkillPorts`. What is missing is the evidence
-  discipline the other node runs have: no transcript is committed for it and no
-  CI job runs it, unlike `artifacts/e2e/exercise-nodes.txt`;
+  such an account is filtered out of every later post-state. That is irreversible
+  for those three. It is not a property of the chain — an owner claimed before it
+  anchors signs indefinitely, and the whole path ran on the public testnet
+  (`approve_spend` block 10776, `spend_approved` block 10786, payee 4 → 6) against
+  a fourth agent provisioned for it;
+- the storage skills **have** driven a live node from inside the module — it
+  `dlopen`s `libstorage` and opens its own node on `meta.configure("storage","on")`
+  — but without the evidence discipline the other node runs have: no committed
+  transcript, no CI job;
 - an inbound A2A task request is not automatically dispatched to the skill it
-  names. That is about inbound auto-serving, not about skill dispatch, which the
-  module has and the prize puts in scope: `invoke()` is the single dispatcher
-  every capability sits behind;
+  names. That is inbound auto-serving, not skill dispatch, which the module has:
+  `invoke()` is the single dispatcher every capability sits behind;
 - no model has run against the inference port. The prize puts the choice of model
   **out of scope** and asks only that inference be pluggable, which it is — a
   local and an HTTP backend behind one port — but neither has served a real
-  request here.
+  request.
 
 ## Repository
 
-- **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module>
-- **Reviewed commit:** [`e1c57ba`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/e1c57bab5c12f783429debd735579002e2d3fcb1).
-  Every repository link below names that commit rather than `main`, so the
-  version under review cannot move after this is opened.
-- **CI on that exact commit:**
-  [the host suite](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726730085)
-  and [the full lifecycle against a standalone LEZ sequencer](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726759802),
-  both green.
-- **License:** dual MIT / Apache-2.0 (both full texts committed)
-- **Default branch:** `main`
+- **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
+- **Reviewed commit:** `e1c57ba`. Every path below is relative to it, and the
+  links are pinned to it rather than to `main`, so the version under review cannot
+  move after submission.
+- **CI on that exact commit, both green:** the host suite, and the full lifecycle
+  against a standalone LEZ sequencer.
+- **Where the detail lives:** `docs/criteria-evidence.md` (the long form of every
+  criterion), `docs/architecture.md`, `docs/skills.md`, `docs/security-model.md`,
+  `docs/a2a-binding.md`, `docs/limitations.md`, `docs/DEPLOYMENT.md`,
+  `docs/basecamp.md`, `docs/benchmarks/cu-budget.md`.
 
 Everything here is verifiable from a clean clone plus the public sequencer. No
 claim depends on trusting the author.
 
 ### The four commands that check the rest
 
-Run from a clean clone at the reviewed commit. These exit codes were observed
-on a fresh clone of the public repository, not intended.
+Run from a clean clone at the reviewed commit. These exit codes were observed on
+a fresh clone of the public repository, not intended.
 
 ```console
 $ ./scripts/demo.sh                                            # exit 0
@@ -114,353 +91,247 @@ $ ./scripts/submission-evidence.py --check SUBMISSION-DRAFT.md # exit 0
 ```
 
 **`./scripts/demo.sh` needs no key, no funded account and no local sequencer** —
-only a Rust toolchain, `python3` and `curl`, and it names any of them that are
-missing before it runs anything. It runs the policy tests, recomputes the
-deployed program's hash from the committed binary, asks the public sequencer
-whether that transaction exists, asks the same sequencer about a hash that
-*cannot* exist, and replays the adversarial attack against both the superseded
-program and the shipped one. Without the null control the first question would
-prove nothing: an RPC that answered non-null to everything would pass it just as
-happily. Thirteen checks print `OK`, none prints `FAIL`, and it closes on
+only a Rust toolchain, `python3` and `curl`, and it names any that are missing
+before running anything. It runs the policy tests, recomputes the deployed
+program's hash from the committed binary, asks the public sequencer whether that
+transaction exists, asks it about a hash that *cannot* exist, and replays the
+adversarial attack against both the superseded program and the shipped one.
+Without the null control the first question would prove nothing: an RPC answering
+non-null to everything would pass it just as happily. Thirteen checks print `OK`.
 
-```
-OK   the committed program refuses each attack, with the documented code
+### Evidence generated rather than typed
 
-demo complete — every claim above was computed or fetched here, not asserted.
-```
+Every figure here is fetched by `./scripts/submission-evidence.py` from the
+committed binary and from `https://testnet.lez.logos.co`. It derives the deploy
+transaction from the committed bytes rather than quoting it, reads the manifests by
+column name, confirms every transaction it cites is inside the block it names and
+absent from **both** neighbours, and exits non-zero otherwise. `--check` re-runs
+the comparison without writing, so a stale copy cannot be produced. CI runs it on
+every push.
 
-### Evidence on the public testnet, generated rather than typed
-
-**The three tables below are reproduced from the output of
-`./scripts/submission-evidence.py`.** That script fetches every figure from the
-committed binary and from `https://testnet.lez.logos.co`, derives the deploy
-transaction from the committed bytes rather than quoting it, reads the manifests
-by column name, confirms every transaction it cites is inside the block it names
-and absent from **both** neighbours, and exits non-zero if any of that fails.
-`--check` re-runs the comparison against a document without writing, so a stale
-copy cannot be produced. It runs in CI on every push. Regenerate them yourself:
-
-```console
-$ ./scripts/submission-evidence.py
-```
-
-Nothing in these tables was transcribed by hand. Where a fact moves — CI state,
-a period's running total — this document gives the command to ask rather than a
-number.
-
-#### The program, and the three agents
-
-The deployed program is
-[`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf).
-A LEZ deploy hash is `SHA256(u32_le(len) || bytecode)`, so
-`artifacts/programs/agent_verifier.bin` **is** its own deploy transaction —
-recompute it and compare, which `./scripts/demo.sh` does in front of you.
-
-The three agents, their limits and the `create_policy` that anchored each are in
-the table under [Summary](#summary), every hash a link to the block explorer.
-Their claim transactions, policy-account addresses, owner ids and the byte-level
-record layout are in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#the-program-and-the-three-agents-at-length)
-and re-read from the chain by `./scripts/verify-deployment.sh`.
-
-#### The settlements
-
-Sixteen settlements are recorded in [`artifacts/a2a-task.tsv`][a2a-task-tsv]
-and [`artifacts/shielded-settlement.tsv`][shielded-settlement-tsv];
-thirteen are under the shipped program, where the criterion asks for two. Each is
+The deployed program is `697746f5…cb5370bf`. A LEZ deploy hash is
+`SHA256(u32_le(len) ‖ bytecode)`, so `artifacts/programs/agent_verifier.bin` **is**
+its own deploy transaction — recompute it and compare, which `./scripts/demo.sh`
+does in front of you. The sixteen settlements are recorded in
+`artifacts/a2a-task.tsv` and `artifacts/shielded-settlement.tsv`; each is
 re-decoded from the chain's own copy of the transaction rather than from the
 manifest, by `./scripts/verify-deployment.sh`, which also labels the rows a
-redeploy orphaned instead of counting them.
-
-The one the video ends on:
-[`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115),
-block 10102 — the recipient goes 107 → 108 LEZ, and no owner signs anything.
-Every row, with its before/after balances and the program that owned the ledger
-it charged, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#the-settlements-in-full).
+redeploy orphaned instead of counting them. The one the video ends on is
+`54f85182…e2f47115`, block 10102 — the recipient goes 107 → 108 LEZ, and no owner
+signs anything.
 
 ## Approach
 
-### The spending limit is an account, not an `if`
+**The spending limit is an account, not an `if`.** A limit enforced inside the
+agent is enforced by whoever controls the agent's process — which, for an agent on
+a remote node holding its own key, is not necessarily the owner. So it is moved
+out of the process entirely. `create_policy` initialises exactly one account per
+agent and is `#[account(init, …)]`: the first anchor is the only anchor possible,
+not merely the only one detected. Only the program may write that account's data
+(LEZ rule 6), and `spend` derives the address from the *paying* account out of the
+pre-state, so there is no argument to lie about.
 
-A limit enforced inside the agent is enforced by whoever controls the agent's
-process — which, for an agent on a remote node holding its own key, is not
-necessarily the owner. So it is moved out of the process entirely.
-
-`create_policy` initialises exactly one account per agent, at
-`PDA(program, "agent-policy/v1", agent_id)`, and it is `#[account(init, …)]`:
-the first anchor for an agent is the only anchor possible, not merely the only
-one detected. Only the program may write that account's data (LEZ rule 6), and
-`spend` derives the address from the *paying* account out of the pre-state, so
-there is no argument to lie about. The full argument, with the refusal codes and
-the four deployments it took to get there, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#approach-the-spending-limit-at-length).
-
-### What was tried and did not work, and why Logos
-
-Four deployments were needed to get the anchoring right, and each earlier one was
-walked around by an attacker who was not lying — they really were the owner of
-the policy they anchored; they had simply never been asked whether the agent
-agreed. The full account, including the attack transaction that the superseded
-program accepted and the one today's program refuses, is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#approach-what-was-tried-and-why-logos).
-`./scripts/demo.sh` section 5 replays it against both programs in front of you.
+**What was tried and did not work.** Four deployments were needed to get the
+anchoring right, and each earlier one was walked around by an attacker who was not
+lying — they really were the owner of the policy they anchored; they had simply
+never been asked whether the agent agreed. `docs/criteria-evidence.md` carries the
+full account, including the attack transaction the superseded program accepted and
+the one today's program refuses, and `./scripts/demo.sh` section 5 replays it
+against both programs in front of you.
 
 ## Design Write-up
 
-The prize names seven topics. Each has a document in the repository that carries
-it at full length; what follows is the decision each one turns on, so this
-section reads in five minutes and the document is opened only where it matters.
+The prize names seven topics. Each has a document carrying it at full length; what
+follows is the decision each one turns on.
 
-**Module architecture** — [`docs/architecture.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/architecture.md).
-A Logos Core plugin exposing three skill categories, each a thin binding onto a
-real Logos node or onto LEZ. `invoke()` is the single dispatcher every capability
-sits behind, which is what lets a second Logos app drive the owner's end without
-the module exporting anything else. No skill links a library: each takes a struct
-of `std::function`s — `DeliveryPort`, `StoragePort`, `WalletPort`, `ProgramPort`
-— so every skill has a test against a fake port and there is one place where a
-real node is wired.
+**Module architecture** (`docs/architecture.md`) — a Logos Core plugin exposing
+three skill categories, each a thin binding onto a real Logos node or onto LEZ.
+`invoke()` is the single dispatcher every capability sits behind, which lets a
+second Logos app drive the owner's end without the module exporting anything else.
+No skill links a library: each takes a struct of `std::function` ports, so every
+skill has a test against a fake and there is one place where a real node is wired.
 
-**Skill interface design** — [`docs/skills.md`][skills-md].
-A skill is a class with `name()`, `parameterSchema()` and `invoke(json)`, added
-through `registerSkill` without touching the core module. Schemas are declared
-once and the Agent Card is generated from the registry rather than written by
-hand, so a card cannot advertise a skill the module does not have.
+**Skill interface design** (`docs/skills.md`) — a skill is a class with `name()`,
+`parameterSchema()` and `invoke(json)`, added through `registerSkill` without
+touching the core module. Schemas are declared once and the Agent Card is
+generated from the registry rather than written by hand, so a card cannot
+advertise a skill the module does not have.
 
-**Spending threshold mechanism** — [Approach](#approach) above has the argument;
-[`docs/security-model.md`][security-model-md] has the mechanism, the
-refusal codes, and what a holder of the agent's key can and cannot do.
+**Spending threshold mechanism** — Approach above has the argument;
+`docs/security-model.md` has the refusal codes and what a holder of the agent's
+key can and cannot do.
 
-**Agent-to-agent coordination protocol** — [`docs/a2a-binding.md`][a2a-binding-md].
-Agent Cards follow the A2A schema, tasks follow the A2A lifecycle, and Logos
-Messaging is the transport A2A leaves open. Payment is the part A2A omits: the
-client pays the price the card advertises, signed by the agent's own shielded
-account, with no owner in the loop.
+**Agent-to-agent coordination** (`docs/a2a-binding.md`) — Agent Cards follow the
+A2A schema, tasks follow the A2A lifecycle, and Logos Messaging is the transport
+A2A leaves open. Payment is the part A2A omits: the client pays the price the card
+advertises, signed by the agent's own shielded account, with no owner in the loop.
 
-**Security model** — [`docs/security-model.md`][security-model-md].
-Anchoring takes two signatures: the agent signs `claim_agent` to name the account
-that may bind it, and only that account is accepted by `create_policy`, which is
-`#[account(init, …)]` — so the first anchor is the only one possible, not merely
-the only one detected. What is *not* closed is enumerated there too: the balance
+**Security model** — what is *not* closed is enumerated alongside it: the balance
 is held by the transfer program, so the agent's key can move it by calling that
 program directly. This program bounds what the agent moves *through it*.
 
-**Known limitations** — [`docs/limitations.md`][limitations-md], where
-anything that does not work is written down first, with the retractions of claims
-that did not survive checking.
+**Known limitations** (`docs/limitations.md`) — anything that does not work is
+written down there first, with the retractions of claims that did not survive it.
 
-**Integration instructions** — [`docs/DEPLOYMENT.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/DEPLOYMENT.md) for
-the chain side, [`docs/basecamp.md`][basecamp-md] for loading the module
-into Logos Basecamp, including what a `.lgx` must satisfy to load at all.
+**Integration instructions** — `docs/DEPLOYMENT.md` for the chain side,
+`docs/basecamp.md` for loading into Logos Basecamp.
 
 ## Success Criteria Checklist
 
 Twenty-three criteria, mirrored from the prize in its own order and its own
-words. **Tally: 23 MET, 0 UNMET** — Functionality 11 of 11, Usability 2 of 2,
-Reliability 3 of 3, Performance 1 of 1, Supportability 6 of 6.
+words. **Tally: 23 MET, 0 UNMET.** Each entry gives the verdict and the one
+thing that re-derives it; the long form of every one — the controls, the
+transcripts, what was watched failing — is in `docs/criteria-evidence.md`.
 
-Each entry gives the verdict and the one thing that re-derives it. The long form
-of every one — the controls, the transcripts, what was watched failing — is in
-[`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md), copied there
-unchanged.
-
-**Functionality**
+### Functionality
 
 - [x] **MET — The agent module loads and runs inside Logos Core alongside the wallet, storage, and messaging modules without requiring modifications to those modules.**
-  All three companions are built from their published sources and all four modules load in one runtime, with both negative controls firing. Green on Linux in [run `32726762720`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726762720), which ran on the reviewed commit. [Evidence][criteria-evidence-md-functionality].
+  All three companions are built from their published sources and all four modules load in one runtime; transcript in `artifacts/e2e/exercise-nodes.txt`.
 
 - [x] **MET — The agent has its own shielded LEZ account and can send and receive tokens independently of the owner's wallet.**
-  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: [`5942d6cd…`](https://explorer.testnet.lez.logos.co/transaction/5942d6cd6d223fd5bc7b5abd3bf34a1c1fc8e540e508232411e60e4d53a03d61) pays it at its shielded keys. [Evidence][criteria-evidence-md-functionality].
+  *Send*: 13 settlements under the shipped program, each signed by the agent's own shielded account. *Receive*: the payee's balance moves on chain, 107 → 108 LEZ on the settlement the video ends on.
 
 - [x] **MET — The owner can deploy the agent and configure it with a single CLI command on any machine using Logos Core headless.**
-  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no Logos install. [Evidence][criteria-evidence-md-functionality].
+  `./scripts/deploy-and-configure.sh` — one command, deploy through configure, on a machine with no prior state.
 
 - [x] **MET — The owner can interact with the agent in real time from a separate Logos app instance using Logos Messaging, with no intermediary server.**
-  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging with no server between them. [Evidence][criteria-evidence-md-functionality].
+  Two LogosBasecamp processes, each with its own user dir and its own loaded copy, exchanging over Logos Messaging.
 
 - [x] **MET — The spending threshold mechanism correctly holds above-threshold transactions for owner approval and executes below-threshold transactions autonomously.**
-  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval the owner signed. Both halves are in the e2e run and in the video. [Evidence][criteria-evidence-md-functionality].
+  Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain (blocks 10776, 10786).
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in [`docs/skills.md`][skills-md], and `./scripts/check-docs.py` holds the catalogue to the registry rather than to prose. [Evidence][criteria-evidence-md-functionality].
+  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable.
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
-  Cards follow the A2A schema, tasks follow the A2A lifecycle, and the transport binding is specified in [`docs/a2a-binding.md`][a2a-binding-md]. [Evidence][criteria-evidence-md-functionality].
+  Cards follow the A2A schema, tasks follow the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
 
 - [x] **MET — Two or more agents can discover each other via Agent Cards, execute a task following the A2A lifecycle, and transfer LEZ payment autonomously, without owner intervention.**
-  `./scripts/delivery-in-plugin.sh settle` does all three in one invocation, and the settlement it produces is on chain with no owner signature. [Evidence][criteria-evidence-md-functionality].
+  `./scripts/delivery-in-plugin.sh settle` does discovery, task and settlement in one invocation — `ed8c3514…374b8cb3`, block 9477, from a module a host loaded.
 
 - [x] **MET — At least 3 of the illustrative use cases above are demonstrated end-to-end on LEZ testnet.**
-  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold. [Evidence][criteria-evidence-md-functionality].
+  Four run end to end in the recorded demo: marketplace, notary, event alerter, spending threshold.
 
 - [x] **MET — Three separate agents are deployed on LEZ testnet — one per default skill category (Storage, Messaging, and Blockchain) — each with a demonstrated, reproducible deployment and evidence provided.**
-  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; the three `create_policy` links are in [Summary](#summary). [Evidence][criteria-evidence-md-functionality].
+  Storage, messaging and blockchain, each with its own shielded account and its own anchored envelope; addresses and `create_policy` hashes in the table above.
 
 - [x] **MET — Full documentation — including the skill interface spec, deployment guide, and owner interaction guide — and a clean public repository are delivered.**
-  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents. Public, under MIT / Apache-2.0. [Evidence][criteria-evidence-md-functionality].
+  `./scripts/check-docs.py` resolves every path, link and citation across fifteen documents, and runs in CI.
 
-
-**Usability**
+### Usability
 
 - [x] **MET — Provide a documented skill interface (module/SDK) that can be used to add new skills without modifying the core agent module.**
-  `logos::agent::ISkill` plus `registerSkill()`, specified in [`docs/skills.md`][skills-md]; a new skill needs no change to the core module. [Evidence][criteria-evidence-md-usability].
+  `logos::agent::ISkill` plus `registerSkill()`, specified in `docs/skills.md`; a new skill touches no core file.
 
 - [x] **MET — The owner-facing interface is accessible from the Logos app (Basecamp) via the owner channel — local build instructions and loadable assets are provided.**
-  The owner console is a loadable `app/agent-ui.lgx` with local build instructions in [`docs/basecamp.md`][basecamp-md]. [Evidence][criteria-evidence-md-usability].
+  A loadable `app/agent-ui.lgx` with local build instructions in `docs/basecamp.md`, which also records what a `.lgx` must satisfy to load at all.
 
-
-**Reliability**
+### Reliability
 
 - [x] **MET — The agent module recovers from transient failures (network interruptions, node restarts) without losing pending task state.**
-  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task comes back. [Evidence][criteria-evidence-md-reliability].
+  `module/tests/module_recovery_test.cpp` destroys the module mid-task and rebuilds it over the same directory; the pending task survives.
 
 - [x] **MET — Above-threshold transactions that fail to reach the owner for approval are not executed — the agent retries notification before timing out and reports the failure.**
-  The agent retries the notification, times out rather than executing, and reports the failure — all three clauses demonstrated through Logos Core's own transport. [Evidence][criteria-evidence-md-reliability].
+  The agent retries the notification, times out rather than executing, and reports the failure.
 
 - [x] **MET — Skill failures are isolated: a failing skill does not crash the module or affect other concurrently running skills.**
-  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running. [Evidence][criteria-evidence-md-reliability].
+  `invoke()` catches everything a skill can throw, returns the failure as JSON naming the skill, and leaves concurrent skills running.
 
-
-**Performance**
+### Performance
 
 - [x] **MET — Document the compute unit (CU) cost of each on-chain operation the agent performs (token transfers, program calls, deployments) on LEZ devnet/testnet. Note: LEZ's per-transaction compute budget may change during testnet.**
-  [`docs/benchmarks/cu-budget.md`][cu-budget-md], which is candid about the premise: LEZ v0.2.4 does not meter compute units, and the search establishing that is in the file. [Evidence](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#performance).
+  `docs/benchmarks/cu-budget.md`, candid about its premise: LEZ v0.2.4 does not meter compute units, and the document shows the search establishing that rather than inventing a number. What is measured instead is what actually costs — a `claim_agent` proof at ~54 min on a four-core runner, `create_policy` at about one block.
 
-
-**Supportability**
+### Supportability
 
 - [x] **MET — The agent module is deployed and tested on LEZ devnet/testnet.**
-  Deployed at [`697746f5…`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf) and re-read from the chain by `./scripts/verify-deployment.sh`. [Evidence][criteria-evidence-md-supportability].
+  Deployed at `697746f5…cb5370bf`; `./scripts/verify-deployment.sh` re-reads every agent, policy and settlement from the chain.
 
 - [x] **MET — End-to-end integration tests run against a LEZ sequencer (standalone mode) and are included in CI.**
-  [Run `32726759802`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726759802) — **success, 3 h 18, on the reviewed commit**, `RISC0_DEV_MODE: 0`, no skip path: it refuses a runner it cannot finish on rather than skipping the proving. The same lifecycle also ran green in 3 h 06 as [run `32669505555`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32669505555) on [`708b2ce`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/708b2cea8401ef3a2a179baf4d2aabeddefac59f): `git diff 708b2ce..e1c57ba` touches only `docs/recording-evidence.md`, `recordings/lp8-demo.srt` and `scripts/check-transcript.py`, so both runs drove an identical script against identical binaries. Two independent measurements, not one. [Evidence][criteria-evidence-md-supportability].
+  `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path, run `32726759802`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main`, and on the reviewed commit specifically: [run `32726730085`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/32726730085). The badge is not the check, a run id is. [Evidence][criteria-evidence-md-supportability].
+  Green on `main` and on the reviewed commit specifically, run `32726730085`.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
-  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one. [Evidence][criteria-evidence-md-supportability].
+  `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.
 
 - [x] **MET — A reproducible end-to-end demo script is provided and works against a real local sequencer with `RISC0_DEV_MODE=0`.**
-  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes. [Evidence][criteria-evidence-md-supportability].
+  `scripts/e2e-local-sequencer.sh`, which is what the CI run above executes.
 
 - [x] **MET — A recorded video demo of the end-to-end flow is included in the submission; the recording must show terminal output (including proof generation) to confirm `RISC0_DEV_MODE=0` was active.**
-  <https://youtu.be/5HF0xv6GX64> — one narrated walkthrough, 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout, four use cases. [Evidence][criteria-evidence-md-supportability].
-
+  <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, public testnet, `RISC0_DEV_MODE=0` legible throughout the proving output; `./scripts/check-video.py` reads that off the pixels rather than describing it. See Supporting Materials.
 ## FURPS Self-Assessment
 
 ### Functionality
 
-The agent holds a shielded LEZ account, signs its own
-transactions, and spends under a ceiling the chain keeps in state only its own
-program may write. It can also be *paid* at that account, by the keys its signed
-card publishes rather than by an id, so a settlement can hide both ends. Every
-default skill is implemented and registered, and the registry is asserted against
-the loaded binary rather than the source, because this repository has shipped
-skills that were implemented, documented and unreachable. A2A discovery, the task
-lifecycle and settlement are one call rather than three.
+The agent holds a shielded LEZ account, signs its own transactions, and spends
+under a ceiling the chain keeps in state only its own program may write. It can
+also be *paid* at that account, by the keys its signed card publishes rather than
+by an id, so a settlement can hide both ends. Every default skill is implemented
+and registered, and the registry is asserted against the loaded binary rather than
+the source, because this repository has shipped skills that were implemented,
+documented and unreachable. A2A discovery, the task lifecycle and settlement are
+one call rather than three.
 
 ### Usability
 
-A new skill is a class with three methods and a `registerSkill`
-call; the core module is not touched. The owner's end is three registered skills
-behind `invoke()`, which is why a second Logos app can drive it with nothing else
+A new skill is a class with three methods and a `registerSkill` call; the core
+module is not touched. The owner's end is three registered skills behind
+`invoke()`, which is why a second Logos app can drive it with nothing else
 exported. One command deploys and configures.
 
 ### Reliability
 
-Pending task state survives the module being destroyed and
-rebuilt over the same directory. An above-threshold payment whose approval never
-reaches the owner is not executed — it retries, times out and reports. A skill
-that throws is caught, named, and does not take the module or a concurrent skill
-with it.
+Pending task state survives the module being destroyed and rebuilt over the same
+directory. An above-threshold payment whose approval never reaches the owner is
+not executed — it retries, times out and reports. A skill that throws is caught,
+named, and does not take the module or a concurrent skill with it.
 
 ### Performance
 
-LEZ v0.2.4 does not meter compute units, and
-[`docs/benchmarks/cu-budget.md`][cu-budget-md] says so with the
-search that establishes it, rather than inventing a number. What is measured
-instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
+LEZ v0.2.4 does not meter compute units, and `docs/benchmarks/cu-budget.md` says
+so with the search that establishes it, rather than inventing a number. What is
+measured instead is what actually costs: a `claim_agent` proof at ~54 minutes on a
 four-core runner, `create_policy` at about one block.
 
 ### Supportability
 
-Ten jobs on every push, an end-to-end run against a real
-standalone sequencer with `RISC0_DEV_MODE=0` and no skip path, and gates that
-hold the documents to the code — `check-docs.py` resolves every path and citation
-across fifteen documents, `check-package-fresh.py` refuses a package whose binary
-has lost a source literal, `write-program-record.py` refuses a source that has
-moved under the deployed program.
+Ten jobs on every push, an end-to-end run against a real standalone sequencer with
+`RISC0_DEV_MODE=0` and no skip path, and gates that hold the documents to the code
+— `check-docs.py` resolves every path and citation across fifteen documents,
+`check-package-fresh.py` refuses a package whose binary has lost a source literal,
+`write-program-record.py` refuses a source that has moved under the deployed
+program.
 
-**What is weakest, stated here rather than found later.** The three agents
-published here can never have an above-threshold spend approved — their owners
-anchored while unclaimed, which is irreversible for them; the path itself works
-and has run on chain against a fourth agent, and the ordering requirement it
-implies is written up in full. An inbound A2A request is not dispatched to the
-skill it names. The storage skills
-have never driven a live node from inside the module. No model has run against
-the inference port. Each is expanded in
-[`docs/limitations.md`][limitations-md].
+**What is weakest** is the list at the end of [Summary](#summary), stated there
+rather than left to be found — and expanded in `docs/limitations.md`, where
+anything that does not work is written down before anything that does.
 
 ## Supporting Materials
 
-- **Video demo:** **<https://youtu.be/5HF0xv6GX64>** — one narrated walkthrough, 21 m 57 s,
-  four illustrative use cases, against the public testnet at
-  `https://testnet.lez.logos.co` and never a localnet, with `RISC0_DEV_MODE=0`
-  legible throughout the proving output. The same file is a release asset of this
-  repository, [`lp8-demo.mp4`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/releases/download/demo-v1/lp8-demo.mp4), so the
-  evidence does not depend on a third party keeping it up.
-  `./scripts/check-video.py` reads the terminal text off the pixels and asserts
-  all of that rather than describing it.
-- **The demo as text, and a check that it is this film's:**
-  [`recordings/lp8-demo.srt`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/recordings/lp8-demo.srt) — 298 cues, 2,784
-  words, the narration as spoken, so twenty-two minutes can be read and grepped
-  instead of watched. `./scripts/check-transcript.py` ties it to the film: cues
-  ordered and non-overlapping, the last landing inside the film rather than 577 s
-  short of it, and four anchors requiring the picture to show what the narration
-  is talking about at the second it says it — where the line is "that percentage
-  is r0vm", the frame there must show the prover's output. The narration is
-  spoken and never on screen, so those anchors are the part a plausible file
-  written from memory could not satisfy. It refuses to pass on structure alone:
-  a transcript with no anchors defined is rejected, and fewer than two tested
-  anchors is a failure — a rule that exists because the first version of this
-  check reported "anchor not testable" four times and then printed "transcript
-  matches the film". Mutation-tested three ways, all caught.
-  [`docs/recording-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/recording-evidence.md) carries both
-  checks' measured output and ends with what they do **not** establish: not every
-  frame, not the wording against the audio, and one OCR behaviour routed around
-  rather than diagnosed.
-- **Reproduce from a clean clone, no keys and no funds:** `./scripts/demo.sh` ·
-  `./scripts/verify-deployment.sh` · `./scripts/check-docs.py`
+- **Video demo:** <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, four illustrative
+  use cases, against the public testnet and never a localnet, `RISC0_DEV_MODE=0`
+  legible throughout the proving output. The same file is a release asset
+  (`lp8-demo.mp4`), so the evidence does not depend on a third party keeping it up.
+- **The demo as text, checked against the film:** `recordings/lp8-demo.srt` is the
+  narration as spoken, so twenty-two minutes can be read and grepped instead of
+  watched. `./scripts/check-transcript.py` ties it to the picture: four anchors
+  require the frame to show what the narration names at the second it says it —
+  where the line is "that percentage is r0vm", the frame there must show the
+  prover's output. The narration is spoken and never on screen, so those anchors
+  are the part a plausible file written from memory could not satisfy. It refuses
+  to pass on structure alone, because its first version reported "anchor not
+  testable" four times and then printed "transcript matches the film".
+  Mutation-tested three ways, all caught; `docs/recording-evidence.md` carries the
+  measured output and what it does **not** establish.
 - **Reproduce the deployment and the settlements** (needs a funded testnet
   signer): `./scripts/deploy-agents.sh` · `./scripts/a2a-task.sh` ·
-  `./scripts/e2e-local-sequencer.sh` · `./scripts/delivery-in-plugin.sh settle`
-- **On-chain evidence:** every hash, block and explorer link is in
-  [Repository](#repository), generated rather than transcribed, and deliberately
-  not repeated here. Manifests, read **by column name**:
-  [`agents.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/agents.tsv) ·
-  [`anchored.tsv`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/anchored.tsv) ·
-  [`a2a-task.tsv`][a2a-task-tsv] ·
-  [`shielded-settlement.tsv`][shielded-settlement-tsv]
-- **Documentation:** [`docs/`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/e1c57bab5c12f783429debd735579002e2d3fcb1/docs) — architecture, skills,
-  security model, A2A binding, deployment, Basecamp loading, CU budget, and
-  [`limitations.md`][limitations-md], which is where anything
-  that does not work is written down first.
+  `./scripts/e2e-local-sequencer.sh` · `./scripts/delivery-in-plugin.sh settle`.
+  The four commands that need no key are in [Repository](#repository); the
+  manifests they read by column name are `artifacts/{agents,anchored,a2a-task,shielded-settlement}.tsv`.
 
 ## Terms & Conditions
 
 By submitting this solution, I confirm that I have read and agree to the
 [Terms & Conditions](../TERMS.md).
-
-[a2a-binding-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/a2a-binding.md
-[a2a-task-tsv]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/a2a-task.tsv
-[basecamp-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/basecamp.md
-[criteria-evidence-md-functionality]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#functionality
-[criteria-evidence-md-reliability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#reliability
-[criteria-evidence-md-supportability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#supportability
-[criteria-evidence-md-usability]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/criteria-evidence.md#usability
-[cu-budget-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/benchmarks/cu-budget.md
-[limitations-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/limitations.md
-[security-model-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/security-model.md
-[shielded-settlement-tsv]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/artifacts/shielded-settlement.tsv
-[skills-md]: https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/e1c57bab5c12f783429debd735579002e2d3fcb1/docs/skills.md

--- a/solutions/LP-0008.md
+++ b/solutions/LP-0008.md
@@ -70,7 +70,7 @@ Expanded in `docs/limitations.md`:
 
 - **Repo:** <https://github.com/edenbd1/lp-0008-autonomous-agent-module> — dual MIT / Apache-2.0
 - **Reviewed commit:**
-  [`d157b47`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/d157b4748f10f3148667ec39b04091af1e7c3cf5).
+  [`42b922f`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/tree/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83).
   Every path below is relative to it. Read them at that tree rather than at
   `main`: `main` moves, and a path that has moved with it is no longer the file
   this document describes.
@@ -225,7 +225,7 @@ of every entry, including the controls and what was watched failing, is in
   Below the ceiling executes unattended; above it refuses with `Program error 6005` and needs an approval. Both paths ran on chain: [`approve_spend`](https://explorer.testnet.lez.logos.co/transaction/4104dde4f504d42862ac89056e2476c414c4342dc145934c8a238382863841d8) at block 10776 and [`spend_approved`](https://explorer.testnet.lez.logos.co/transaction/c243eaedfcbba87dc11d5ad28aad4f8424916d087adf8c811747169668169597) at block 10786, the payee going 4 → 6.
 
 - [x] **MET — All default skills listed above are implemented and documented.**
-  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. `messaging.join` subscribes the topic `messaging.create_group` opens, and a unit test asserts the two meet — it did not until recently, and `docs/limitations.md` keeps the whole record of that, including the assumption that kept it open longer than its cause: rebuilding the three-architecture package was believed impossible here and was not.
+  Every skill the prize lists is registered and documented in `docs/skills.md`, and the registry is asserted against the *loaded binary* rather than the source — this repository has shipped skills that were implemented, documented and unreachable. Two were brought to match the prize's wording rather than merely disclosed against it: `storage.upload` now **encrypts** the file before the node sees it and `storage.download` **decrypts** on the way back — SHA256-CTR with an HMAC-SHA256 tag in `module/src/vault_crypto.cpp`, its primitives carrying RFC known-answer tests and the round trip asserted in `skills_test.cpp`, so the content address names ciphertext and Logos Storage never holds the file; and `storage.list` returns the labels the agent recorded, which Storage keys-by-content has nowhere to keep. `messaging.join` subscribes the topic `messaging.create_group` opens, a unit test asserting the two meet. All three moved compiled code, so the three-architecture package was rebuilt and its digests re-recorded — `check-package-fresh.py`, green in CI.
 
 - [x] **MET — Agent-to-agent coordination is A2A-compatible: Agent Cards follow the A2A schema, task interactions follow the A2A task lifecycle, and the implementation is documented as an A2A transport binding over Logos Messaging.**
   Cards follow the A2A schema, tasks follow the A2A lifecycle, and `docs/a2a-binding.md` specifies the transport binding A2A leaves open.
@@ -275,7 +275,7 @@ of every entry, including the controls and what was watched failing, is in
   `scripts/e2e-local-sequencer.sh` against a standalone sequencer with `RISC0_DEV_MODE=0`, no skip path: run `33093872580` on the reviewed commit, 3 h 16, of which 58 minutes are real `claim_agent` proving — its log prints `claim_agent: 0h58m04s`.
 
 - [x] **MET — CI must be green on the default branch.**
-  Green on `main` and on the reviewed commit specifically: run `33084399499`, the host suite, and `33084399822`, the explorer-link gate, both on `1956340`.
+  Green on `main` and on the reviewed commit specifically: run `33199329323`, the full CI suite — every skill compiled and exercised against fake ports including the encrypted storage round trip, the package freshness gate, and the SDK third-party-skill example — is green on the reviewed commit itself. Its head_sha is the reviewed commit.
 
 - [x] **MET — A README documents end-to-end usage: deployment steps, agent configuration, and step-by-step instructions for deploying and interacting with the agent via CLI and the Logos app owner channel.**
   `README.md` is a runnable walkthrough — every section is a command with its output, not a description of one.


### PR DESCRIPTION
An agent that participates in the Logos stack directly rather than through an API key: it holds its own shielded LEZ account, and the ceiling on what it may spend is not a check inside the agent process but **state on chain that the agent's own program is the only thing permitted to write**. An agent whose process has been taken cannot raise its own ceiling — there is no second address to anchor a larger one at, and the write itself is refused.

## The exact version under review

Everything below is pinned to one commit. Nothing in this submission points at a
branch, so nothing under review can move after it is opened.

| | |
|---|---|
| **Repository** | https://github.com/edenbd1/lp-0008-autonomous-agent-module |
| **Reviewed commit** | [`42b922f`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/commit/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83) |
| **Basecamp modules** | [`module/agent.lgx`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83/module/agent.lgx) and [`app/agent-ui.lgx`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83/app/agent-ui.lgx) |
| **Demo video** | <https://youtu.be/5HF0xv6GX64> — 21 m 57 s, narrated. A 26-second cut of the settlement plays below. |
| **CI — host tests + deployed-binary audit** | [run 33084399499](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/33084399499) ✅ — 12 min, on `1956340` |
| **CI — full lifecycle vs a standalone LEZ sequencer** | [run 33093872580](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/33093872580) ✅ — 3 h 16 on `1956340`, `RISC0_DEV_MODE=0`, no skip path |
| **Solution file** | [`solutions/LP-0008.md`](https://github.com/logos-co/lambda-prize/pull/129/files) |
| **What does not work** | [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83/docs/limitations.md) |

## Verify it in five minutes

**1. Three agents anchored and live on the public testnet**, one per default skill category. Each `create_policy` on the block explorer:

| category | per-tx | per-period | `create_policy` |
|---|---|---|---|
| storage | 50 | 500 | [`6857ba23…631fe7d4`](https://explorer.testnet.lez.logos.co/transaction/6857ba2378a84ba51618582e852e3827a872e3ea85f17de76bdb45b1631fe7d4) · block 8868 |
| messaging | 25 | 250 | [`ce557a0a…278e1918`](https://explorer.testnet.lez.logos.co/transaction/ce557a0a8adc517b60496c35514e269fff92a4393b90bef41ce10916278e1918) · block 8876 |
| blockchain | 200 | 1,000 | [`2f6b481c…ecec5eda`](https://explorer.testnet.lez.logos.co/transaction/2f6b481cffde2adaeed9442c19599c939d97da0c930b70b45d97ac34ecec5eda) · block 8884 |

The deployed program itself: [`697746f5…cb5370bf`](https://explorer.testnet.lez.logos.co/transaction/697746f52ff24019dbde4861c3649f49426904617840139a5405aa24cb5370bf). A LEZ deploy hash is `SHA256(borsh(bytecode))`, so the committed `artifacts/programs/agent_verifier.bin` **is** its own deploy transaction — recompute it and compare.

**2. One agent paid another, unattended.** The settlement filmed for the video: [`54f85182…e2f47115`](https://explorer.testnet.lez.logos.co/transaction/54f851825f171cf62f6b4723f7133687f3d9dff7e138417374cc7960e2f47115), block 10102 — the recipient's balance goes 107 → 108 LEZ and no owner signs anything. Eleven more settlements under the shipped program are listed in the submission — twelve counting this one, thirteen with the shielded one, each re-decoded from the chain's own copy rather than from a cached file. Every transaction hash this submission cites resolves on `explorer.testnet.lez.logos.co`.

Twenty-six seconds of it, cut from the film above with its own narration and nothing re-recorded — the signature, taken from the agent's own wallet rather than the owner's, with the recipient's balance read *before* anything is signed; then the same balance read again after it lands:

https://github.com/user-attachments/assets/92bdf7c5-3c5d-48d9-93ba-6197dc5f5c6b

**3. A recorded demo — <https://youtu.be/5HF0xv6GX64>**, one narrated walkthrough, 21 m 57 s, **against the public testnet at `https://testnet.lez.logos.co`, never a localnet**. Three of the prize's illustrative use cases run in it — the agent services marketplace that settles the transaction above, the privacy-preserving notary, and the on-chain event alerter — and the narration names each by the prize's own numbering. The spending threshold and its refusal above the ceiling are filmed as well; that is a criterion of its own, not one of the nine, and the film says so on camera. The fourth use case this submission claims, the personal file vault, runs in `alongside-companion-modules.yml` rather than here, because as the prize words it that case has no chain step. `RISC0_DEV_MODE=0` is visible throughout the proving output; the multi-minute proof times are what real proving costs. The same file is a release asset of the repository, [`lp8-demo.mp4`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/releases/download/demo-v1/lp8-demo.mp4), so the evidence does not depend on a third party keeping it up.

**4. End-to-end against a LEZ standalone sequencer, green in CI, with no skip path:**

| workflow | run | |
|---|---|---|
| CI — host suite | [`33084399499`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/33084399499) | **success**, 12 min, on `1956340` |
| e2e vs local sequencer | [`33093872580`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/33093872580) | **success, 3 h 16** on `1956340` — builds LEZ at a pinned revision, installs `r0vm`, runs the full lifecycle with `RISC0_DEV_MODE: 0` |
| alongside the companion modules | [`33087503041`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/actions/runs/33087503041) | **success**, 7 min — all four modules in one Logos Core runtime on Linux, from published sources, both negative controls firing. Ran on `4d684c2` |

**None of these ran on the reviewed commit itself, and this names the commit
each did run on rather than leaving it to be found.** The host suite, e2e and
explorer-link runs are on `1956340`; the companion-modules run is on `4d684c2`.
Both are ancestors of the reviewed commit, and what lies between them and it is
documentation, the `messaging.join` source fix, the storage-skill encryption
(`vault_crypto.cpp` and the three rebuilt encrypting package variants), and the
rebuilt package — run `git diff 1956340 42b922f --stat` for the exact list. The 3 h 16 e2e run predates
that fix, which matters and does not: the fix touches `messaging_skills.cpp` and
its unit test, not the spending lifecycle the e2e proves, so the proving run
exercised exactly the code it is cited for. The fix itself is covered on the
reviewed commit — the per-push CI job that compiles and runs the skills test,
and `check-package-fresh.py` over the rebuilt three-architecture package, both on
the tree under review.

The e2e refuses a runner it cannot finish on rather than skipping the expensive step: a job that completes through a skip path is not a job that ran. Inside that run, `claim_agent` takes 58 minutes of real proving, and the lifecycle ends with a payment inside the envelope moving a balance `0 → 50` between two wallets, and a payment above the ceiling refused with `Program error 6005` leaving the balance untouched.

**5. From a clean clone, with nothing installed:**

```sh
git clone --depth 1 https://github.com/edenbd1/lp-0008-autonomous-agent-module
cd lp-0008-autonomous-agent-module
./scripts/demo.sh
```

**21 MiB over the network, 51 MiB on disk** — the two are different quantities and this line used to give the second as though it were the first, then gave the second in MiB while labelling it MB, which is the same mistake wearing the other unit. Re-measured today: 21.04 MiB received, 50.8 MiB written, or 53 MB if you want the decimal. (A full clone: 177.26 MiB received, 221.9 MiB written.) It needs a Rust toolchain, `python3` and `curl`, names any of them that are missing before it runs anything, and exports `RISC0_DEV_MODE=0` itself. No funded account, no keys, no local sequencer, no Logos install.

---

## Against the criteria

**23 of 23 met.** Functionality 11/11, Usability 2/2, Reliability 3/3, Performance 1/1, Supportability 6/6 — most boxes in [the checklist](https://github.com/logos-co/lambda-prize/pull/129/files) carry the command that re-derives them rather than a claim; six are about behaviour rather than an artefact, and for those the long form carries the transcript. The long form of every entry — the controls, the transcripts, what was watched failing — is in [`docs/criteria-evidence.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83/docs/criteria-evidence.md).

Nothing here is asserted that has not been reproduced. What does **not** work is written down in [`docs/limitations.md`](https://github.com/edenbd1/lp-0008-autonomous-agent-module/blob/42b922fa1cc18c3c8fe0884dbbde7e0ff35afa83/docs/limitations.md) rather than omitted — including that `getAccount` cannot see a private balance, that no model has been run against the inference port, and that the storage skills encrypt through `vault_crypto` and their sealed round trip is exercised in the per-push skills test, but the live-node upload/download path they also drive has no committed transcript of its own.

The repository holds gates rather than prose: `check-docs.py` resolves every path, link and `file:line` citation across fifteen documents; `check-package-fresh.py` refuses the shipped `.lgx` unless every source string literal is present in it; `verify-deployment.sh` re-reads the deployment off the chain; `check-video.py` reads the terminal text off the video's pixels and asserts the testnet is on screen and no loopback address is.

## Verified by execution before this was opened

Every line below was run against the public testnet or the shipped artefacts, and
the output read, rather than inferred from the code:

- **Three agents anchored.** Each `create_policy` live via `getTransaction`, each
  policy account re-read off the chain with the envelope it records, and the
  control hash `dedede…` returning null. `./scripts/verify-deployment.sh` exit 0.
- **Two agents paying each other, twice, with no owner in the path.** Three
  consecutive settlements decoded from the chain's own copy of each transaction —
  `hash_ok=1`, so the decoded bytes are that transaction — with the payee at
  106 → **107** → **108**, each credited by exactly the advertised price,
  143 blocks apart and then 21. The payer is shielded, so its debit is not publicly readable;
  what is, is the policy ledger going `spent 1` → `spent 2` in window 10000, in
  an account LEZ rule 6 lets only this program write. All three owners read
  `nonce 1` — one signed transaction each, the anchor, before any settlement.
- **Real nodes.** `./scripts/exercise-nodes.sh` exit 0, 18 assertions, 0
  failures: a Delivery node on the live network published a message the network
  propagated back, and a Storage node returned a content address whose manifest
  names the file that went in.
- **The end-to-end sequencer job**, green in CI at `RISC0_DEV_MODE: 0` with no
  skip path — `ci.yml` and the companion workflow contain no `if:` and no
  `continue-on-error` at all, and the e2e workflow uses `if:` once, on the step
  that runs only when there is a failure to explain.
- **The video**, checked frame by frame: 21 m 57 s, both public testnet domains
  on screen, `RISC0_DEV_MODE=0` legible, none of the five forbidden strings in
  any sampled frame, four use cases identified by the section titles they print.
- **The module in Logos Core**, headless against LogosBasecamp 0.2.2: exit 0,
  40 assertions, 28 skills each carrying a parameter schema.

## Terms & Conditions

By submitting this solution, I confirm that I have read and agree to the [Terms & Conditions](https://github.com/logos-co/lambda-prize/blob/master/TERMS.md).

Happy to address anything in review.




