### PR TITLE
Update Terms & Conditions and add specification disclaimer

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -1,218 +1,236 @@
-# Logos Lambda Prize Program – Terms & Conditions
+# λPrize Program – Terms & Conditions
 
-*Last updated: 17 July 2026*
+*Last updated: 27 August 2026*
 
-These Terms and Conditions ("Terms") are entered into by and between Logos Collective Association, Baarerstrasse 10, 6300 Zug, Switzerland ("Logos", "we", "us") and any individual or legal entity participating in the λ Prize Program, including by submitting any solution or pull request ("Submission") to the λ Prize GitHub repository ("you", "Participant") (each a "Party" and together the "Parties").
+These Terms and Conditions (“Terms”) are entered into by and between Logos Collective Association, Baarerstrasse 10, 6300 Zug, Switzerland (“Logos”, “we”, “us”) and any individual or legal entity participating in the λPrize Program, including by submitting any solution (“you”, “Participant”) (each a “Party” and together the “Parties”).
 
-By making a Submission to λ Prize through the relevant λ Prize GitHub repositories or relevant platform (and for the purposes of these Terms, it'll be referred to as λ Prize Github repository), you acknowledge that you have read, understood, and agree to be bound by these Terms and any applicable Prize specifications.
+By making a Submission as part of the λPrize Program, you acknowledge that you have read, understood, and agree to be bound by these Terms and any applicable Prize specifications (“Specifications”).
 
-You can contact us about these Terms in case you have any questions: [legal@free.technology](mailto:legal@free.technology).
+You can contact us about these Terms in case you have any questions: [ecosystem@logos.co](mailto:ecosystem@logos.co).
 
 ## 1. Lambda Prize Overview
 
-Logos supports the development and adoption of decentralised technologies and applications around the Logos technology stack and related ecosystem components through the λ Prize Program ("Program" or "λ Prize").
+This section sets out the nature of the λPrize Program and the Prizes and seeks to contextualise and provide Logos’ intention for the λPrize Program. All descriptions in this section are provided for context only and are further subject to the disclaimers and risk‑allocation provisions set out later in these Terms.
 
-The Program comprises multiple prizes (each a "Prize"), including but not limited to prizes described in the λ Prize GitHub repository. Each Prize is governed by a separate prize specification, which sets out the scope, requirements, success criteria, and prize amount applicable to that Prize.
+λPrize Program: Logos seeks to support and promote development on the Logos technology stack, which has been made available as open-source infrastructure for independent use by developers and the wider community. As such, Logos has developed the λPrize Program (“Program” or “λPrize”) is a voluntary, criteria-based, discretionary prize initiative where Participants may be awarded for independently developing and submitting innovative solutions that benefit the Logos ecosystem through reusable open-source work and credible “social-proof” of ecosystem progress.
 
-The Program is discretionary in nature. Logos retains sole and absolute discretion over the design of the Program, the content and nature of any prize specifications, the evaluation of submissions, the selection (or non‑selection) of winners, and the award or non‑award of any Prize. No Participant will have any entitlement to receive a Prize.
+Through the Program, participants may independently develop and submit innovative solutions for Artefacts that demonstrate the capabilities of the Logos technology stack and support its adoption.
+
+Logos acts solely as the administrator of the Program, which includes, determining and setting out the relevant Specifications, evaluating and selecting a winning Submission, the award of a Prize amount and any other activities in support of the Program. Please also refer to the additional disclaimers around Logos (and its Affiliates’) role in clause 13 of these Terms.
+
+Prizes: The Program comprises multiple prizes (each a “Prize”) for which Participants may be eligible and these are further described in the λPrize GitHub repository. Prizes are typically defined through an analysis of gaps in the Logos technology stack and its ecosystem. This analysis refers to categories of infrastructure and applications commonly found in mature blockchain systems and their ecosystems as well as the technical dependencies between components, such that one Prize may build on a component delivered under another. Please also refer to the conditions of the Prize in the Specification and also clauses 7 (Evaluation and judging) clause 8 (Prizes).
+
+Specifications: Each Prize has a separate specification (“Specification”) which sets out, among others, its motivation, criteria, scope, the Prize amount and eligibility requirements. The Specifications are guided by existing approaches and implementations in other mature blockchain systems and their ecosystems, as well as by functional requirements particular to the Logos technology stack or perceived usefulness to the Logos ecosystem and community building on the Logos technology stack. Considerations may include open-source delivery, trust minimisation and a non-custodial design, however, these are indicative rather than exhaustive and any given Prize may reflect further or more specific considerations.
+
+As such, Specifications may describe Prizes with a range of maturity levels, ranging from experimental prototypes and proofs-of-concept to production-ready or near-production-ready applications and integrations. Where the Specifications set out specific criteria, this is because such criteria may need to fulfill particular requirements, such as to satisfy particular technical requirements or ensure compatibility with the Logos technology stack, rather than to prescribe how a Submission should be implemented.
+
+The Specifications also helps guide Logos in determining whether a Submission has met the criteria within and as such, when Logos selects a winning Submission for that Prize, it only means that the Submission has met the stated technical or non-technical criteria for that Prize and nothing more.
 
 ## 2. Defined Terms
 
 In these terms, the following capitalised terms have the meaning set out below:
 
-"Affiliate" means any entity that directly or indirectly controls, is controlled by, or is under common control with another entity, where "control" means the direct or indirect power to direct the management or policies of an entity, whether through ownership, contract, or otherwise;
+“Affiliate” means any entity that directly or indirectly controls, is controlled by, or is under common control with another entity, where “control” means the direct or indirect power to direct the management or policies of an entity, whether through ownership, contract, or otherwise. For the purposes of these Terms, an “Affiliate” of Logos Collective Association shall also include any entity which, as of the date of these Terms, both Members of the Association Board, other than the President of the Board, serve as directors, supervisors or persons exercising similar functions.
 
-"Sanctioned Person" means a person that: (a) is listed on any Sanctions list maintained by OFAC or any similar Sanctions list maintained by any other governmental authority having jurisdiction over the Participant; (b) is located, organised, or resident in any country, territory, or region that is the subject or target of Sanctions; or (c) is 50.0% or more owned or controlled by one (1) or more persons described in clauses (a) and (b) hereof;
+“Artefacts” including open-source tools, infrastructure, applications, integrations, SDKs or other technical artefacts created by Participants in connection with a Submission.
 
-"Sanctions" means the economic sanctions laws, regulations, embargoes or restrictive measures administered, enacted or enforced by the United States government and any of its agencies, (including, without limitation, the Office of Foreign Assets Control of the U.S. Department of the Treasury ("OFAC") or the U.S. Department of State and including, without limitation, the designation as a "specially designated national" or "blocked person"), the United Nations Security Council ("UNSC"), the European Union, His Majesty's Treasury ("HMT") or any other governmental authority having jurisdiction over the Participant.
+“Sanctioned Person” means a person that: (a) is listed on any Sanctions list maintained by OFAC or any similar Sanctions list maintained by any other governmental authority having jurisdiction over the Participant; (b) is located, organised, or resident in any country, territory, or region that is the subject or target of Sanctions; or (c) is 50.0% or more owned or controlled by one (1) or more persons described in clauses (a) and (b) hereof;
+
+“Sanctions” means the economic sanctions laws, regulations, embargoes or restrictive measures administered, enacted or enforced by the United States government and any of its agencies, (including, without limitation, the Office of Foreign Assets Control of the U.S. Department of the Treasury (“OFAC”) or the U.S. Department of State and including, without limitation, the designation as a “specially designated national” or “blocked person”), the United Nations Security Council (“UNSC”), the European Union, His Majesty’s Treasury (“HMT”), Switzerland (including the State Secretariat for Economic Affairs (“SECO”), or any other governmental authority having jurisdiction over the Participant.
+
+“Submission” means the Artefacts, together with any other materials submitted by a Participant in connection with the Program, including any associated documentation or items.
 
 ## 3. Scope of these Terms
 
 These Terms govern:
 
-1. your participation in the Program and any related hackathon or event (including the Parallel Society Congress hackathon);
-2. the making and evaluation of Submissions in the Program;
-3. the selection of winners and the award of prize amounts by Logos, and
-4. all related interactions between you and Logos in connection with the Program.
+1. A Participant’s participation in the Program;
+2. The making and evaluation of Submissions in the Program;
+3. The selection of a winning Submission and award of the relevant Prize amount by Logos, and
+4. All related interactions between the Participant and Logos in connection with the Program.
 
-These Terms do not create any contract for services, employment relationship, partnership, or joint venture, and do not create any obligation on Logos to award any prize amount or provide any funding, support, or ongoing engagement beyond any specific prize amount actually awarded.
+These Terms do not create any contract for services, employment relationship, partnership, or joint venture, and do not create any obligation on Logos to award a Prize amount or provide any funding, support, or ongoing engagement beyond any specific Prize amount actually paid.
 
 ## 4. Eligibility & representations
 
-By participating in the Program or making a Submission, you represent and warrant to Logos that:
+By participating in the Program or making a Submission, the Participant represents to Logos that:
 
-1. You have full legal capacity and authority to enter into these Terms and to make the Submission, and, where applicable, the individual acting is duly authorised to bind any entity on whose behalf the Submission is made.
-2. These Terms constitute a legal, valid, and binding obligation, enforceable against you in accordance with their terms.
-3. All information provided by you in connection with the Program (including registration details and any information in or relating to a Submission) is true, accurate, complete, and not misleading in any material respect at the time provided, and you will promptly notify Logos if it becomes inaccurate or incomplete.
-4. You will comply with all laws applicable to you and your activities in connection with the Program,
-
-Neither you nor, if you are an entity, any of your directors, officers, or beneficial owners is a Sanctioned Person or in violation of any Sanctions, and you will not engage in any activity in connection with the Program that would cause Logos or its Affiliates to violate any Sanctions.
-
-Your Submission is your own work (or that of your team), you have the right to submit it, and it does not infringe the intellectual property rights or other rights of any third party.
-
-You shall indemnify and hold harmless Logos from and against all third‑party claims, losses, and reasonable costs (including professional fees) arising out of or in connection with any breach of the above representations and warranties.
+1. The Participant has full legal capacity and authority to enter into these Terms and to make the Submission, and, where applicable, the individual acting is duly authorised to bind any entity on whose behalf the Submission is made.
+2. These Terms constitute a legal, valid, and binding obligation, enforceable against the Participant in accordance with their terms.
+3. All information provided by the Participant in connection with the Program (including registration details and any information in or relating to a Submission) is true, accurate, complete, and not misleading in any material respect at the time provided, and the Participant will promptly notify Logos if it becomes inaccurate or incomplete.
+4. The Participant shall comply with all laws applicable to itself and its activities in connection with the Program,
+5. Neither the Participant, or if the Participant is an entity, its directors, officers, or beneficial owners is a Sanctioned Person or in violation of any Sanctions, and the Participant shall not engage in any activity in connection with the Program that would cause Logos to violate any Sanctions.
+6. The Submission is the Participant’s work (or that of the Participant’s team) and the Participant hs the right to submit it, and it does not infringe the intellectual property rights or other rights of any third party.
 
 ## 5. Submissions
 
-### 5.1 Only one Submission per Prize
+### 5.1 Number of Submissions per Prize
 
-Each Submission shall target only one Prize as defined in the relevant Prize specification. A team or individual may submit to multiple Prizes, but are limited to providing one solution per Prize.
+For each Prize, Logos will indicate the number of Submissions that a Participant may accordingly make. A team or individual may make Submissions to multiple Prizes, but are limited to providing up to the indicated limit of Submissions per Prize. Logos may also indicate other limits on the number of Submissions, including the frequency that can be submitted per week by a Participant.
 
 ### 5.2 Manner of submissions and deadline
 
-Submissions must be made through λ Prize GitHub repository workflow, as indicated in the applicable Prize specification or an alternative platform as communicated by Logos.
-
-Unless stated otherwise, Submissions for the Parallel Society event must be received before the deadline specified in the relevant platform (e.g. Saturday 7 March 2026, 23:59 UTC). Late Submissions will not be considered.
+Submissions must be made through λPrize GitHub repository workflow, as indicated in the applicable Specification or an alternative platform as communicated by Logos. If there is a deadline indicated in the Specifications of a Prize, then Participants must make their Submission by such deadline. Logos reserves the right to not consider any late Submissions.
 
 ### 5.3 Submission requirements
 
-A valid Submission must satisfy all of Logos' requirements set out in the relevant prize specification, which includes but is not limited to:
+A valid Submission must satisfy all of Logos’ mandatory requirements as set out in the relevant Specification, which includes but is not limited to:
 
-1. source code hosted in a public repository;
-2. a working demo or deployable artefact;
-3. a recorded demo or walkthrough video of the Submission;
-4. adequate technical documentation and any other specified documentation indicated; and
-5. any other requirements indicated by Logos.
+1. Source code hosted in a public repository and available for Logos to review the Submission;
+2. A working demo or deployable Artefact;
+3. Adequate technical documentation and any other specified documentation indicated; and
+4. Any other requirements indicated by Logos as mandatory for that Prize.
 
-Logos reserves the right to not review any incomplete or partial Submissions or Submissions which do not meet all mandatory requirements in the applicable Prize specification.
+The Specifications may include additional criteria or requirements that the Participant must satisfy. Logos reserves the right not to review any incomplete or partial Submissions or any Submissions that do not meet the mandatory requirements or criteria of the applicable Specification.
 
-### 5.4 Open source licensing
+### 5.4 Open-source Licencing
 
-Participants shall ensure that any Submission is licenced under MIT License or Apache License 2.0. Participants are solely responsible for ensuring that they have the necessary rights to licence the Submission on this basis.
+Participants shall ensure that any Artefacts included as part of any Submission are made available under a dual licence of MIT License and Apache License 2.0. Participants are solely responsible for ensuring that they have the necessary rights to licence such Artefacts on this basis.
+
+While not mandatory, Participants are encouraged to continue making their Artefacts publicly available after the conclusion of their participation in the Program as part of aligning with open-source principles.
 
 ### 5.5 Public and non-confidential nature of Submissions
 
-Participants acknowledge that all Submissions are made on a voluntary, public, and non‑confidential basis. The content of a Submission may be publicly visible in the relevant repository and may be viewed, discussed, forked, and built upon by Logos or third parties in accordance with the applicable open‑source licence. Participants are solely responsible for ensuring that no confidential or sensitive information is included in their Submission.
+Participants acknowledge that all Submissions are made on a voluntary, public, and non‑confidential basis. The content of a Submission may be publicly visible in the relevant repository and may be viewed, commented upon and discussed in accordance with the functionality available in the respective GIthub repository. Participants are solely responsible for ensuring that no confidential or sensitive information is included in their Submission.
 
-## 6. Intellectual Property
+### 5.6 Intellectual Property
 
-### 6.1 Retained ownership
+#### 5.6.1 Retained ownership
 
-Subject to the licences granted below, Participants retain ownership of the intellectual property rights in their respective submissions.
+Subject to the licences granted below and the open-source licences applicable to the Submissions, Participants retain ownership of the intellectual property rights in their respective submissions.
 
-### 6.2 Licence to Logos
+#### 5.6.2 Licence to Logos
 
-By making a Submission, Participants grant Logos and its Affiliates a worldwide, perpetual, irrevocable, non‑exclusive, royalty‑free licence (with the right to sublicense) to use, reproduce, display, perform, distribute, adapt, modify, and create derivative works from Participant's Submission and related materials (including any video and audiovisual materials) for purposes connected with the Program, the Logos technology stack, and the broader Logos ecosystem, including without limitation for testing, evaluation, promotion, documentation, demonstration and as the case may be, publishing on any of Logos' or Affiliates' websites, social media profiles or other public channels.
+By making a Submission, Participants grant Logos and its Affiliates a worldwide, perpetual, irrevocable, non‑exclusive, royalty‑free licence (with the right to sublicense) to use, reproduce, display, perform, distribute, adapt, modify, and create derivative works from Participant’s Submission and related materials for purposes connected with the Program, the Logos technology stack, and the broader Logos ecosystem, including without limitation for testing, evaluation, promotion, documentation, and demonstration.
 
 ## 7. Evaluation and judging
 
-### 7.1 Eligibility for evaluation
+### 7.1 Eligibility for evaluation:
 
-Only Submissions that satisfy all mandatory requirements and success criteria defined in the applicable Prize specification will be considered for evaluation.
+Only Submissions that satisfy all mandatory eligibility requirements and criteria described in the applicable Specification will be considered for evaluation.
 
 ### 7.2 Evaluation process
 
-Logos (and, where applicable, designated judges or advisors) will evaluate whether Submissions meet all the eligibility requirements using criteria set out in the relevant Prize specification and any additional criteria Logos considers relevant, in its sole discretion, which may include technical merit, security, user experience, ecosystem impact, and completeness.
+Logos (and, where applicable, designated judges or advisors) will evaluate Submissions against mandatory eligibility requirements and criteria set out in the relevant Specification any additional criteria Logos may, in its sole discretion, consider relevant.
 
-The relevant timing of any Submission within any defined event window has no bearing on evaluation, except where explicitly stated in the Prize specification or in these Terms.
+All Submissions made within the open period of a Prize will be evaluated without regard to when they were submitted by a Participant and the timing of a Submission does not affect its evaluation or its chances of success.
 
 ### 7.3 Discretion and no obligation
 
-Logos maintains sole discretion in determining whether any Submission satisfies the applicable criteria, whether to select a winner for any Prize, and whether to withhold a corresponding prize amount entirely if, in Logos' judgment, no Submission satisfactorily meets the criteria.
+Logos has sole discretion in determining whether any Submission satisfies the applicable Specifications, whether to select a winning Submission for any Prize, and whether to withhold a corresponding Prize amount entirely if, in Logos’ judgment, no Submission satisfactorily meets the criteria. The Participant acknowledges that simply making a Submission does not entitle the Participant to a Prize amount.
 
-Logos is under no obligation to provide reasons for any evaluation decision and no communication or feedback (whether written or oral) shall be construed as a commitment to select a Submission or award a prize amount in respect of a Prize.
+Logos is under no obligation to provide reasons for the selection (or non-selection) of a Submission to be paid a Prize amount. No statement, communication, or conduct by Logos (including feedback, commentary on Submissions, or use of labels, statuses, or discussion on GitHub or relevant platforms) will constitute an endorsement of a Submission or any commitment to award a Prize amount, unless expressly confirmed in a formal written notice by Logos.
+
+All decisions by Logos regarding eligibility, evaluation, and selection of a winning Submission are final and binding.
 
 ## 8. Prizes
 
 ### 8.1 Prize amounts
 
-Unless the applicable Prize specification expressly provides otherwise, each Prize will only have a single winner. The anticipated prize amount, form of consideration, and any specific conditions are defined in the applicable Prize specification. Logos reserves the right in it to adjust prize amounts, including reducing or increasing amounts, or not awarding any prize amount in respect of a Prize at all in its sole discretion.
+Unless the applicable Specification expressly provides otherwise, each Prize will only have a single winner. The anticipated Prize amount, its form, and any specific conditions are defined in the applicable Specification.
+
+Logos has no obligation to compensate a Participant for their time, effort, or expenses, whether or not their Submission is selected to be awarded a Prize Amount;
 
 ### 8.2 Additional conditions for the receipt of a Prize
 
-Logos may require the winner to provide (additional) identifying and other information as a condition of the distribution of a prize amount for a Prize or comply with any other requirements that Logos may request. Logos may decline to award or may revoke a prize amount where information is not provided, is incomplete or misleading, where the winner fails to comply with Logos' instructions or where awarding the prize amount may expose Logos or its Affiliates to legal, regulatory, financial, or reputational risk.
+Logos may require the Participant who made the winning Submission to provide (additional) identifying and other information as a condition of distribution of a Prize amount.
+
+Logos may decline to distribute a Prize amount where such information is not provided, is incomplete or misleading, where the Participant fails to comply with Logoss’ instructions or where awarding or distributing a Prize amount may expose Logos to legal, regulatory, financial, or reputational risk.
 
 ### 8.3 Taxes
 
-Winners are solely responsible for any tax obligations, reporting, or filings arising from the receipt of a prize amount in their jurisdiction.
+Successful Participants are solely responsible for any tax obligations, reporting, or filings arising from the receipt of a Prize amount in their jurisdiction.
 
-## 9. Post-Event continuation
+## 9. Code of Conduct
 
-Following the conclusion of any associated hackathon or live event (including the Parallel Society Congress), the λ Prize GitHub repository may remain open or be opened for further Submissions from a specified date.
+1. Participants are expected to behave in a respectful, professional, and constructive manner towards other participants, Logos personnel, and any judges or community members.
+2. Logos reserves the right, in its sole discretion and without liability, to disqualify any Participant, or to disregard any Submission, where it reasonably believes that such Participant or Submission is associated with:
+   1. harassment, discrimination, or abusive conduct;
+   2. plagiarism or misappropriation of others’ work;
+   3. fraud, cheating, or manipulation of the evaluation process; or
+   4. any conduct that undermines the integrity, safety, or reputation of the Program, Logos and its Affiliates, or their respective projects.
 
-Unless otherwise specified:
+## 10. Personal data processing
 
-1. Logos may evaluate repository Submissions on a first‑come‑first‑served basis, such that the first Submission that satisfies all success criteria for a particular Prize may be selected as the winner;
-2. where Parallel Society Congress or other live‑event Submissions for a given Prize remain under review, such event Submissions may take precedence over later repository Submissions targeting the same Prize; and
-3. Participants who began work during the event may continue that work and submit through the repository after the event, subject to these Terms and the relevant prize specification.
+1. Logos shall process personal data submitted in connection with the Program in accordance with its Privacy Policy, as updated from time to time and made available here: [https://logos.co/privacy-policy](https://logos.co/privacy-policy).
+2. In addition to the Privacy Policy and for the specific purposes of the administration of the Program, Logos may process the following personal data, such as a Participant’s name, contact information, GIthub account, social media profiles or links, and any other personal information that might be included as part of a Submission.
+3. If a Participant is awarded a Prize Amount, Logos may further request additional information including: a Participant’s country of residence, wallet address or any other information that may be reasonably required to identify a Participant and to distribute the Prize Amount. This information is necessary to enable Logos to comply with its obligations under applicable law, including sanctions laws.
 
-Logos may modify or discontinue any post‑event process in its sole discretion.
+## 11. Modifications and changes to the Program
 
-## 10. Code of Conduct
+1. Logos reserves the right, at any time and in its sole discretion, to:
+   1. modify these Terms;
+   2. modify any Specification, including any requirements or criteria set out therein;
+   3. modify Prize amounts, including their form and amounts;
+   4. modify or cancel any Prizes; or
+   5. cancel, suspend, or modify the Program.
+2. Logos will communicate material changes to the Program through the λPrize GitHub repository, or other official channels utilised by Logos. The Participant’s continued participation in the Program after the publication of updated Terms or modifications constitutes acceptance of those changes.
 
-Participants are expected to behave in a respectful, professional, and constructive manner towards other participants, Logos personnel, and any judges or community members.
+## 12. Participant acknowledgements and additional obligations
 
-Logos reserves the right, in its sole discretion and without liability, to disqualify any Participant or team, or to disregard any Submission, where it reasonably believes that such Participant or Submission is associated with:
+Participants acknowledge and agree to the following in connection to their participation in the Program:
 
-1. harassment, discrimination, or abusive conduct;
-2. plagiarism or misappropriation of others' work;
-3. fraud, cheating, or manipulation of the evaluation process; or
-4. any conduct that undermines the integrity, safety, or reputation of the Program, the event, or any Logos projects.
-
-## 11. Personal data processing
-
-Logos shall process personal data submitted in connection with the Program in accordance with its Privacy Policy, as updated from time to time and made available here: [https://logos.co/privacy-policy](https://logos.co/privacy-policy).
-
-In addition to the Privacy Policy and for the specific purposes of the administration of your participation in the Program, we may process the following personal data, such as your name, your Github account and contact email (if provided). If awarded a prize amount, we may further request additional information including: your country of residence and your wallet address or any other information that may be required to send you the prize amount.
-
-## 12. Modifications and changes to the Program
-
-Logos reserves the right, at any time and in its sole discretion, to:
-
-1. modify these Terms;
-2. modify any Prize specification or rules;
-3. adjust prize amounts or structures;
-4. cancel individual Prizes; or
-5. cancel, suspend, or modify the Program or any associated event in whole or in part.
-
-Logos will communicate material changes to the Program through the λ Prize GitHub repository, or other official channels designated by Logos. Your continued participation in the Program after publication of updated Terms or rules constitutes your acceptance of such updates.
-
-All decisions by Logos regarding eligibility, evaluation, and winner selection are final and binding.
+1. Participants act independently, voluntarily and at their own initiative in participating in the Program;
+2. Participants have sole discretion over, and are solely responsible for the design, development, review, testing, maintenance and public promotion of any Artefacts that form part of their Submission, including any potential deployment or operation of such Artefacts if they choose to undertake it;
+3. Participants are solely responsible for assessing the risks and implications of their participation in the Programme, including any activity relating to the development of Artefacts that form part of their Submission. This also includes assessing any legal or regulatory implications and complying with any applicable law, rules or regulations;
+4. If Participants choose to deploy, host, operate, use or publicly promote any Artefacts, whether from their own Submission or from other Submissions, they do so at their own risk. Participants remain solely responsible for complying with any legal or regulatory requirements that apply to them, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business;
+5. If Participants issues, offers, promotes or facilitates the issuance of a digital asset in connection with an Artefact, it does so exclusively in its own name and is solely responsible for complying any legal or regulatory requirements.
+6. Participants shall not represent or imply that they, their Artefacts or Submissions are affiliated with, endorsed, approved, built, hosted, maintained, deployed or operated by Logos or its Affiliates.
 
 ## 13. Disclaimers
 
-You acknowledge that:
+Logos makes the following disclaimers in relation to the Programme:
 
-- you participate in the Program and prepare Submissions at your own cost and risk;
-- Logos has no obligation to compensate you for your time, effort, or expenses, whether or not you are selected as a winner; and
-- no statement, communication, or conduct by Logos (including feedback, commentary on Submissions, or use of labels, statuses, or discussion on GitHub or relevant platforms) shall constitute an endorsement of you or your Submission, or any commitment to award a Prize, unless expressly confirmed in a formal written notice from Logos.
+1. Nothing in the Program, the Specifications or any communications from Logos or its Affiliates constitutes legal, regulatory, tax, financial or technical advice. Participants should not rely on such communications and must obtain their own independent professional advice.
+2. Logos makes no representations as to the legal or regulatory treatment of any Prizes or activities under the Program in any jurisdiction;
+3. Logos does not endorse or approve any Participant, Artefacts included in any Submission, Submissions or any third party tools or services that may be used by Participants in connection with the Program or any Submission;
+4. Logos makes no representations or warranties regarding the security, quality, functionality, correctness, safety, fitness for purpose or performance of any Artefact included in any Submission;
+5. Logos and its Affiliates do not publish, host or maintain any Artefacts arising out of any Submission;
+6. Logos and its Affiliates do not build, deploy, host, operate or control any Artefacts arising out of any Submission;
+7. Logos and its Affiliates do not, directly or indirectly, (i) facilitate the transfer or exchange of any assets of any person (s) who use any deployed Artefact arising out of any Submission; or (ii) hold custody or control such assets.
 
-You must not state or imply that Logos operates, guarantees, audits, certifies, or assumes responsibility for your Submissions.
+## 14. Indemnity and Limitation of Liability
 
-## 14. Limitation of liability
+1. The Participant shall indemnify, defend and hold harmless Logos and its Affiliates from and against any and all third‑party claims, liabilities, damages, losses, costs and expenses (including reasonable legal and professional fees) arising out of or in connection with:
+   1. Any breach or inaccuracy of the Participant’s representations and warranties in these Terms;
+   2. The Participant’s participation in, and actions or omissions in connection with the Program (including their Submissions and Artefacts);
+   3. Any breach of the Participant of applicable law or regulation in connection with the Program (including their Submissions and Artefacts); or
+   4. The Participant’s gross negligence, wilful misconduct or fraud in connection with the Program (including their Submissions and Artefacts).
+2. To the maximum extent permitted by applicable law, neither Logos nor its Affiliates will be liable to the Participant under any contract, tort (including negligence), strict liability, or other legal or equitable theory for:
+   1. Any loss of profits, revenue, opportunity, or business;
+   2. Any loss of data or loss of work;
+   3. Any cost of procurement of substitute goods or services; or
+   4. Any indirect, incidental, special, punitive, or consequential damages
 
-To the maximum extent permitted by applicable law, Logos will not be liable to you under any contract, tort (including negligence), strict liability, or other legal or equitable theory for:
+arising out of or in connection with the Program, the Participant’s Submission and Artefacts therein, or these Terms, even if Logos or its Affiliates have been advised of the possibility of such damages.
 
-1. any loss of profits, revenue, opportunity, or business;
-2. any loss of data or loss of work;
-3. any cost of procurement of substitute goods or services; or
-4. any indirect, incidental, special, punitive, or consequential damages
+In any event, Logos’ and its Affiliates’ aggregate liability arising out of or in connection with these Terms and the Program shall be limited to CHF 100 (one hundred Swiss Francs).
 
-arising out of or in connection with the Program, your participation in any event, your Submission, or these Terms, even if Logos has been advised of the possibility of such damages.
+## 15. Notices and communications
 
-In any event, Logos' aggregate liability arising out of or in connection with these Terms and the Program shall be limited to EUR 100 (one hundred Euros).
+1. Any notice or other legally binding communication under these Terms must be in writing and sent by email to the official contact address designated by the receiving Party. Notices to Logos should be sent to [ecosystem@logos.co](mailto:ecosystem@logos.co). Logos may update this email address for notices to us by updating these Terms.
+2. Notices to the Participant will be sent to the email address provided in the Submission or subsequently provided in writing. A notice sent by email shall be deemed received at the time of transmission, provided no delivery failure message is received.
+3. All communications and notices to be made or given pursuant to these Terms must be in the English language.
 
-You acknowledge that participation in the Program is at your own risk.
+## 16. Publicity
 
-## 15. Governing law and disputes
+Logos or its Affiliates may publicly refer to, describe or publicly promote winning Submissions or Artefacts therein. This may include publicly identifying the Participant, their Submissions or publishing links to external Participant repositories where such Submissions or Artefacts are hosted. This should be understood to be made for informational and/or promotional purposes only and should not be construed as an approval or endorsement or affiliation with Logos or its Affiliates, of the Participant or any Submissions or Artefacts.
 
-These Terms and any non‑contractual obligations arising out of or in connection with them are governed by and shall be construed in accordance with the substantive laws of Switzerland, without regard to its conflict of law rules.
+## 17. Governing law and disputes
 
-Any dispute, controversy, or claim arising out of or in connection with these Terms, including the validity, invalidity, breach, or termination thereof, that cannot be resolved amicably within a reasonable time shall be referred to and finally resolved by arbitration administered by the Swiss Chambers' Arbitration Institution in accordance with the Swiss Rules of International Arbitration in force at the time the notice of arbitration is submitted.
+1. These Terms and any non‑contractual obligations arising out of or in connection with them are governed by and shall be construed in accordance with the substantive laws of Switzerland, without regard to its conflict of law rules.
+2. Any dispute, controversy, or claim arising out of or in connection with these Terms, including the validity, invalidity, breach, or termination thereof, that cannot be resolved amicably within a reasonable time shall be referred to and finally resolved by arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration in force at the time the notice of arbitration is submitted.
+   1. The seat of arbitration shall be Zug, Switzerland.
+   2. The arbitral tribunal shall consist of one arbitrator.
+   3. The language of the arbitration shall be English.
+   4. The arbitration proceedings and all related communications shall be confidential to the extent permitted by law.
 
-1. The seat of arbitration shall be Zug, Switzerland.
-2. The arbitral tribunal shall consist of one arbitrator.
-3. The language of the arbitration shall be English.
-4. The arbitration proceedings and all related communications shall be confidential to the extent permitted by law.
+Participants waive, to the fullest extent permitted by applicable law, any right to participate in any class, collective, or representative action against Logos and its Affiliates in relation to the Program.
 
-You waive, to the fullest extent permitted by applicable law, any right to participate in any class, collective, or representative action against Logos in relation to the Program.
+## 18. Miscellaneous
 
-## 16. Miscellaneous
-
-These Terms, together with any applicable prize specifications and the Privacy Policy, constitute the entire agreement between the Parties in relation to the subject matter hereof and supersede all prior discussions, understandings, or agreements relating to the Program.
-
-If any provision of these Terms is held to be invalid, illegal, or unenforceable, the remaining provisions shall remain in full force and effect.
-
-No failure or delay by Logos in exercising any right or remedy under these Terms shall operate as a waiver thereof.
-
-You may not assign or transfer any of your rights or obligations under these Terms without Logos' prior written consent. Logos may assign or transfer its rights and obligations under these Terms to any of its Affiliates.
+1. These Terms, together with any documents referred to in them, constitute the entire agreement between the Parties in relation to the subject matter hereof and supersede all previous agreements, arrangements, understandings between the Parties with respect hereto.
+2. If any provision of these Terms is held to be invalid, illegal, or unenforceable, the remaining provisions shall remain in full force and effect.
+3. No failure or delay by Logos in exercising any right or remedy under these Terms shall operate as a waiver thereof.
+4. Participants shall not assign or transfer any of their rights or obligations under these Terms without Logos’ prior written consent. Logos may assign or transfer its rights and obligations under these Terms to any of its Affiliates.
+5. There are no representations, warranties, terms, conditions, undertakings or understanding, express or implied, between the Parties other than those expressly set forth in these Terms.

--- a/TERMS.md
+++ b/TERMS.md
@@ -44,10 +44,10 @@ In these terms, the following capitalised terms have the meaning set out below:
 
 These Terms govern:
 
-1. A Participant’s participation in the Program;
-2. The making and evaluation of Submissions in the Program;
-3. The selection of a winning Submission and award of the relevant Prize amount by Logos, and
-4. All related interactions between the Participant and Logos in connection with the Program.
+(a) A Participant’s participation in the Program;
+(b) The making and evaluation of Submissions in the Program;
+(c) The selection of a winning Submission and award of the relevant Prize amount by Logos, and
+(d) All related interactions between the Participant and Logos in connection with the Program.
 
 These Terms do not create any contract for services, employment relationship, partnership, or joint venture, and do not create any obligation on Logos to award a Prize amount or provide any funding, support, or ongoing engagement beyond any specific Prize amount actually paid.
 
@@ -55,12 +55,12 @@ These Terms do not create any contract for services, employment relationship, pa
 
 By participating in the Program or making a Submission, the Participant represents to Logos that:
 
-1. The Participant has full legal capacity and authority to enter into these Terms and to make the Submission, and, where applicable, the individual acting is duly authorised to bind any entity on whose behalf the Submission is made.
-2. These Terms constitute a legal, valid, and binding obligation, enforceable against the Participant in accordance with their terms.
-3. All information provided by the Participant in connection with the Program (including registration details and any information in or relating to a Submission) is true, accurate, complete, and not misleading in any material respect at the time provided, and the Participant will promptly notify Logos if it becomes inaccurate or incomplete.
-4. The Participant shall comply with all laws applicable to itself and its activities in connection with the Program,
-5. Neither the Participant, or if the Participant is an entity, its directors, officers, or beneficial owners is a Sanctioned Person or in violation of any Sanctions, and the Participant shall not engage in any activity in connection with the Program that would cause Logos to violate any Sanctions.
-6. The Submission is the Participant’s work (or that of the Participant’s team) and the Participant hs the right to submit it, and it does not infringe the intellectual property rights or other rights of any third party.
+(a) The Participant has full legal capacity and authority to enter into these Terms and to make the Submission, and, where applicable, the individual acting is duly authorised to bind any entity on whose behalf the Submission is made.
+(b) These Terms constitute a legal, valid, and binding obligation, enforceable against the Participant in accordance with their terms.
+(c) All information provided by the Participant in connection with the Program (including registration details and any information in or relating to a Submission) is true, accurate, complete, and not misleading in any material respect at the time provided, and the Participant will promptly notify Logos if it becomes inaccurate or incomplete.
+(d) The Participant shall comply with all laws applicable to itself and its activities in connection with the Program,
+(e) Neither the Participant, or if the Participant is an entity, its directors, officers, or beneficial owners is a Sanctioned Person or in violation of any Sanctions, and the Participant shall not engage in any activity in connection with the Program that would cause Logos to violate any Sanctions.
+(f) The Submission is the Participant’s work (or that of the Participant’s team) and the Participant hs the right to submit it, and it does not infringe the intellectual property rights or other rights of any third party.
 
 ## 5. Submissions
 
@@ -76,10 +76,10 @@ Submissions must be made through λPrize GitHub repository workflow, as indicate
 
 A valid Submission must satisfy all of Logos’ mandatory requirements as set out in the relevant Specification, which includes but is not limited to:
 
-1. Source code hosted in a public repository and available for Logos to review the Submission;
-2. A working demo or deployable Artefact;
-3. Adequate technical documentation and any other specified documentation indicated; and
-4. Any other requirements indicated by Logos as mandatory for that Prize.
+(a) Source code hosted in a public repository and available for Logos to review the Submission;
+(b) A working demo or deployable Artefact;
+(c) Adequate technical documentation and any other specified documentation indicated; and
+(d) Any other requirements indicated by Logos as mandatory for that Prize.
 
 The Specifications may include additional criteria or requirements that the Participant must satisfy. Logos reserves the right not to review any incomplete or partial Submissions or any Submissions that do not meet the mandatory requirements or criteria of the applicable Specification.
 
@@ -93,13 +93,13 @@ While not mandatory, Participants are encouraged to continue making their Artefa
 
 Participants acknowledge that all Submissions are made on a voluntary, public, and non‑confidential basis. The content of a Submission may be publicly visible in the relevant repository and may be viewed, commented upon and discussed in accordance with the functionality available in the respective GIthub repository. Participants are solely responsible for ensuring that no confidential or sensitive information is included in their Submission.
 
-### 5.6 Intellectual Property
+## 6. Intellectual Property
 
-#### 5.6.1 Retained ownership
+### 6.1 Retained ownership
 
 Subject to the licences granted below and the open-source licences applicable to the Submissions, Participants retain ownership of the intellectual property rights in their respective submissions.
 
-#### 5.6.2 Licence to Logos
+### 6.2 Licence to Logos
 
 By making a Submission, Participants grant Logos and its Affiliates a worldwide, perpetual, irrevocable, non‑exclusive, royalty‑free licence (with the right to sublicense) to use, reproduce, display, perform, distribute, adapt, modify, and create derivative works from Participant’s Submission and related materials for purposes connected with the Program, the Logos technology stack, and the broader Logos ecosystem, including without limitation for testing, evaluation, promotion, documentation, and demonstration.
 
@@ -143,74 +143,107 @@ Successful Participants are solely responsible for any tax obligations, reportin
 
 ## 9. Code of Conduct
 
-1. Participants are expected to behave in a respectful, professional, and constructive manner towards other participants, Logos personnel, and any judges or community members.
-2. Logos reserves the right, in its sole discretion and without liability, to disqualify any Participant, or to disregard any Submission, where it reasonably believes that such Participant or Submission is associated with:
-   1. harassment, discrimination, or abusive conduct;
-   2. plagiarism or misappropriation of others’ work;
-   3. fraud, cheating, or manipulation of the evaluation process; or
-   4. any conduct that undermines the integrity, safety, or reputation of the Program, Logos and its Affiliates, or their respective projects.
+### 9.1
+
+Participants are expected to behave in a respectful, professional, and constructive manner towards other participants, Logos personnel, and any judges or community members.
+
+### 9.2
+
+Logos reserves the right, in its sole discretion and without liability, to disqualify any Participant, or to disregard any Submission, where it reasonably believes that such Participant or Submission is associated with:
+
+(a) harassment, discrimination, or abusive conduct;
+(b) plagiarism or misappropriation of others’ work;
+(c) fraud, cheating, or manipulation of the evaluation process; or
+(d) any conduct that undermines the integrity, safety, or reputation of the Program, Logos and its Affiliates, or their respective projects.
 
 ## 10. Personal data processing
 
-1. Logos shall process personal data submitted in connection with the Program in accordance with its Privacy Policy, as updated from time to time and made available here: [https://logos.co/privacy-policy](https://logos.co/privacy-policy).
-2. In addition to the Privacy Policy and for the specific purposes of the administration of the Program, Logos may process the following personal data, such as a Participant’s name, contact information, GIthub account, social media profiles or links, and any other personal information that might be included as part of a Submission.
-3. If a Participant is awarded a Prize Amount, Logos may further request additional information including: a Participant’s country of residence, wallet address or any other information that may be reasonably required to identify a Participant and to distribute the Prize Amount. This information is necessary to enable Logos to comply with its obligations under applicable law, including sanctions laws.
+### 10.1
+
+Logos shall process personal data submitted in connection with the Program in accordance with its Privacy Policy, as updated from time to time and made available here: [https://logos.co/privacy-policy](https://logos.co/privacy-policy).
+
+### 10.2
+
+In addition to the Privacy Policy and for the specific purposes of the administration of the Program, Logos may process the following personal data, such as a Participant’s name, contact information, GIthub account, social media profiles or links, and any other personal information that might be included as part of a Submission.
+
+### 10.3
+
+If a Participant is awarded a Prize Amount, Logos may further request additional information including: a Participant’s country of residence, wallet address or any other information that may be reasonably required to identify a Participant and to distribute the Prize Amount. This information is necessary to enable Logos to comply with its obligations under applicable law, including sanctions laws.
 
 ## 11. Modifications and changes to the Program
 
-1. Logos reserves the right, at any time and in its sole discretion, to:
-   1. modify these Terms;
-   2. modify any Specification, including any requirements or criteria set out therein;
-   3. modify Prize amounts, including their form and amounts;
-   4. modify or cancel any Prizes; or
-   5. cancel, suspend, or modify the Program.
-2. Logos will communicate material changes to the Program through the λPrize GitHub repository, or other official channels utilised by Logos. The Participant’s continued participation in the Program after the publication of updated Terms or modifications constitutes acceptance of those changes.
+### 11.1
+
+Logos reserves the right, at any time and in its sole discretion, to:
+
+(a) modify these Terms;
+(b) modify any Specification, including any requirements or criteria set out therein;
+(c) modify Prize amounts, including their form and amounts;
+(d) modify or cancel any Prizes; or
+(e) cancel, suspend, or modify the Program.
+
+### 11.2
+
+Logos will communicate material changes to the Program through the λPrize GitHub repository, or other official channels utilised by Logos. The Participant’s continued participation in the Program after the publication of updated Terms or modifications constitutes acceptance of those changes.
 
 ## 12. Participant acknowledgements and additional obligations
 
 Participants acknowledge and agree to the following in connection to their participation in the Program:
 
-1. Participants act independently, voluntarily and at their own initiative in participating in the Program;
-2. Participants have sole discretion over, and are solely responsible for the design, development, review, testing, maintenance and public promotion of any Artefacts that form part of their Submission, including any potential deployment or operation of such Artefacts if they choose to undertake it;
-3. Participants are solely responsible for assessing the risks and implications of their participation in the Programme, including any activity relating to the development of Artefacts that form part of their Submission. This also includes assessing any legal or regulatory implications and complying with any applicable law, rules or regulations;
-4. If Participants choose to deploy, host, operate, use or publicly promote any Artefacts, whether from their own Submission or from other Submissions, they do so at their own risk. Participants remain solely responsible for complying with any legal or regulatory requirements that apply to them, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business;
-5. If Participants issues, offers, promotes or facilitates the issuance of a digital asset in connection with an Artefact, it does so exclusively in its own name and is solely responsible for complying any legal or regulatory requirements.
-6. Participants shall not represent or imply that they, their Artefacts or Submissions are affiliated with, endorsed, approved, built, hosted, maintained, deployed or operated by Logos or its Affiliates.
+(a) Participants act independently, voluntarily and at their own initiative in participating in the Program;
+(b) Participants have sole discretion over, and are solely responsible for the design, development, review, testing, maintenance and public promotion of any Artefacts that form part of their Submission, including any potential deployment or operation of such Artefacts if they choose to undertake it;
+(c) Participants are solely responsible for assessing the risks and implications of their participation in the Programme, including any activity relating to the development of Artefacts that form part of their Submission. This also includes assessing any legal or regulatory implications and complying with any applicable law, rules or regulations;
+(d) If Participants choose to deploy, host, operate, use or publicly promote any Artefacts, whether from their own Submission or from other Submissions, they do so at their own risk. Participants remain solely responsible for complying with any legal or regulatory requirements that apply to them, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business;
+(e) If Participants issues, offers, promotes or facilitates the issuance of a digital asset in connection with an Artefact, it does so exclusively in its own name and is solely responsible for complying any legal or regulatory requirements.
+(f) Participants shall not represent or imply that they, their Artefacts or Submissions are affiliated with, endorsed, approved, built, hosted, maintained, deployed or operated by Logos or its Affiliates.
 
 ## 13. Disclaimers
 
 Logos makes the following disclaimers in relation to the Programme:
 
-1. Nothing in the Program, the Specifications or any communications from Logos or its Affiliates constitutes legal, regulatory, tax, financial or technical advice. Participants should not rely on such communications and must obtain their own independent professional advice.
-2. Logos makes no representations as to the legal or regulatory treatment of any Prizes or activities under the Program in any jurisdiction;
-3. Logos does not endorse or approve any Participant, Artefacts included in any Submission, Submissions or any third party tools or services that may be used by Participants in connection with the Program or any Submission;
-4. Logos makes no representations or warranties regarding the security, quality, functionality, correctness, safety, fitness for purpose or performance of any Artefact included in any Submission;
-5. Logos and its Affiliates do not publish, host or maintain any Artefacts arising out of any Submission;
-6. Logos and its Affiliates do not build, deploy, host, operate or control any Artefacts arising out of any Submission;
-7. Logos and its Affiliates do not, directly or indirectly, (i) facilitate the transfer or exchange of any assets of any person (s) who use any deployed Artefact arising out of any Submission; or (ii) hold custody or control such assets.
+(a) Nothing in the Program, the Specifications or any communications from Logos or its Affiliates constitutes legal, regulatory, tax, financial or technical advice. Participants should not rely on such communications and must obtain their own independent professional advice.
+(b) Logos makes no representations as to the legal or regulatory treatment of any Prizes or activities under the Program in any jurisdiction;
+(c) Logos does not endorse or approve any Participant, Artefacts included in any Submission, Submissions or any third party tools or services that may be used by Participants in connection with the Program or any Submission;
+(d) Logos makes no representations or warranties regarding the security, quality, functionality, correctness, safety, fitness for purpose or performance of any Artefact included in any Submission;
+(e) Logos and its Affiliates do not publish, host or maintain any Artefacts arising out of any Submission;
+(f) Logos and its Affiliates do not build, deploy, host, operate or control any Artefacts arising out of any Submission;
+(g) Logos and its Affiliates do not, directly or indirectly, (i) facilitate the transfer or exchange of any assets of any person (s) who use any deployed Artefact arising out of any Submission; or (ii) hold custody or control such assets.
 
 ## 14. Indemnity and Limitation of Liability
 
-1. The Participant shall indemnify, defend and hold harmless Logos and its Affiliates from and against any and all third‑party claims, liabilities, damages, losses, costs and expenses (including reasonable legal and professional fees) arising out of or in connection with:
-   1. Any breach or inaccuracy of the Participant’s representations and warranties in these Terms;
-   2. The Participant’s participation in, and actions or omissions in connection with the Program (including their Submissions and Artefacts);
-   3. Any breach of the Participant of applicable law or regulation in connection with the Program (including their Submissions and Artefacts); or
-   4. The Participant’s gross negligence, wilful misconduct or fraud in connection with the Program (including their Submissions and Artefacts).
-2. To the maximum extent permitted by applicable law, neither Logos nor its Affiliates will be liable to the Participant under any contract, tort (including negligence), strict liability, or other legal or equitable theory for:
-   1. Any loss of profits, revenue, opportunity, or business;
-   2. Any loss of data or loss of work;
-   3. Any cost of procurement of substitute goods or services; or
-   4. Any indirect, incidental, special, punitive, or consequential damages
+### 14.1
 
-arising out of or in connection with the Program, the Participant’s Submission and Artefacts therein, or these Terms, even if Logos or its Affiliates have been advised of the possibility of such damages.
+The Participant shall indemnify, defend and hold harmless Logos and its Affiliates from and against any and all third‑party claims, liabilities, damages, losses, costs and expenses (including reasonable legal and professional fees) arising out of or in connection with:
+
+(a) Any breach or inaccuracy of the Participant’s representations and warranties in these Terms;
+(b) The Participant’s participation in, and actions or omissions in connection with the Program (including their Submissions and Artefacts);
+(c) Any breach of the Participant of applicable law or regulation in connection with the Program (including their Submissions and Artefacts); or
+(d) The Participant’s gross negligence, wilful misconduct or fraud in connection with the Program (including their Submissions and Artefacts).
+
+### 14.2
+
+To the maximum extent permitted by applicable law, neither Logos nor its Affiliates will be liable to the Participant under any contract, tort (including negligence), strict liability, or other legal or equitable theory for:
+
+(a) Any loss of profits, revenue, opportunity, or business;
+(b) Any loss of data or loss of work;
+(c) Any cost of procurement of substitute goods or services; or
+(d) Any indirect, incidental, special, punitive, or consequential damages arising out of or in connection with the Program, the Participant’s Submission and Artefacts therein, or these Terms, even if Logos or its Affiliates have been advised of the possibility of such damages.
 
 In any event, Logos’ and its Affiliates’ aggregate liability arising out of or in connection with these Terms and the Program shall be limited to CHF 100 (one hundred Swiss Francs).
 
 ## 15. Notices and communications
 
-1. Any notice or other legally binding communication under these Terms must be in writing and sent by email to the official contact address designated by the receiving Party. Notices to Logos should be sent to [ecosystem@logos.co](mailto:ecosystem@logos.co). Logos may update this email address for notices to us by updating these Terms.
-2. Notices to the Participant will be sent to the email address provided in the Submission or subsequently provided in writing. A notice sent by email shall be deemed received at the time of transmission, provided no delivery failure message is received.
-3. All communications and notices to be made or given pursuant to these Terms must be in the English language.
+### 15.1
+
+Any notice or other legally binding communication under these Terms must be in writing and sent by email to the official contact address designated by the receiving Party. Notices to Logos should be sent to [ecosystem@logos.co](mailto:ecosystem@logos.co). Logos may update this email address for notices to us by updating these Terms.
+
+### 15.2
+
+Notices to the Participant will be sent to the email address provided in the Submission or subsequently provided in writing. A notice sent by email shall be deemed received at the time of transmission, provided no delivery failure message is received.
+
+### 15.3
+
+All communications and notices to be made or given pursuant to these Terms must be in the English language.
 
 ## 16. Publicity
 
@@ -218,19 +251,39 @@ Logos or its Affiliates may publicly refer to, describe or publicly promote winn
 
 ## 17. Governing law and disputes
 
-1. These Terms and any non‑contractual obligations arising out of or in connection with them are governed by and shall be construed in accordance with the substantive laws of Switzerland, without regard to its conflict of law rules.
-2. Any dispute, controversy, or claim arising out of or in connection with these Terms, including the validity, invalidity, breach, or termination thereof, that cannot be resolved amicably within a reasonable time shall be referred to and finally resolved by arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration in force at the time the notice of arbitration is submitted.
-   1. The seat of arbitration shall be Zug, Switzerland.
-   2. The arbitral tribunal shall consist of one arbitrator.
-   3. The language of the arbitration shall be English.
-   4. The arbitration proceedings and all related communications shall be confidential to the extent permitted by law.
+### 17.1
+
+These Terms and any non‑contractual obligations arising out of or in connection with them are governed by and shall be construed in accordance with the substantive laws of Switzerland, without regard to its conflict of law rules.
+
+### 17.2
+
+Any dispute, controversy, or claim arising out of or in connection with these Terms, including the validity, invalidity, breach, or termination thereof, that cannot be resolved amicably within a reasonable time shall be referred to and finally resolved by arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration in force at the time the notice of arbitration is submitted.
+
+(a) The seat of arbitration shall be Zug, Switzerland.
+(b) The arbitral tribunal shall consist of one arbitrator.
+(c) The language of the arbitration shall be English.
+(d) The arbitration proceedings and all related communications shall be confidential to the extent permitted by law.
 
 Participants waive, to the fullest extent permitted by applicable law, any right to participate in any class, collective, or representative action against Logos and its Affiliates in relation to the Program.
 
 ## 18. Miscellaneous
 
-1. These Terms, together with any documents referred to in them, constitute the entire agreement between the Parties in relation to the subject matter hereof and supersede all previous agreements, arrangements, understandings between the Parties with respect hereto.
-2. If any provision of these Terms is held to be invalid, illegal, or unenforceable, the remaining provisions shall remain in full force and effect.
-3. No failure or delay by Logos in exercising any right or remedy under these Terms shall operate as a waiver thereof.
-4. Participants shall not assign or transfer any of their rights or obligations under these Terms without Logos’ prior written consent. Logos may assign or transfer its rights and obligations under these Terms to any of its Affiliates.
-5. There are no representations, warranties, terms, conditions, undertakings or understanding, express or implied, between the Parties other than those expressly set forth in these Terms.
+### 18.1
+
+These Terms, together with any documents referred to in them, constitute the entire agreement between the Parties in relation to the subject matter hereof and supersede all previous agreements, arrangements, understandings between the Parties with respect hereto.
+
+### 18.2
+
+If any provision of these Terms is held to be invalid, illegal, or unenforceable, the remaining provisions shall remain in full force and effect.
+
+### 18.3
+
+No failure or delay by Logos in exercising any right or remedy under these Terms shall operate as a waiver thereof.
+
+### 18.4
+
+Participants shall not assign or transfer any of their rights or obligations under these Terms without Logos’ prior written consent. Logos may assign or transfer its rights and obligations under these Terms to any of its Affiliates.
+
+### 18.5
+
+There are no representations, warranties, terms, conditions, undertakings or understanding, express or implied, between the Parties other than those expressly set forth in these Terms.

--- a/prizes/LP-0000.md
+++ b/prizes/LP-0000.md
@@ -116,3 +116,21 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 ## Potential for Subsequent λ Prizes
 
 > If this prize targets a specific testnet, codebase version, or external dependency that is expected to change, note here whether a follow-up prize may be opened to cover adaptation to future versions.
+
+---
+
+**Note:** The Specification in this Prize describes an outcome that Logos intends to benefit the Logos ecosystem. It sets out criteria and certain requirements a Participant should fulfill in order to potentially be eligible to be awarded a Prize amount, and is not intended to be an instruction or to direct a Participant’s initiative or approach. They are guided by existing approaches and implementations in other mature blockchain systems and their ecosystems, as well as by functional requirements particular to the Logos technology stack or perceived usefulness to such stack or the wider community building on it.
+
+Logos makes no representation as to the legal or regulatory treatment of this Specification or any implementation of it in any jurisdiction.
+
+Participants act independently, voluntarily and at their own initiative in connection with their Submissions and are solely responsible for:
+
+1. assessing the risks and implications of their Participation in the Program and of any Artefacts that form part of their Submission;
+2. determining whether to obtain independent professional advice;
+3. complying with all applicable laws to them and in connection with the Program, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business.
+
+Artefacts developed by Participants in connection with the Program are published and maintained by Participants and not by Logos or its Affiliates. Logos and its Affiliates do not build, host, maintain, deploy, operate, use or control any Artefacts arising out of any Submission.
+
+Participants or other persons who choose to build upon, host, maintain, deploy, operate, use or publicly promote any Artefacts, do so at their own risk and as a principal and in their own name. Any such persons are further solely responsible for complying with any legal or regulatory requirements that apply to them with such use. Logos does not make any representation, provide any advice or assume any responsibility regarding the use of such Artefacts, or any determination of compliance with applicable law or regulation.
+
+For further details of the above and what terms and conditions apply to a Participant, please refer to the [λPrize Program – Terms & Conditions](../TERMS.md).

--- a/prizes/LP-0002.md
+++ b/prizes/LP-0002.md
@@ -115,3 +115,21 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 ## Potential for Subsequent λ Prizes
 
 This prize targets the current LEZ testnet. Should a future testnet version introduce breaking changes, a subsequent λ Prize may be opened to cover the necessary adaptation and redeployment.
+
+---
+
+**Note:** The Specification in this Prize describes an outcome that Logos intends to benefit the Logos ecosystem. It sets out criteria and certain requirements a Participant should fulfill in order to potentially be eligible to be awarded a Prize amount, and is not intended to be an instruction or to direct a Participant’s initiative or approach. They are guided by existing approaches and implementations in other mature blockchain systems and their ecosystems, as well as by functional requirements particular to the Logos technology stack or perceived usefulness to such stack or the wider community building on it.
+
+Logos makes no representation as to the legal or regulatory treatment of this Specification or any implementation of it in any jurisdiction.
+
+Participants act independently, voluntarily and at their own initiative in connection with their Submissions and are solely responsible for:
+
+1. assessing the risks and implications of their Participation in the Program and of any Artefacts that form part of their Submission;
+2. determining whether to obtain independent professional advice;
+3. complying with all applicable laws to them and in connection with the Program, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business.
+
+Artefacts developed by Participants in connection with the Program are published and maintained by Participants and not by Logos or its Affiliates. Logos and its Affiliates do not build, host, maintain, deploy, operate, use or control any Artefacts arising out of any Submission.
+
+Participants or other persons who choose to build upon, host, maintain, deploy, operate, use or publicly promote any Artefacts, do so at their own risk and as a principal and in their own name. Any such persons are further solely responsible for complying with any legal or regulatory requirements that apply to them with such use. Logos does not make any representation, provide any advice or assume any responsibility regarding the use of such Artefacts, or any determination of compliance with applicable law or regulation.
+
+For further details of the above and what terms and conditions apply to a Participant, please refer to the [λPrize Program – Terms & Conditions](../TERMS.md).

--- a/prizes/LP-0003.md
+++ b/prizes/LP-0003.md
@@ -117,3 +117,21 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 ## Potential for Subsequent λ Prizes
 
 Testnet 0.3/0.4 compatibility, mainnet deployment and adoption.
+
+---
+
+**Note:** The Specification in this Prize describes an outcome that Logos intends to benefit the Logos ecosystem. It sets out criteria and certain requirements a Participant should fulfill in order to potentially be eligible to be awarded a Prize amount, and is not intended to be an instruction or to direct a Participant’s initiative or approach. They are guided by existing approaches and implementations in other mature blockchain systems and their ecosystems, as well as by functional requirements particular to the Logos technology stack or perceived usefulness to such stack or the wider community building on it.
+
+Logos makes no representation as to the legal or regulatory treatment of this Specification or any implementation of it in any jurisdiction.
+
+Participants act independently, voluntarily and at their own initiative in connection with their Submissions and are solely responsible for:
+
+1. assessing the risks and implications of their Participation in the Program and of any Artefacts that form part of their Submission;
+2. determining whether to obtain independent professional advice;
+3. complying with all applicable laws to them and in connection with the Program, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business.
+
+Artefacts developed by Participants in connection with the Program are published and maintained by Participants and not by Logos or its Affiliates. Logos and its Affiliates do not build, host, maintain, deploy, operate, use or control any Artefacts arising out of any Submission.
+
+Participants or other persons who choose to build upon, host, maintain, deploy, operate, use or publicly promote any Artefacts, do so at their own risk and as a principal and in their own name. Any such persons are further solely responsible for complying with any legal or regulatory requirements that apply to them with such use. Logos does not make any representation, provide any advice or assume any responsibility regarding the use of such Artefacts, or any determination of compliance with applicable law or regulation.
+
+For further details of the above and what terms and conditions apply to a Participant, please refer to the [λPrize Program – Terms & Conditions](../TERMS.md).

--- a/prizes/LP-0008.md
+++ b/prizes/LP-0008.md
@@ -186,3 +186,21 @@ The following policies apply to all prizes (see [evaluation policies](../README.
 ## Potential for Subsequent λ Prizes
 
 This prize targets the current LEZ testnet. Should a future testnet version introduce breaking changes, a subsequent λ Prize may be opened to cover the necessary adaptation and redeployment.
+
+---
+
+**Note:** The Specification in this Prize describes an outcome that Logos intends to benefit the Logos ecosystem. It sets out criteria and certain requirements a Participant should fulfill in order to potentially be eligible to be awarded a Prize amount, and is not intended to be an instruction or to direct a Participant’s initiative or approach. They are guided by existing approaches and implementations in other mature blockchain systems and their ecosystems, as well as by functional requirements particular to the Logos technology stack or perceived usefulness to such stack or the wider community building on it.
+
+Logos makes no representation as to the legal or regulatory treatment of this Specification or any implementation of it in any jurisdiction.
+
+Participants act independently, voluntarily and at their own initiative in connection with their Submissions and are solely responsible for:
+
+1. assessing the risks and implications of their Participation in the Program and of any Artefacts that form part of their Submission;
+2. determining whether to obtain independent professional advice;
+3. complying with all applicable laws to them and in connection with the Program, including, where relevant, any licensing, registration, sanctions or anti-money laundering obligations that may arise from operating any software-as-a-service or business.
+
+Artefacts developed by Participants in connection with the Program are published and maintained by Participants and not by Logos or its Affiliates. Logos and its Affiliates do not build, host, maintain, deploy, operate, use or control any Artefacts arising out of any Submission.
+
+Participants or other persons who choose to build upon, host, maintain, deploy, operate, use or publicly promote any Artefacts, do so at their own risk and as a principal and in their own name. Any such persons are further solely responsible for complying with any legal or regulatory requirements that apply to them with such use. Logos does not make any representation, provide any advice or assume any responsibility regarding the use of such Artefacts, or any determination of compliance with applicable law or regulation.
+
+For further details of the above and what terms and conditions apply to a Participant, please refer to the [λPrize Program – Terms & Conditions](../TERMS.md).


### PR DESCRIPTION
## Summary
- Replace `TERMS.md` with the 27 August 2026 λPrize Program Terms & Conditions (markdown headings, lists, and links only).
- Append the specification disclaimer to the three currently Open prizes (LP-0002, LP-0003, LP-0008) and to the LP-0000 template so new prizes copy it.

## Test plan
- [ ] Confirm `TERMS.md` matches the enclosed legal text (wording, including numbering as in the source).
- [ ] Confirm contact email and privacy-policy URL render as links.
- [ ] Confirm the disclaimer at the end of `prizes/LP-0000.md`, `prizes/LP-0002.md`, `prizes/LP-0003.md`, and `prizes/LP-0008.md`.
- [ ] Confirm closed and draft prizes were left unchanged.