### PR TITLE
Split prize index into adoption-first vs legacy schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Solutions live in the `[solutions/](solutions/)` directory. To submit a solution
 2. Fill in the solution template: describe your approach, link to the repository containing the implementation, and attach any supporting materials. The implementation must be dual licensed under the MIT License **and** Apache License 2.0.
 3. Open a pull request titled `Solution: LP-XXXX — <Short Description>`.
 
-For **adoption-first** prizes, the solution PR should include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
+To meet **adoption-first** criteria, the solution PR should include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
 
 If multiple solutions target the same prize, the first submission that satisfies all success criteria wins unless specified otherwise. For **adoption-first** prizes that includes the Adoption criteria. A solution PR is timestamped by its opening date.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Build something useful on the Logos stack, share it, and let other builders pick
 
 ### Where do I share my work before I hit the adoption?
 
-This repository is the place you claim a prize, not a showcase while you are still building or trying to get users/integrations. **Discord is currently the main community hub.** Share what you are building towards a λPrize there, look for collaborators and people who might use it, and follow other builders in **#builder-hub**. Additional discovery platforms may be introduced in the future, but for now, make sure to participate actively on Discord. Being engaged in the community and becoming a trusted resource for others is also an important part of what this program indirectly funds.
+This repository is the place you claim a prize, not a showcase while you are still building or trying to get users/integrations. **Discord is currently the main community hub.** Share what you are building towards a λPrize there, look for collaborators and people who might use it, and follow other builders in **#builder-hub**. The [Logos Forum](https://forum.logos.co/) is another community space for longer-form discussion. Additional discovery platforms may be introduced in the future, but for now, make sure to participate actively on Discord. Being engaged in the community and becoming a trusted resource for others is also an important part of what this program indirectly funds.
 
 ### Should I chase the adoption criteria as soon as the code works?
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Prizes can currently only be proposed by Logos CCs. A separate process for sourc
 2. Fill in all sections except **Prize Structure** (prize pool, revision date) — these are determined by the Logos team.
 3. Open a pull request titled `LP-XXXX: <Prize Title>`.
 
-Evaluation is first-come-first-served: the first submission that meets all success criteria wins. For **adoption-first** prizes that includes the **Adoption** criteria; the first to meet them and submit the solution (with supporting evidence) wins. Single winner unless otherwise specified in the prize.
+Evaluation criteria are:
+- first-come-first-served: the first submission that meets all success criteria wins.
+- **adoption-first** as listed in **Adoption** section of a prize.
+
+The first to meet them and submit the solution (with supporting evidence) wins. Single winner unless otherwise specified in the prize.
 
 ### Submitting a Solution
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,28 @@ Together these form a unified, modular ecosystem, accessible through **Logos Cor
 
 All prizes live in the `[prizes/](prizes/)` directory. Each prize is a markdown file following the `LP-XXXX` naming convention.
 
+λPrize is moving from its original **build-and-review** model to an **adoption-first** model. Which scheme a prize follows is shown in the tables below.
+
+- **Adoption-first prizes** are graded on a functionality gate **plus** adoption criteria (real third-party usage, on-chain coverage or activity, and human/social validation where the prize lists it). Manual code review is not the primary gate. See each prize's **Adoption** section for the dimensions we look at.
+- **Legacy prizes** follow the original first-come-first-served, manual-review model. The remaining live legacy prizes are being wound down (see below).
+
+### Adoption-first prizes (current scheme)
+
+| File | Description | Size | Status |
+|------|-------------|------|--------|
+| [LP-0000](prizes/LP-0000.md) | Template — use this as the starting point for new prizes | — | — |
+
+### Legacy prizes (original scheme)
 
 | File                         | Description                                              | Size   | Status                       |
 |------------------------------|----------------------------------------------------------|--------|------------------------------|
 | [LP-0000](prizes/LP-0000.md) | Template — use this as the starting point for new prizes | —      | —                            |
 | [LP-0001](prizes/LP-0001.md) | Private NFT Ownership Proof                              | Medium | Draft                        |
-| [LP-0002](prizes/LP-0002.md) | Private M-of-N Multisig                                  | Large  | Open                         |
-| [LP-0003](prizes/LP-0003.md) | Private Allowlist / Airdrop Distributor                  | Medium | Open                         |
+| [LP-0002](prizes/LP-0002.md) | Private M-of-N Multisig                                  | Large  | Open (closes 11 Sep 2026, 23:59 CEST) |
+| [LP-0003](prizes/LP-0003.md) | Private Allowlist / Airdrop Distributor                  | Medium | Open (closes 11 Sep 2026, 23:59 CEST) |
 | [LP-0004](prizes/LP-0004.md) | Sealed-Bid Auction Using Shielded Balances               | Large  | Draft                        |
-| [LP-0005](prizes/LP-0005.md) | Private Token Balance Attestation                        | Large  | Closed ([Solution](solutions/LP-0005.md) |
-| [LP-0008](prizes/LP-0008.md) | Autonomous AI Module with Wallet, Storage, and Messaging | Large  | Open                         |
+| [LP-0005](prizes/LP-0005.md) | Private Token Balance Attestation                        | Large  | Closed ([Solution](solutions/LP-0005.md)) |
+| [LP-0008](prizes/LP-0008.md) | Autonomous AI Module with Wallet, Storage, and Messaging | Large  | Open (closes 11 Sep 2026, 23:59 CEST) |
 | [LP-0009](prizes/LP-0009.md) | Keycard NIP-46 Nostr Signer Proxy                        | Small  | Closed ([Solution](solutions/LP-0009.md)) |
 | [LP-0010](prizes/LP-0010.md) | Shell dApp Integration Proof of Concept                  | Small  | Closed ([Solution](solutions/LP-0010.md)) |
 | [LP-0011](prizes/LP-0011.md) | Program development tooling: Rust SDK                    | Medium | Draft                        |
@@ -41,6 +53,9 @@ All prizes live in the `[prizes/](prizes/)` directory. Each prize is a markdown 
 | [LP-0016](prizes/LP-0016.md) | Anonymous Forum with Threshold Moderation                | Large  | Closed ([Solution](solutions/LP-0016.md)) |
 | [LP-0017](prizes/LP-0017.md) | Whistleblower: document upload and indexing Basecamp app     | Medium | Closed ([Solution](solutions/LP-0017.md)) |
 
+> [!IMPORTANT]
+> **Legacy scheme wind-down.** To make room for adoption-first prizes, **LP-0002**, **LP-0003**, and **LP-0008** close on **11 September 2026 at 23:59 CEST**. No new submissions will be accepted after that time. If you have already submitted a solution, yours will be reviewed first. In-flight submissions received before the deadline will still be evaluated. Prizes already marked *Closed* are unaffected. 
+
 ### Proposing a New Prize
 
 Prizes can currently only be proposed by Logos CCs. A separate process for sourcing ideas from the wider community is planned.
@@ -49,7 +64,7 @@ Prizes can currently only be proposed by Logos CCs. A separate process for sourc
 2. Fill in all sections except **Prize Structure** (prize pool, revision date) — these are determined by the Logos team.
 3. Open a pull request titled `LP-XXXX: <Prize Title>`.
 
-Evaluation is first-come-first-served by default: the first submission that meets all success criteria wins. Single winner unless otherwise specified in the prize.
+Evaluation is first-come-first-served: the first submission that meets all success criteria wins. For **adoption-first** prizes that includes the **Adoption** criteria; the first to meet them and submit the solution (with supporting evidence) wins. Single winner unless otherwise specified in the prize.
 
 ### Submitting a Solution
 
@@ -59,24 +74,19 @@ Solutions live in the `[solutions/](solutions/)` directory. To submit a solution
 2. Fill in the solution template: describe your approach, link to the repository containing the implementation, and attach any supporting materials.
 3. Open a pull request titled `Solution: LP-XXXX — <Short Description>`.
 
-If multiple solutions target the same prize, the first submission that satisfies all success criteria wins unless specified otherwise. A solution PR is timestamped by its opening date.
+For **adoption-first** prizes, the solution PR should include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
 
-> [!IMPORTANT]
-> **Parallel Society Launch Event**
->
-> **λ**Prize launched at **Parallel Society**, a Logos-run event in Lisbon on **6–7 March 2026**, via a dedicated hackathon platform. Submissions for LP-0013 and LP-0014 were received during the event.
->
-> Submissions through this repository are now open and follow the standard first-come-first-served process. However, Parallel Society submissions that are still being evaluated take precedence.
+If multiple solutions target the same prize, the first submission that satisfies all success criteria wins unless specified otherwise. For **adoption-first** prizes that includes the Adoption criteria. A solution PR is timestamped by its opening date.
 
 ### Evaluation Policies
 
-The following policies apply to **all** prizes unless a specific prize states otherwise.
+The following policies apply to **all** prizes unless a specific prize states otherwise. **Adoption-first** prizes are also evaluated against their **Adoption** section. Authors are expected to include evidence and supporting data for those criteria in the solution PR.
 
 **Submissions.** Each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 
-**Feedback.** Initial evaluation feedback is limited to a simple pass/fail result based on the success criteria. For more detailed guidance or technical discussion, builders are encouraged to participate in the community Discord. The #builder-hub channel is the best place to ask questions and engage with evaluators or other builders.
+**Feedback.** Initial evaluation feedback is limited to a simple pass/fail result based on the success criteria, and on the **Adoption** section for adoption-first prizes. For more detailed guidance or technical discussion, builders are encouraged to participate in the community Discord. The #builder-hub channel is the best place to ask questions and engage with evaluators or other builders.
 
-**Demo requirements.** Every submission that requires a demo must include a narrated video walkthrough in which the builder explains what they built and why, walks through the architecture and key implementation decisions, and demonstrates the full end-to-end flow. A silent screencast without explanation is not sufficient. Prize-specific demo content is listed in each prize's **Submission Requirements**.
+**Demo requirements.** For **legacy** prizes, every submission that requires a demo must include a narrated video walkthrough in which the builder explains what they built and why, walks through the architecture and key implementation decisions, and demonstrates the full end-to-end flow. A silent screencast without explanation is not sufficient. Prize-specific demo content is listed in each prize's **Submission Requirements**. For **adoption-first** prizes, a narrated demo is optional unless the prize's Submission Requirements say otherwise.
 
 ## Claiming payment
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All prizes live in the `[prizes/](prizes/)` directory. Each prize is a markdown 
 
 λPrize is moving from its original **build-and-review** model to an **adoption-first** model. Which scheme a prize follows is shown in the tables below.
 
-- **Adoption-first prizes** are graded on a functionality gate **plus** adoption criteria (real third-party usage, on-chain coverage or activity, and human/social validation where the prize lists it). Manual code review is not the primary gate. See each prize's **Adoption** section for the dimensions we look at.
+- **Adoption-first prizes** are graded on a functionality gate **plus** adoption criteria (real third-party usage, on-chain coverage or activity, and human/social validation where the prize lists it). Manual code review is not the primary gate. See each prize's **Adoption** section for the dimensions we look at. See FAQ below for more details.
 - **Legacy prizes** follow the original first-come-first-served, manual-review model. The remaining live legacy prizes are being wound down (see below).
 
 ### Adoption-first prizes (current scheme)
@@ -91,6 +91,26 @@ The following policies apply to **all** prizes unless a specific prize states ot
 **Feedback.** Initial evaluation feedback is limited to a simple pass/fail result based on the success criteria, and on the **Adoption** section for adoption-first prizes. For more detailed guidance or technical discussion, builders are encouraged to participate in the community Discord. The #builder-hub channel is the best place to ask questions and engage with evaluators or other builders.
 
 **Demo requirements.** For **legacy** prizes, every submission that requires a demo must include a narrated video walkthrough in which the builder explains what they built and why, walks through the architecture and key implementation decisions, and demonstrates the full end-to-end flow. A silent screencast without explanation is not sufficient. Prize-specific demo content is listed in each prize's **Submission Requirements**. For **adoption-first** prizes, a narrated demo is optional unless the prize's Submission Requirements say otherwise.
+
+## FAQ
+
+This FAQ covers the current Lambda Prize (LP) scheme that includes adoption-based criteria.
+
+### How is this meant to work?
+
+Build something useful on the Logos stack, share it, and let other builders pick it up if it helps them. When that usage is real — independent modules, on-chain activity, or whatever the prize lists — open a **solution PR** with evidence. Remember that meeting a number without a solution PR in this repository does not establish priority.
+
+### Where do I share my work before I hit the adoption?
+
+This repository is the place you claim a prize, not a showcase while you are still building or trying to get users/integrations. **Discord is currently the main community hub.** Share what you are building towards a λPrize there, look for collaborators and people who might use it, and follow other builders in **#builder-hub**. Additional discovery platforms may be introduced in the future, but for now, make sure to participate actively on Discord. Being engaged in the community and becoming a trusted resource for others is also an important part of what this program indirectly funds.
+
+### Should I chase the adoption criteria as soon as the code works?
+
+The criteria describe what a useful piece of infrastructure looks like once the ecosystem has had time to grow around it. If the work is good, other teams will use it as the stack and the community mature. Be prepared to support others in using your project and to incorporate their feedback. Whether that takes a couple of weeks or longer is fine. 
+
+### Can I build in public? What if someone copies my work?
+
+Building in public is expected. We expect original, fair participation: taking someone else's in-progress challenge, rebranding it, and claiming the prize on the back of their work is not how this is meant to work. Logos has sole discretion over evaluation and awards.
 
 ## Claiming payment
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Prizes can currently only be proposed by Logos CCs. A separate process for sourc
 3. Open a pull request titled `LP-XXXX: <Prize Title>`.
 
 Evaluation criteria are:
-- first-come-first-served: the first submission that meets all success criteria wins.
+- first-come-first-served: the first **solution PR** that meets all success criteria wins.
 - **adoption-first** as listed in **Adoption** section of a prize.
 
-The first to meet them and submit the solution (with supporting evidence) wins. Single winner unless otherwise specified in the prize.
+The first to meet them and open a solution PR (with supporting evidence) wins. Meeting the criteria without a solution PR in this repository does not establish priority. Single winner unless otherwise specified in the prize.
 
 ### Submitting a Solution
 
@@ -78,15 +78,15 @@ Solutions live in the `[solutions/](solutions/)` directory. To submit a solution
 2. Fill in the solution template: describe your approach, link to the repository containing the implementation, and attach any supporting materials. The implementation must be dual licensed under the MIT License **and** Apache License 2.0.
 3. Open a pull request titled `Solution: LP-XXXX — <Short Description>`.
 
-To meet **adoption-first** criteria, the solution PR should include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
+To meet **adoption-first** criteria, the solution PR must include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
 
-If multiple solutions target the same prize, the first submission that satisfies all success criteria wins unless specified otherwise. For **adoption-first** prizes that includes the Adoption criteria. A solution PR is timestamped by its opening date.
+A solution PR in this repository is required to claim any prize, including **adoption-first** prizes. If multiple solutions target the same prize, the first solution PR that satisfies all success criteria wins unless specified otherwise. For **adoption-first** prizes that includes the Adoption criteria. Meeting the criteria without a solution PR does not establish priority. A solution PR is timestamped by its opening date.
 
 ### Evaluation Policies
 
 The following policies apply to **all** prizes unless a specific prize states otherwise. **Adoption-first** prizes are also evaluated against their **Adoption** section. Authors are expected to include evidence and supporting data for those criteria in the solution PR.
 
-**Submissions.** Each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
+**Submissions.** A solution PR in this repository is required to claim any prize. Each builder (or team) is allowed a maximum of **3 submissions** per prize, with at most **one submission/review per week**.
 
 **Feedback.** Initial evaluation feedback is limited to a simple pass/fail result based on the success criteria, and on the **Adoption** section for adoption-first prizes. For more detailed guidance or technical discussion, builders are encouraged to participate in the community Discord. The #builder-hub channel is the best place to ask questions and engage with evaluators or other builders.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Evaluation is first-come-first-served: the first submission that meets all succe
 Solutions live in the `[solutions/](solutions/)` directory. To submit a solution:
 
 1. Create a markdown file in `solutions/` matching the prize identifier — e.g., `solutions/LP-0001.md` for prize `LP-0001`.
-2. Fill in the solution template: describe your approach, link to the repository containing the implementation, and attach any supporting materials.
+2. Fill in the solution template: describe your approach, link to the repository containing the implementation, and attach any supporting materials. The implementation must be dual licensed under the MIT License **and** Apache License 2.0.
 3. Open a pull request titled `Solution: LP-XXXX — <Short Description>`.
 
 For **adoption-first** prizes, the solution PR should include evidence and supporting data for each required adoption criterion (for example links to independent modules, on-chain entries, and anything else the prize lists). Evaluators will not take a headline number on trust.
@@ -106,7 +106,7 @@ If **privacy** is a concern, we recommend using a **single-use Ethereum address*
 
 All participants are bound by the [Terms & Conditions](TERMS.md). Key points:
 
-- Submissions must be licensed under MIT or Apache 2.0.
+- Submissions must be dual licensed under the MIT License and Apache License 2.0.
 - One submission per prize per participant/team.
 - Logos retains sole discretion over evaluation and prize awards.
 - Submissions are public and non-confidential.


### PR DESCRIPTION
## Summary

- Splits the README prize index into **adoption-first** (current scheme) and **legacy** (original FCFS / manual-review) tables.
- Remaining live legacy prizes **LP-0002**, **LP-0003**, and **LP-0008** close on **11 September 2026 at 23:59 CEST**. Already-submitted solutions are reviewed first; in-flight submissions before the deadline are still evaluated.
- Adoption-first prizes stay first-come-first-served: the first solution that meets FURPS **and** Adoption (with evidence in the solution PR) wins. Narrated demos are required for legacy prizes; optional for adoption-first unless the prize says otherwise.
- Removes the Parallel Society launch box. LP-0000 is listed in both tables as the template placeholder until the first adoption-first prize lands.

## TERMS.md (follow-up)

This PR does **not** change [TERMS.md](TERMS.md). Two mismatches with the README should be addressed in a later TERMS update (legal pass):

- **§5.3** still requires a recorded demo / walkthrough video for every submission. README now makes narrated demos **optional** for adoption-first prizes unless the prize specification requires one.
- **§5.1** still says one submission per prize; README evaluation policy allows a maximum of **3 submissions** per prize (pre-existing mismatch, not introduced here).

§5.2 still describes the Parallel Society event deadline; that can be cleaned up in the same TERMS pass.

